### PR TITLE
fix(logging_level_configure): change to static_obstacle_avoidance from avoidance

### DIFF
--- a/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
+++ b/common/tier4_logging_level_configure_rviz_plugin/config/logger_config.yaml
@@ -38,11 +38,11 @@ Planning:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
       logger_name: autoware_motion_utils
 
-  behavior_path_planner_avoidance:
+  behavior_path_planner_static_obstacle_avoidance:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
-      logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance
+      logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.static_obstacle_avoidance
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner
-      logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.avoidance.utils
+      logger_name: planning.scenario_planning.lane_driving.behavior_planning.behavior_path_planner.static_obstacle_avoidance.utils
 
   behavior_path_planner_goal_planner:
     - node_name: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner


### PR DESCRIPTION
## Description
Previous [PR](https://github.com/autowarefoundation/autoware.universe/pull/7168) changed the module name as
`behavior_path_avoidance_module -> autoware_behavior_path_static_obstacle_avoidance_module`,
Changed the logger name to static_obstacle_avoidance.

## Related links
[PR](https://github.com/autowarefoundation/autoware.universe/pull/7617)
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
PSim
![Screenshot from 2024-06-21 15-38-12](https://github.com/autowarefoundation/autoware_tools/assets/12757369/844f2b31-9286-4774-8fef-b35dc6486cbb)


## Notes for reviewers

## Interface changes
None

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
