### PR TITLE
fix: changed map.launch file from .py to .xml

### DIFF
--- a/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/launch/deviation_evaluator.launch.xml
@@ -28,7 +28,8 @@
   <arg name="out_pose_with_covariance_dr" default="/deviation_evaluator/dead_reckoning/pose_estimator/pose_with_covariance"/>
   <arg name="out_pose_with_covariance_gt" default="/deviation_evaluator/ground_truth/pose_estimator/pose_with_covariance"/>
   <arg name="out_init_pose_with_covariance" default="/deviation_evaluator/initialpose3d"/>
-  <arg name="lanelet2_map_file" default="$(var map_path)/lanelet2_map.osm"/>
+  <arg name="lanelet2_map_file" default="lanelet2_map.osm"/>
+  <arg name="pointcloud_map_file" default="pointcloud_map.pcd"/>
 
   <group>
     <node pkg="deviation_evaluator" exec="deviation_evaluator" name="deviation_evaluator" output="screen">
@@ -103,10 +104,16 @@
 
   <!-- Map -->
   <group>
-    <include file="$(find-pkg-share tier4_map_launch)/launch/map.launch.py" if="$(var rviz)">
-      <arg name="lanelet2_map_path" value="$(var lanelet2_map_file)"/>
+    <include file="$(find-pkg-share tier4_map_launch)/launch/map.launch.xml" if="$(var rviz)">
+      <arg name="pointcloud_map_path" value="$(var map_path)/$(var pointcloud_map_file)"/>
+      <arg name="pointcloud_map_metadata_path" value="$(var map_path)/pointcloud_map_metadata.yaml"/>
+      <arg name="lanelet2_map_path" value="$(var map_path)/$(var lanelet2_map_file)"/>
+      <arg name="map_projector_info_path" value="$(var map_path)/map_projector_info.yaml"/>
+
       <arg name="pointcloud_map_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/pointcloud_map_loader.param.yaml"/>
       <arg name="lanelet2_map_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/lanelet2_map_loader.param.yaml"/>
+      <arg name="map_tf_generator_param_path" value="$(find-pkg-share autoware_launch)/config/map/map_tf_generator.param.yaml"/>
+      <arg name="map_projection_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/map_projection_loader.param.yaml"/>
     </include>
   </group>
 

--- a/vehicle/parameter_estimator/launch/parameter_estimator_with_simulation.launch.xml
+++ b/vehicle/parameter_estimator/launch/parameter_estimator_with_simulation.launch.xml
@@ -20,9 +20,16 @@
   </include>
 
   <!-- Map -->
-  <include file="$(find-pkg-share map_launch)/launch/map.launch.py">
-    <arg name="lanelet2_map_path" value="$(var map_path)/$(var lanelet2_map_file)"/>
+  <include file="$(find-pkg-share map_launch)/launch/map.launch.xml">
     <arg name="pointcloud_map_path" value="$(var map_path)/$(var pointcloud_map_file)"/>
+    <arg name="pointcloud_map_metadata_path" value="$(var map_path)/pointcloud_map_metadata.yaml"/>
+    <arg name="lanelet2_map_path" value="$(var map_path)/$(var lanelet2_map_file)"/>
+    <arg name="map_projector_info_path" value="$(var map_path)/map_projector_info.yaml"/>
+
+    <arg name="pointcloud_map_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/pointcloud_map_loader.param.yaml"/>
+    <arg name="lanelet2_map_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/lanelet2_map_loader.param.yaml"/>
+    <arg name="map_tf_generator_param_path" value="$(find-pkg-share autoware_launch)/config/map/map_tf_generator.param.yaml"/>
+    <arg name="map_projection_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/map_projection_loader.param.yaml"/>
   </include>
 
   <!-- Rviz -->


### PR DESCRIPTION
## Description
The following pull request changed map.launch.py to map.launch.xml.

* https://github.com/autowarefoundation/autoware.universe/pull/6185

This pull request will follow up on that change.

## Tests performed

I have only tested the operation of the deviation_evaluator. However, as I have never run the previous version, I do not know whether it is operating correctly or not.

No operation checks have been carried out for parameter_estimator.

## Notes for reviewers

None.

## Effects on system behavior

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
