### PR TITLE
feat(rqt_diagnostic_graph_monitor): ignore status before struct

### DIFF
--- a/system/rqt_diagnostic_graph_monitor/python/module.py
+++ b/system/rqt_diagnostic_graph_monitor/python/module.py
@@ -43,6 +43,8 @@ class MonitorModule:
         foreach(self.struct_callbacks, lambda callback: callback(self.graph))
 
     def on_status(self, msg):
+        if self.graph is None:
+            return
         self.graph.update(msg)
         foreach(self.status_callbacks, lambda callback: callback(self.graph))
 


### PR DESCRIPTION
## Description

Fix following error.
```
  File "/home/user/autoware/install/rqt_diagnostic_graph_monitor/local/lib/python3.10/dist-packages/rqt_diagnostic_graph_monitor/module.py", line 46, in on_status
    self.graph.update(msg)
AttributeError: 'NoneType' object has no attribute 'update'
```
## Related links

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/CTEJP8L4T/p1724807383750299?thread_ts=1719556079.188599&cid=CTEJP8L4T)

## Tests performed

Publish diag graph status before struct.

Terminal1: `ros2 run rqt_diagnostic_graph_monitor rqt_diagnostic_graph_monitor`
Terminal2: `ros2 topic pub /diagnostics_graph/status tier4_system_msgs/msg/DiagGraphStatus`


## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
