### PR TITLE
feat(driving_environment_analyzer): remove dependency to autoware_auto_tf2

### DIFF
--- a/driving_environment_analyzer/package.xml
+++ b/driving_environment_analyzer/package.xml
@@ -17,7 +17,6 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_auto_tf2</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>behavior_path_planner_common</depend>


### PR DESCRIPTION
## Description
Removes unnecessary dependency to autoware_auto_tf2.

## Related links
This must be merged before https://github.com/autowarefoundation/autoware.universe/pull/7218

## Tests performed
I have done build check with [remove-autoware-auto-tf2](https://github.com/mitsudome-r/autoware.universe/tree/remove-autoware-auto-tf2) branch on my local machine
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
