### PR TITLE
chore: fix topic name in README.md

### DIFF
--- a/evaluation/tier4_metrics_rviz_plugin/README.md
+++ b/evaluation/tier4_metrics_rviz_plugin/README.md
@@ -6,8 +6,8 @@ This plugin panel to visualize `planning_evaluator` output.
 
 ## Inputs / Outputs
 
-| Name                                     | Type                                    | Description                           |
-| ---------------------------------------- | --------------------------------------- | ------------------------------------- |
+| Name                                   | Type                                    | Description                           |
+| -------------------------------------- | --------------------------------------- | ------------------------------------- |
 | `/planning/planning_evaluator/metrics` | `diagnostic_msgs::msg::DiagnosticArray` | Subscribe `planning_evaluator` output |
 
 ## HowToUse

--- a/evaluation/tier4_metrics_rviz_plugin/README.md
+++ b/evaluation/tier4_metrics_rviz_plugin/README.md
@@ -8,7 +8,7 @@ This plugin panel to visualize `planning_evaluator` output.
 
 | Name                                     | Type                                    | Description                           |
 | ---------------------------------------- | --------------------------------------- | ------------------------------------- |
-| `/diagnostic/planning_evaluator/metrics` | `diagnostic_msgs::msg::DiagnosticArray` | Subscribe `planning_evaluator` output |
+| `/planning/planning_evaluator/metrics` | `diagnostic_msgs::msg::DiagnosticArray` | Subscribe `planning_evaluator` output |
 
 ## HowToUse
 


### PR DESCRIPTION
This PR fix that topic name changes made by https://github.com/autowarefoundation/autoware_tools/pull/82 were not reflected in README.md.