### PR TITLE
feat(rviz): make it possible to set default topic name

### DIFF
--- a/common/tier4_string_viewer_rviz_plugin/src/string_viewer_panel.hpp
+++ b/common/tier4_string_viewer_rviz_plugin/src/string_viewer_panel.hpp
@@ -40,6 +40,10 @@ public:
 
   void onInitialize() override;
 
+  void save(rviz_common::Config config) const override;
+
+  void load(const rviz_common::Config & config) override;
+
 private Q_SLOTS:
   void on_topic_name(const QString & topic);
 
@@ -51,6 +55,8 @@ private:
   QLabel * contents_;
 
   QComboBox * topic_list_;
+
+  QString default_topic_;
 
   rclcpp::Node::SharedPtr raw_node_;
 


### PR DESCRIPTION
## Description

I fixed logic so that we can set default topic name in rviz config like this:

```yaml
  - Class: tier4_string_viewer_rviz_plugin::StringViewerPanel
    Name: StringViewerPanel
    topic: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/internal_state
```

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
