### PR TITLE
fix(system_usage_monitor): change the node search method

### DIFF
--- a/common/autoware_debug_tools/autoware_debug_tools/system_usage_monitor.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/system_usage_monitor.py
@@ -44,7 +44,14 @@ def get_system_usage(pid, system_usages, interval):
         )
         if component == "":
             component = "others"
+
         elements = process_name.split("__node:=", 1)
+
+        # If `process_name`` can be split by "__node:=", get the container name from the second element.
+        # Otherwise, get the container name from the file name in the first element.
+        # An example of `process_name` is as follows:
+        # `/path/to/autoware/install/topic_state_monitor/lib/topic_state_monitor/topic_state_monitor_node
+        #     --ros-args -r __node:=topic_state_monitor_scenario_planning_trajectory -r __ns:=/system ...`
         if len(elements) < 2:
             container = process_name.split(" ")[0].split("/")[-1]
             if container.startswith("autoware_"):


### PR DESCRIPTION
## Description

This PR changes the node search method.

Before result : [system_usage_monitor_before.txt](https://github.com/user-attachments/files/17471791/system_usage_monitor_before.txt)
After result : [system_usage_monitor_after.txt](https://github.com/user-attachments/files/17471788/system_usage_monitor_after.txt)

#### Summary
The following information will be added when I use current the latest OSS Autoware.

```
+ | default_ad_api | initial_pose_adaptor_node                             |
+ | default_ad_api | routing_adaptor_node                                  |
+ | localization   | automatic_pose_initializer_node                       |
+ | localization   | ekf_localizer_node                                    |
+ | localization   | gyro_odometer_node                                    |
+ | localization   | localization_error_monitor_node                       |
+ | localization   | pose_initializer_node                                 |
+ | localization   | stop_filter_node                                      |
+ | localization   | twist2accel_node                                      |
+ | map            | map_projection_loader_node                            |
+ | sensing        | gyro_bias_estimator_node                              |
+ | sensing        | imu_corrector_node                                    |
+ | sensing        | vehicle_velocity_converter_node                       |
+ | system         | aggregator_node                                       |
+ | system         | service_log_checker_node                              |
```

No information is lost as a result of the change.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

I have confirmed that `system_usage_monitor` works well with AWSIM.

Before : ![localization_cpu_usage-24-10-22-15-06-15](https://github.com/user-attachments/assets/c3fc0150-3b8f-4ee9-9bc0-f82ad8522bf1)

After : ![localization_cpu_usage-24-10-22-16-40-00](https://github.com/user-attachments/assets/33466897-75cc-4267-a6a5-36dd03dc7ab4)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
