### PR TITLE
feat: wait until autonomous mode is enabled

### DIFF
--- a/common/tier4_automatic_goal_rviz_plugin/src/automatic_goal_sender.cpp
+++ b/common/tier4_automatic_goal_rviz_plugin/src/automatic_goal_sender.cpp
@@ -97,6 +97,7 @@ void AutowareAutomaticGoalSender::onOperationMode(const OperationModeState::Cons
     state_ = State::STOPPED;
   else if (msg->mode == OperationModeState::AUTONOMOUS && state_ == State::STARTING)
     state_ = State::STARTED;
+  is_autonomous_mode_available_ = msg->is_autonomous_mode_available;
   onOperationModeUpdated(msg);
 }
 
@@ -131,7 +132,8 @@ void AutowareAutomaticGoalSender::updateAutoExecutionTimerTick()
     RCLCPP_INFO_STREAM(get_logger(), goal << ": Goal set as the next. Planning in progress...");
     if (callPlanToGoalIndex(cli_set_route_, current_goal_)) state_ = State::PLANNING;
 
-  } else if (state_ == State::PLANNED) {  // start plan to next goal
+  } else if (state_ == State::PLANNED && is_autonomous_mode_available_) {  // start plan to next
+                                                                           // goal
     RCLCPP_INFO_STREAM(get_logger(), goal << ": Route has been planned. Route starting...");
     if (callService<ChangeOperationMode>(cli_change_to_autonomous_)) state_ = State::STARTING;
 

--- a/common/tier4_automatic_goal_rviz_plugin/src/automatic_goal_sender.hpp
+++ b/common/tier4_automatic_goal_rviz_plugin/src/automatic_goal_sender.hpp
@@ -168,6 +168,7 @@ protected:
   std::vector<Route> goals_list_{};
   std::map<unsigned, std::pair<std::string, unsigned>> goals_achieved_{};
   std::string goals_achieved_file_path_{};
+  bool is_autonomous_mode_available_{false};
 
 private:
   void loadParams(rclcpp::Node * node);


### PR DESCRIPTION
## Description

The current automatic_goal_sender is set to call the ```/api/operation_mode/change_to_autonomous``` service as soon as ```/api/routing/state``` becomes ```RouteState::SET```. However, in this state, Planning may still be in preparation, and autonomous_mode may not be ready. In such situations, the automatic_goal_sender process crashes as shown in the message below. I have modified the code to wait for autonomous_mode to be ready before calling the change_to_autonomous service.

```
automatic_goal_sender-1] [INFO 1720670631.443807582] [automatic_goal_sender]: Achieved goals will be saved in: /home/kimura/git/pilot-auto.x2/src/evaluation/autoware_awsim_evaluation_tools/src/awsim_evaluation_launcher/config/odaibagoals_achieved.log
[automatic_goal_sender-1] [INFO 1720670632.443782270] [automatic_goal_sender]: G0 (89067.52, 42360.04, 2.17): Goal set as the next. Planning in progress...
[automatic_goal_sender-1] [INFO 1720670632.943799086] [automatic_goal_sender]: G0 (89067.52, 42360.04, 2.17): Route has been planned. Route starting...
[automatic_goal_sender-1] [ERROR 1720670632.944549606] [automatic_goal_sender]: Service type "N22autoware_adapi_v1_msgs3srv19ChangeOperationModeE" status: 1, The target mode is not available. Please check the diagnostics.

```

<!-- Write a brief description of this PR. -->

## Related links
none
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

I verified with the Planning_simulator that the automatic_goal_sender operates correctly in situations where Planning takes time to prepare.

$ros2 launch autoware_launch planning_simulator.launch.xml vehicle_id:=default vehicle_model:=[VEHICLE_MODEL] sensor_model:=[SENSOR_MODEL] map_path:=[MAP_PATH]
$ros2 launch tier4_automatic_goal_rviz_plugin automatic_goal_sender.launch.xml goals_list_file_path:=[GOAL_LIST_PATH] goals_achieved_dir_path:=[PATH]

<!-- Describe how you have tested this PR. -->

## Notes for reviewers
none
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
none ( This is a feature not used in regular autonomous driving. )


<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
