### PR TITLE
fix(driving_environment_analyzer): remove unused autoware_interpolation dependency

### DIFF
--- a/driving_environment_analyzer/package.xml
+++ b/driving_environment_analyzer/package.xml
@@ -25,7 +25,6 @@
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>libqt5-core</depend>


### PR DESCRIPTION
## Description

Follow up from:
- https://github.com/autowarefoundation/autoware.universe/pull/8088

There is no mention of the word "interpolation" within this package directory. I have doubts that this package uses this dependency.

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

:rotating_light: :warning: Must be merged after:
- https://github.com/autowarefoundation/autoware.universe/pull/8088

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
