### PR TITLE
feat(rtc_manager_panel): add cooperateStatus state column

### DIFF
--- a/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
@@ -242,7 +242,8 @@ RTCManagerPanel::RTCManagerPanel(QWidget * parent) : rviz_common::Panel(parent)
     rtc_table_ = new QTableWidget();
     rtc_table_->setColumnCount(column_size_);
     rtc_table_->setHorizontalHeaderLabels(
-      {"ID", "Module", "AW Safe", "Received Cmd", "AutoMode", "State", "StartDistance", "FinishDistance"});
+      {"ID", "Module", "AW\nSafe", "Recv\nCmd", "Auto\nMode", "State", "Start\nDistance",
+       "Finish\nDistance"});
     rtc_table_->setVerticalHeader(vertical_header);
     rtc_table_->setHorizontalHeader(horizontal_header);
     rtc_table_layout->addWidget(rtc_table_);
@@ -441,30 +442,29 @@ void RTCManagerPanel::onRTCStatus(const CooperateStatusArray::ConstSharedPtr msg
     // State
     std::string module_state = "NONE";
     {
-      switch (status.state.type)
-      {
-      case State::WAITING_FOR_EXECUTION:
-        module_state = "Waiting";
-        break;
-      case State::RUNNING:
-        module_state = "Running";
-        break;
-      case State::ABORTING:
-        module_state = "Aborting";
-        break;
-      case State::SUCCEEDED:
-        module_state = "Succeeded";
-        break;
-      case State::FAILED:
-        module_state = "Failed";
-        break;
-      default:
-        break;
+      switch (status.state.type) {
+        case State::WAITING_FOR_EXECUTION:
+          module_state = "Waiting";
+          break;
+        case State::RUNNING:
+          module_state = "Running";
+          break;
+        case State::ABORTING:
+          module_state = "Aborting";
+          break;
+        case State::SUCCEEDED:
+          module_state = "Succeeded";
+          break;
+        case State::FAILED:
+          module_state = "Failed";
+          break;
+        default:
+          break;
       }
       auto label = new QLabel(QString::fromStdString(module_state));
       label->setAlignment(Qt::AlignCenter);
       label->setText(QString::fromStdString(module_state));
-      rtc_table_->setCellWidget(cnt, 5 , label);
+      rtc_table_->setCellWidget(cnt, 5, label);
     }
 
     // start distance

--- a/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
@@ -242,7 +242,7 @@ RTCManagerPanel::RTCManagerPanel(QWidget * parent) : rviz_common::Panel(parent)
     rtc_table_ = new QTableWidget();
     rtc_table_->setColumnCount(column_size_);
     rtc_table_->setHorizontalHeaderLabels(
-      {"ID", "Module", "AW Safe", "Received Cmd", "AutoMode", "StartDistance", "FinishDistance"});
+      {"ID", "Module", "AW Safe", "Received Cmd", "AutoMode", "State", "StartDistance", "FinishDistance"});
     rtc_table_->setVerticalHeader(vertical_header);
     rtc_table_->setHorizontalHeader(horizontal_header);
     rtc_table_layout->addWidget(rtc_table_);
@@ -438,13 +438,42 @@ void RTCManagerPanel::onRTCStatus(const CooperateStatusArray::ConstSharedPtr msg
       rtc_table_->setCellWidget(cnt, 4, label);
     }
 
+    // State
+    std::string module_state = "NONE";
+    {
+      switch (status.state.type)
+      {
+      case State::WAITING_FOR_EXECUTION:
+        module_state = "Waiting";
+        break;
+      case State::RUNNING:
+        module_state = "Running";
+        break;
+      case State::ABORTING:
+        module_state = "Aborting";
+        break;
+      case State::SUCCEEDED:
+        module_state = "Succeeded";
+        break;
+      case State::FAILED:
+        module_state = "Failed";
+        break;
+      default:
+        break;
+      }
+      auto label = new QLabel(QString::fromStdString(module_state));
+      label->setAlignment(Qt::AlignCenter);
+      label->setText(QString::fromStdString(module_state));
+      rtc_table_->setCellWidget(cnt, 5 , label);
+    }
+
     // start distance
     {
       std::string start_distance = std::to_string(status.start_distance);
       auto label = new QLabel(QString::fromStdString(start_distance));
       label->setAlignment(Qt::AlignCenter);
       label->setText(QString::fromStdString(start_distance));
-      rtc_table_->setCellWidget(cnt, 5, label);
+      rtc_table_->setCellWidget(cnt, 6, label);
     }
 
     // finish distance
@@ -453,7 +482,7 @@ void RTCManagerPanel::onRTCStatus(const CooperateStatusArray::ConstSharedPtr msg
       auto label = new QLabel(QString::fromStdString(finish_distance));
       label->setAlignment(Qt::AlignCenter);
       label->setText(QString::fromStdString(finish_distance));
-      rtc_table_->setCellWidget(cnt, 6, label);
+      rtc_table_->setCellWidget(cnt, 7, label);
     }
 
     // add color for recognition

--- a/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.hpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.hpp
@@ -43,6 +43,7 @@
 #include <tier4_rtc_msgs/msg/module.hpp>
 #include <tier4_rtc_msgs/srv/auto_mode.hpp>
 #include <tier4_rtc_msgs/srv/cooperate_commands.hpp>
+#include <tier4_rtc_msgs/msg/state.hpp>
 #endif
 
 namespace rviz_plugins
@@ -55,6 +56,7 @@ using tier4_rtc_msgs::msg::CooperateStatusArray;
 using tier4_rtc_msgs::msg::Module;
 using tier4_rtc_msgs::srv::AutoMode;
 using tier4_rtc_msgs::srv::CooperateCommands;
+using tier4_rtc_msgs::msg::State;
 using unique_identifier_msgs::msg::UUID;
 
 static const QString BG_BLUE = "background-color: #3dffff;";
@@ -123,7 +125,7 @@ private:
   QPushButton * wait_button_ptr_ = {nullptr};
   QLabel * num_rtc_status_ptr_ = {nullptr};
 
-  size_t column_size_ = {7};
+  size_t column_size_ = {8};
   std::string enable_auto_mode_namespace_ = "/planning/enable_auto_mode";
 };
 

--- a/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.hpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.hpp
@@ -41,9 +41,9 @@
 #include <tier4_rtc_msgs/msg/cooperate_status.hpp>
 #include <tier4_rtc_msgs/msg/cooperate_status_array.hpp>
 #include <tier4_rtc_msgs/msg/module.hpp>
+#include <tier4_rtc_msgs/msg/state.hpp>
 #include <tier4_rtc_msgs/srv/auto_mode.hpp>
 #include <tier4_rtc_msgs/srv/cooperate_commands.hpp>
-#include <tier4_rtc_msgs/msg/state.hpp>
 #endif
 
 namespace rviz_plugins
@@ -54,9 +54,9 @@ using tier4_rtc_msgs::msg::CooperateResponse;
 using tier4_rtc_msgs::msg::CooperateStatus;
 using tier4_rtc_msgs::msg::CooperateStatusArray;
 using tier4_rtc_msgs::msg::Module;
+using tier4_rtc_msgs::msg::State;
 using tier4_rtc_msgs::srv::AutoMode;
 using tier4_rtc_msgs::srv::CooperateCommands;
-using tier4_rtc_msgs::msg::State;
 using unique_identifier_msgs::msg::UUID;
 
 static const QString BG_BLUE = "background-color: #3dffff;";


### PR DESCRIPTION
## Description
The RTC status could be observed by the RTCManagerPanel in Rviz.
Currently the cooperateStatus/[State](https://github.com/tier4/tier4_autoware_msgs/blob/tier4/universe/tier4_rtc_msgs/msg/State.msg) could not be observed by the panel.
In this PR, I have added a column named "State" to observe the state transition of the cooperateStatus/state.

## Related links
None

## Tests performed
PSim
![Screenshot from 2024-08-23 18-18-53](https://github.com/user-attachments/assets/bbc30624-b799-40bc-be82-5ff537d78e2c)

## Notes for reviewers
None

## Interface changes
None

## Effects on system behavior
None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
