### PR TITLE
fix(perception_replayer): support two kinds of old messages in rosbags

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
@@ -19,16 +19,18 @@ from subprocess import CalledProcessError
 from subprocess import check_output
 import time
 
+from autoware_auto_perception_msgs.msg import (
+    TrafficSignalArray as autoware_auto_perception_msgs_TrafficSignalArray,
+)
+from autoware_perception_msgs.msg import (
+    TrafficSignalArray as autoware_perception_msgs_TrafficSignalArray,
+)
 from autoware_perception_msgs.msg import DetectedObjects
 from autoware_perception_msgs.msg import PredictedObjects
 from autoware_perception_msgs.msg import TrackedObjects
 from autoware_perception_msgs.msg import TrafficLightElement
 from autoware_perception_msgs.msg import TrafficLightGroup
 from autoware_perception_msgs.msg import TrafficLightGroupArray
-
-from autoware_perception_msgs.msg import TrafficSignalArray as autoware_perception_msgs_TrafficSignalArray
-from autoware_auto_perception_msgs.msg import TrafficSignalArray as autoware_auto_perception_msgs_TrafficSignalArray
-
 from geometry_msgs.msg import PoseStamped
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from nav_msgs.msg import Odometry
@@ -149,12 +151,16 @@ class PerceptionReplayerCommon(Node):
                 if not isinstance(msg, self.traffic_signals_pub.msg_type):
                     # convert two kinds of old `TrafficSignalArray` msgs to new `TrafficLightGroupArray` msg.
                     new_msg = self.traffic_signals_pub.msg_type()
-                    assert type(new_msg).__name__ == "TrafficLightGroupArray", f"Unsupported conversion to {type(new_msg).__name__}"
+                    assert (
+                        type(new_msg).__name__ == "TrafficLightGroupArray"
+                    ), f"Unsupported conversion to {type(new_msg).__name__}"
                     if isinstance(msg, autoware_auto_perception_msgs_TrafficSignalArray):
                         new_msg.stamp = msg.header.stamp
                         for traffic_signal in msg.signals:
                             traffic_light_group = TrafficLightGroup()
-                            traffic_light_group.traffic_light_group_id = traffic_signal.map_primitive_id
+                            traffic_light_group.traffic_light_group_id = (
+                                traffic_signal.map_primitive_id
+                            )
                             for traffic_light in traffic_signal.lights:
                                 traffic_light_element = TrafficLightElement()
                                 traffic_light_element.color = traffic_light.color

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
@@ -143,20 +143,23 @@ class PerceptionReplayerCommon(Node):
                 self.rosbag_ego_odom_data.append((stamp, msg))
             if topic == traffic_signals_topic:
                 if not isinstance(msg, self.traffic_signals_pub.msg_type):
-                    # convert old TrafficSignalArray msg to new TrafficLightGroupArray msg.
+                    # convert old `TrafficSignalArray` msg to new `TrafficLightGroupArray` msg.
                     new_msg = self.traffic_signals_pub.msg_type()
-                    new_msg.stamp = msg.stamp
+                    assert (
+                        type(msg).__name__ == "TrafficSignalArray"
+                        and type(new_msg).__name__ == "TrafficLightGroupArray"
+                    ), f"Unsupported conversion from {type(msg).__name__} to {type(new_msg).__name__}"
+
+                    new_msg.stamp = msg.header.stamp
                     for traffic_signal in msg.signals:
                         traffic_light_group = TrafficLightGroup()
-                        traffic_light_group.traffic_light_group_id = (
-                            traffic_signal.traffic_signal_id
-                        )
-                        for traffic_signal_element in traffic_signal.elements:
+                        traffic_light_group.traffic_light_group_id = traffic_signal.map_primitive_id
+                        for traffic_light in traffic_signal.lights:
                             traffic_light_element = TrafficLightElement()
-                            traffic_light_element.color = traffic_signal_element.color
-                            traffic_light_element.shape = traffic_signal_element.shape
-                            traffic_light_element.status = traffic_signal_element.status
-                            traffic_light_element.confidence = traffic_signal_element.confidence
+                            traffic_light_element.color = traffic_light.color
+                            traffic_light_element.shape = traffic_light.shape
+                            traffic_light_element.status = traffic_light.status
+                            traffic_light_element.confidence = traffic_light.confidence
                             traffic_light_group.elements.append(traffic_light_element)
                         new_msg.traffic_light_groups.append(traffic_light_group)
                     msg = new_msg

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -221,7 +221,7 @@ class PerceptionReproducer(PerceptionReplayerCommon):
             self.ego_odom_id2last_published_timestamp[ego_odom_idx] = timestamp
             self.cool_down_indices.append(ego_odom_idx)
 
-            self.stopwatch.toc("total on_timer")
+        self.stopwatch.toc("total on_timer")
 
     def find_nearest_ego_odom_index(self, ego_pose):
         # nearest search with numpy format is much (~ x100) faster than regular for loop


### PR DESCRIPTION
## Description

In the previous [PR](https://github.com/autowarefoundation/autoware_tools/pull/60), I incorrectly assumed that the code for converting old messages was wrong. 
But in fact, there are two old messages with the same name`TrafficSignalArray`, so this PR aim to support both old messages.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
