### PR TITLE
feat(tier4_control_rviz_plugin): add timestamp to gear command

### DIFF
--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -129,6 +129,7 @@ void ManualController::update()
   }
   GearCommand gear_cmd;
   {
+    gear_cmd.stamp = raw_node_->get_clock()->now();
     const double eps = 0.001;
     if (control_cmd.longitudinal.velocity > eps && current_velocity > -eps) {
       gear_cmd.command = GearCommand::DRIVE;


### PR DESCRIPTION
## Description
Currently the control_rviz_plugin cannot be activated once the vehicle has changed its gear to PARKING, as the following output occurs.
```
1727785737.7806146 [component_container_mt-39] [[INFO 1727785737.779172848] [control.vehicle_cmd_gate]: The operation mode is changed, but the GearCommand is not received yet: (getContinuousTopic():368)
```

This is because no value is assigned to timestamp to the gear_cmd.
The above problem would be fixed in this PR.

## Related links
None

## Tests performed
PSim
Before:
[Screencast from 2024年10月01日 21時28分35秒.webm](https://github.com/user-attachments/assets/aa6b75af-eb87-44e9-9e51-c702f7bc8fab)
After:
[Screencast from 2024年10月01日 21時35分58秒.webm](https://github.com/user-attachments/assets/262cebc5-d12c-4ddb-9eaf-09573ba1395e)

The warning have nothing to do with the gear command as it is shown below:
```
1727786176.2798743 [component_container_mt-33] [WARN 1727786176.278228000] [behavior_path_planner.util]: ego pose is beyond goal (isEgoOutOfRoute():448)
1727786176.3509068 [component_container_mt-39] [INFO 1727786176.350280817] [control.vehicle_cmd_gate]: The operation mode is changed, but the TurnIndicatorsCommand is not received yet: (getContinuousTopic():368)
1727786176.3511274 [component_container_mt-39] [INFO 1727786176.350357308] [control.vehicle_cmd_gate]: The operation mode is changed, but the HazardLightsCommand is not received yet: (getContinuousTopic():368)
1727786176.3766267 [component_container_mt-33] [WARN 1727786176.375963859] [behavior_path_planner.util]: ego pose is beyond goal (isEgoOutOfRoute():448)
```

## Notes for reviewers
None

## Interface changes
None

## Effects on system behavior

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
