### PR TITLE
fix(deviation_estimator): add depend

### DIFF
--- a/localization/deviation_estimation_tools/deviation_estimator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_estimator/package.xml
@@ -23,13 +23,13 @@
   <depend>rosbag2</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>
-  <exec_depend>rosbag2_storage_mcap</exec_depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_debug_msgs</depend>
+  <exec_depend>rosbag2_storage_mcap</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/deviation_estimation_tools/deviation_estimator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_estimator/package.xml
@@ -22,6 +22,8 @@
   <depend>rclcpp</depend>
   <depend>rosbag2</depend>
   <depend>rosbag2_cpp</depend>
+  <depend>rosbag2_storage</depend>
+  <exec_depend>rosbag2_storage_mcap</exec_depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
## Description

In the issue (https://github.com/autowarefoundation/autoware/issues/5089), missing depends were found.
This pull request adds those depends to `deviation_estimator`.

### Limitation
When adding the `rosbag2_storage_mcap` pkg as `<depend>`, the following error occurred. So I add the pkg as `<exec_depend>`.

```
CMake Error in CMakeLists.txt:
  Imported target "rosbag2_storage_mcap::rosbag2_storage_mcap" includes
  non-existent path

    "/opt/ros/humble/include/rosbag2_storage_mcap"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```

https://github.com/ros2/rosbag2/tree/humble/rosbag2_storage_mcap/include/rosbag2_storage_mcap

I use the version 0.15.12-1.

```
~/autoware$ apt list | grep ros-humble-rosbag2-storage-mcap
ros-humble-rosbag2-storage-mcap-dbgsym/jammy 0.15.12-1jammy.20240730.142226 amd64
ros-humble-rosbag2-storage-mcap-testdata-dbgsym/jammy 0.15.12-1jammy.20240730.140926 amd64
ros-humble-rosbag2-storage-mcap-testdata/jammy 0.15.12-1jammy.20240730.140926 amd64
ros-humble-rosbag2-storage-mcap/jammy,now 0.15.12-1jammy.20240730.142226 amd64 [installed]
```

## Tests performed

I have confirmed that `deviation_estimator` can be built.


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
