### PR TITLE
fix(map_projection_loader): add autoware prefix to map_projection_loader

### DIFF
--- a/driving_environment_analyzer/launch/driving_environment_analyzer.launch.xml
+++ b/driving_environment_analyzer/launch/driving_environment_analyzer.launch.xml
@@ -20,7 +20,7 @@
     </composable_node>
   </node_container>
 
-  <include file="$(find-pkg-share map_projection_loader)/launch/map_projection_loader.launch.xml">
+  <include file="$(find-pkg-share autoware_map_projection_loader)/launch/map_projection_loader.launch.xml">
     <arg name="param_path" value="$(var map_projection_loader_param_path)"/>
     <arg name="map_projector_info_path" value="$(var map_path)/map_projector_info.yaml"/>
     <arg name="lanelet2_map_path" value="$(var map_path)/lanelet2_map.osm"/>


### PR DESCRIPTION
## Description
This PR will add `autoware_` prefix to `map_projection_loader`

Reflect the change of https://github.com/autowarefoundation/autoware.universe/pull/8420

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
