### PR TITLE
fix: fixed a bug from autoware pointcloud merger

### DIFF
--- a/map/autoware_pointcloud_merger/src/pcd_merger.cpp
+++ b/map/autoware_pointcloud_merger/src/pcd_merger.cpp
@@ -136,7 +136,7 @@ void PCDMerger<PointT>::mergeWithDownsample(const std::vector<std::string> & inp
   std::vector<std::string> seg_names;
   fs::path tmp_path(tmp_dir_);
 
-  for (auto & entry : fs::directory_iterator(tmp_path)) {
+  for (auto & entry : fs::recursive_directory_iterator(tmp_path)) {
     if (fs::is_regular_file(entry.symlink_status())) {
       auto fname = entry.path().string();
       auto ext = fname.substr(fname.size() - 4);


### PR DESCRIPTION
## Description

- In autoware_pointcloud_merger, when a downsampling resolution is specified, the autoware_pointcloud_divider is used to downsample the input PCD files. The downsampled files are stored in a directory named _pointcloud_merger_tmp/pointcloud_map.pcd_. After that, the pointcloud merger iterates on the segmented files and merge them to a single output PCD file. However, the merger only uses a filesystem::directory_iterator to iterate on the _pointcloud_merger_tmp_ directory, so it will not be able to detect any PCD files because they are put under the pointcloud_map.pcd directory. This PR replaces directory_iterator by recursive_directory_iterator, thus fixes that problem.

## Related links

None

## Tests performed

- Merged with downsampling resolution 0.2.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
