### PR TITLE
fix: change_perception_reproducer_parameter

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -65,7 +65,7 @@ class PerceptionReproducer(PerceptionReplayerCommon):
             time_diffs.append(time_diff)
             prev_stamp = stamp
 
-        average_ego_odom_interval = 0.1  # sum(time_diffs) / len(time_diffs)
+        average_ego_odom_interval = sum(time_diffs) / len(time_diffs)
         self.timer = self.create_timer(average_ego_odom_interval, self.on_timer)
 
         # kill perception process to avoid a conflict of the perception topics
@@ -265,9 +265,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "-c",
         "--reproduce-cool-down",
-        help="The cool down time for republishing published messages (default is 15.0 seconds)",
+        help="The cool down time for republishing published messages (default is 80.0 seconds)",
         type=float,
-        default=15.0,
+        default=80.0,
     )
     args = parser.parse_args()
 

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -258,9 +258,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r",
         "--search-radius",
-        help="the search radius for searching rosbag's ego odom messages around the nearest ego odom pose (default is 2 meters), if the search radius is set to 0, it will always publish the closest message, just as the old reproducer did.",
+        help="the search radius for searching rosbag's ego odom messages around the nearest ego odom pose (default is 1.5 meters), if the search radius is set to 0, it will always publish the closest message, just as the old reproducer did.",
         type=float,
-        default=2.0,
+        default=1.5,
     )
     parser.add_argument(
         "-c",


### PR DESCRIPTION
## Description

change the default reproduce-cool-down to 80s, improved the perception reproducer in case of long-term stop.

An example rosbag at the intersection. (https://tier4.atlassian.net/browse/RT1-5797)
[Screencast from 2024年06月19日 16時47分45秒.webm](https://github.com/autowarefoundation/autoware_tools/assets/24828656/874be271-7a25-40f2-bc86-ba1acb394b54)

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
