### PR TITLE
fix(perception_replyer): fix dying when no traffic signals

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
@@ -153,6 +153,9 @@ class PerceptionReplayerCommon(Node):
                 pass
 
     def binary_search(self, data, timestamp):
+        if not data:
+            return None
+
         if data[-1][0] < timestamp:
             return data[-1][1]
         elif data[0][0] > timestamp:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix dying when no  traffic signals

before
```
$ ros2 run planning_debug_tools perception_replayer.py -b Pn_UCv2.0_Pedestrian_Tracking/result_bag_0.db3
Stared loading rosbag
[INFO 1710178110.720895793] [rosbag2_storage]: Opened database 'Pn_UCv2.0_Pedestrian_Tracking/result_bag_0.db3' for READ_ONLY. (open() at ./src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp:227)
Ended loading rosbag
Start timer callback
Traceback (most recent call last):
  File "/home/kosuke55/pilot-auto.latest/install/planning_debug_tools/lib/planning_debug_tools/perception_replayer.py", line 198, in <module>
    rclpy.spin_once(node, timeout_sec=0.01)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 202, in spin_once
    executor.spin_once(timeout_sec=timeout_sec)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 713, in spin_once
    raise handler.exception()
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/task.py", line 239, in __call__
    self._handler.send(None)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 418, in handler
    await call_coroutine(entity, arg)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 332, in _execute_timer
    await await_or_execute(tmr.callback)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 107, in await_or_execute
    return callback(*args)
  File "/home/kosuke55/pilot-auto.latest/install/planning_debug_tools/lib/planning_debug_tools/perception_replayer.py", line 77, in on_timer
    msgs = copy.deepcopy(self.find_topics_by_timestamp(self.bag_timestamp))
  File "/home/kosuke55/pilot-auto.latest/src/tools/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py", line 179, in find_topics_by_timestamp
    traffic_signals_data = self.binary_search(self.rosbag_traffic_signals_data, timestamp)
  File "/home/kosuke55/pilot-auto.latest/src/tools/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py", line 156, in binary_search
    if data[-1][0] < timestamp:
IndexError: list index out of range
[ros2run]: Process exited with failure 1
```

after
```
$ ros2 run planning_debug_tools perception_replayer.py -b Pn_UCv2.0_Pedestrian_Tracking/result_bag_0.db3
Stared loading rosbag
[INFO 1710178283.318049921] [rosbag2_storage]: Opened database 'Pn_UCv2.0_Pedestrian_Tracking/result_bag_0.db3' for READ_ONLY. (open() at ./src/rosbag2_storage_default_plugins/sqlite/sqlite_storage.cpp:227)
Ended loading rosbag
Start timer callback
```
## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

 ros2 run planning_debug_tools perception_replayer.py

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
