### PR TITLE
fix(planning_debug_tools): fix a bug of perception reproducer

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -176,8 +176,12 @@ class PerceptionReproducer(PerceptionReplayerCommon):
                 (ego_pose.position.x - ego_odom_msg.pose.pose.position.x) ** 2
                 + (ego_pose.position.y - ego_odom_msg.pose.pose.position.y) ** 2
             )
-            repeat_flag = ego_rosbag_speed > ego_speed * 5 and ego_rosbag_dist > 1.0
-            # set the speed threshold to many (5) times then ego_speed because this constraint is mainly for departing/stopping (ego speed is close to 0).
+            repeat_flag = (
+                ego_rosbag_speed > ego_speed * 2
+                and ego_rosbag_speed > 3.0
+                and ego_rosbag_dist > self.ego_odom_search_radius
+            )
+            # if ego_rosbag_speed is too fast than ego_speed, stop publishing the rosbag's ego odom message temporarily.
 
         if not repeat_flag:
             self.stopwatch.tic("find_topics_by_timestamp")


### PR DESCRIPTION
## Description
When the psim-ego stops in front of a red traffic light and the rosbag-ego moves at a distance from the psim-ego, the reproducer stops publishing new messages so that the psim-ego freezes forever (because the traffic lights keep red forever). 

This is a cherry-pick of https://github.com/tier4/autoware.universe/pull/1578
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Test with Psim:
(The purple trajectory is rosbag-ego.)
Before:

[Screencast from 10-04-2024 06:39:20 PM.webm](https://github.com/user-attachments/assets/f48e9967-e80e-46a2-871a-9472ed84109e)

After:

[Screencast from 10-04-2024 06:38:00 PM.webm](https://github.com/user-attachments/assets/b3457af6-44f7-42b8-ac19-e84868c01d7c)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
