### PR TITLE
feat: add "skip_plt_show" arg to plotter

### DIFF
--- a/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/system_performance_plotter_base.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/system_performance_plotter_base.py
@@ -196,7 +196,11 @@ def create_common_argment(ymax=None):
         "-s", "--save-result", default=False, action="store_true", help="whether to save result"
     )
     parser.add_argument(
-        "-p", "--skip_plt_show", default=False, action="store_true", help="whether to skip plt.show()"
+        "-p",
+        "--skip_plt_show",
+        default=False,
+        action="store_true",
+        help="whether to skip plt.show()",
     )
 
     args = parser.parse_args()

--- a/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/system_performance_plotter_base.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/system_performance_plotter_base.py
@@ -36,6 +36,7 @@ class SystemPerformancePlotterBase:
         self.ymax = args.ymax
         self.number_of_plot = args.number_of_plot
         self.save_result = args.save_result
+        self.skip_plt_show = args.skip_plt_show
         self.ylabel = ylabel
         self.output_suffix = output_suffix
 
@@ -174,7 +175,8 @@ class SystemPerformancePlotterBase:
             # save figure of plot
             plt.savefig(f"./result/{output_name}-{timestamp}.png")
 
-        plt.show()
+        if not self.skip_plt_show:
+            plt.show()
 
 
 def create_common_argment(ymax=None):
@@ -192,6 +194,9 @@ def create_common_argment(ymax=None):
     )
     parser.add_argument(
         "-s", "--save-result", default=False, action="store_true", help="whether to save result"
+    )
+    parser.add_argument(
+        "-p", "--skip_plt_show", default=False, action="store_true", help="whether to skip plt.show()"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Description

`system_performance_plotter` is useful, but there is an issue that `plt.show()` is executed when plotting a graph, and the plot will not proceed unless the screen is closed each time.
This pull request will fix that.

It will continue to work as before unless it is run with `-p` or `--skip_plot_show`.

If you have any better suggestions please let me know.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

I have confirmed that `system_performance_plotter` works well.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
