### PR TITLE
fix(metrics): fix std::stod exception

### DIFF
--- a/evaluation/tier4_metrics_rviz_plugin/include/metrics_visualize_panel.hpp
+++ b/evaluation/tier4_metrics_rviz_plugin/include/metrics_visualize_panel.hpp
@@ -109,10 +109,16 @@ public:
   void updateData(const double time, const DiagnosticStatus & status)
   {
     for (const auto & [key, value] : status.values) {
-      const double data = std::stod(value);
-      labels.at(key)->setText(QString::fromStdString(toString(data)));
-      plots.at(key)->append(time, data);
-      updateMinMax(data);
+      try {
+        const double data = std::stod(value);
+        labels.at(key)->setText(QString::fromStdString(toString(data)));
+        plots.at(key)->append(time, data);
+        updateMinMax(data);
+      } catch (const std::exception & e) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger(__func__), "%s invalid argument. KEY:%s VALUE:%s", e.what(),
+          key.c_str(), value.c_str());
+      }
     }
 
     {


### PR DESCRIPTION
## Description

`tier4_rviz_metrics_plugin` dies when metrics value includes string values. I fixed the tool so that it can skip process for such kind of metric. (e.g. KEY:decision VALUE:deceleration)

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
