### PR TITLE
fix(autoware_pointcloud_divider): fix a bug in the customized pcd reader

### DIFF
--- a/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_io_reader.hpp
+++ b/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_io_reader.hpp
@@ -155,7 +155,7 @@ private:
   float orientation_w_, orientation_x_, orientation_y_, orientation_z_;
   // Number of points in the PCD file
   size_t point_num_;
-  // Number of points readed so far, reset every time setInput is called
+  // Number of points loaded so far, reset every time setInput is called
   size_t loaded_point_num_;
   bool binary_;                   // Data: true: binary, false: ascii
   std::ifstream file_;            // Input stream of the PCD file

--- a/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_io_reader.hpp
+++ b/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_io_reader.hpp
@@ -56,6 +56,7 @@
 
 #include "utility.hpp"
 
+#include <pcl/io/pcd_io.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -124,6 +125,7 @@ private:
     origin_x_ = origin_y_ = origin_z_ = 0.0;
     orientation_w_ = orientation_x_ = orientation_y_ = orientation_z_ = 0.0;
     point_num_ = 0;
+    loaded_point_num_ = 0;
     binary_ = true;
 
     if (file_.is_open()) {
@@ -153,14 +155,16 @@ private:
   float orientation_w_, orientation_x_, orientation_y_, orientation_z_;
   // Number of points in the PCD file
   size_t point_num_;
+  // Number of points readed so far, reset every time setInput is called
+  size_t loaded_point_num_;
   bool binary_;                   // Data: true: binary, false: ascii
   std::ifstream file_;            // Input stream of the PCD file
   size_t block_size_ = 30000000;  // Number of points to read in each readABlock
   size_t point_size_, read_size_;
   char * buffer_;
-  std::string pcd_path_;  // Path to the current opening PCD
-  std::vector<size_t> read_loc_;
-  std::vector<size_t> read_sizes_;
+  std::string pcd_path_;            // Path to the current opening PCD
+  std::vector<size_t> read_loc_;    // Locations to read fields of a point
+  std::vector<size_t> read_sizes_;  // Sizes of fields of a point
 };
 
 template <typename PointT>
@@ -519,9 +523,14 @@ size_t CustomPCDReader<PointT>::readABlockBinary(std::ifstream & input, PclCloud
     input.read(buffer_, read_size_);
 
     // Parse the buffer and convert to point
-    for (int i = 0; i < input.gcount(); i += point_size_) {
+    for (int i = 0; i < input.gcount() && loaded_point_num_ < point_num_;
+         i += point_size_, ++loaded_point_num_) {
       parsePoint(buffer_ + i, read_sizes_, read_loc_, p);
       output.push_back(p);
+    }
+
+    if (loaded_point_num_ == point_num_) {
+      input.setstate(std::ios_base::eofbit);
     }
 
     return input.gcount();
@@ -565,27 +574,33 @@ size_t CustomPCDReader<PointT>::readABlockASCII(std::ifstream & input, PclCloudT
   output.reserve(block_size_);
 
   std::string point_line;
+  size_t read_byte_num = 0;
 
   PointT p;
 
-  while (input) {
+  while (input && loaded_point_num_ < point_num_) {
     std::getline(input, point_line);
 
     if (!input.fail()) {
       // Parse the buffer and convert to point
       parsePoint(point_line, read_loc_, p);
       output.push_back(p);
+
+      read_byte_num += input.gcount();
+      ++loaded_point_num_;
     } else {
       fprintf(
         stderr, "[%s, %d] %s::Error: Failed to read a block of points from file. File %s\n",
         __FILE__, __LINE__, __func__, pcd_path_.c_str());
       exit(EXIT_FAILURE);
     }
-
-    return input.gcount();
   }
 
-  return 0;
+  if (loaded_point_num_ == point_num_) {
+    input.setstate(std::ios_base::eofbit);
+  }
+
+  return read_byte_num;
 }
 
 template <typename PointT>


### PR DESCRIPTION
## Description

- Fix a bug in the customized pcd reader, which reads more points from a pcd file than the reader should do. Basically, the number of points stored in a PCD file is stated at the header of the file. However, a PCD file may contains some extra bytes of unknown data (like the one generated by CloudCompare). This PR enables the pcd reader to stop loading points after the number of loaded points equal to the number of points specified in the header of the file.

## Related links
None
## Tests performed
- [Input data](https://drive.google.com/file/d/1s5RvbBjgBtLWaGh8iDI5ApOv0cizEHdE/view?usp=drive_link)
- When run pointcloud divider on the input data, the old code generates a segment named `prefix_0_0.pcd`. This file is generated from the extra bytes at the end of the input PCD file. This is not correct. When using the new code, the incorrect segment is not generated.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
