### PR TITLE
fix(deviation_estimator): fix lookup error before subscribe /tf_static

### DIFF
--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator_main.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator_main.cpp
@@ -113,11 +113,16 @@ int main(int argc, char ** argv)
       sensor_msgs::msg::Imu::SharedPtr imu_msg = std::make_shared<sensor_msgs::msg::Imu>();
       serialization_imu.deserialize_message(&msg, imu_msg.get());
       imu_frame_id = imu_msg->header.frame_id;
-      const geometry_msgs::msg::TransformStamped transform =
-        tf_buffer.lookupTransform("base_link", imu_msg->header.frame_id, tf2::TimePointZero);
       geometry_msgs::msg::Vector3Stamped vec_stamped_transformed;
-      vec_stamped_transformed.header = imu_msg->header;
-      tf2::doTransform(imu_msg->angular_velocity, vec_stamped_transformed.vector, transform);
+      try {
+        const geometry_msgs::msg::TransformStamped transform =
+          tf_buffer.lookupTransform("base_link", imu_msg->header.frame_id, tf2::TimePointZero);
+        vec_stamped_transformed.header = imu_msg->header;
+        tf2::doTransform(imu_msg->angular_velocity, vec_stamped_transformed.vector, transform);
+      } catch (const tf2::TransformException & ex) {
+        std::cerr << "Transform exception: " << ex.what() << std::endl;
+        continue;
+      }
       const rclcpp::Time curr_stamp = imu_msg->header.stamp;
       first_stamp = std::min(first_stamp, curr_stamp);
       const double diff_sec = (curr_stamp - first_stamp).seconds();


### PR DESCRIPTION
## Description

Fixed an issue where an error would occur when executing a rosbag with imu before /tf_static arrived, causing a non-existent frame_id to be specified in the transform lookup.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
The below command works fine:

```bash
 ~/autoware/install/deviation_estimator/lib/deviation_estimator/deviation_estimator_unit_tool <rosbag_path>
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
