### PR TITLE
fix: add a new argument "plot_function_level_processing_time"

### DIFF
--- a/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/processing_time_plotter.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/processing_time_plotter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-from tier4_debug_msgs.msg import Float64Stamped, ProcessingTimeTree
+from tier4_debug_msgs.msg import Float64Stamped
+from tier4_debug_msgs.msg import ProcessingTimeTree
 
 from .system_performance_plotter_base import PREDEFINED_COMPONENT_NAMES
 from .system_performance_plotter_base import SystemPerformancePlotterBase
@@ -45,12 +46,8 @@ class ProcessingTimePlotter(SystemPerformancePlotterBase):
                     self.max_metrics[curr_name] = 0.0
 
                 processing_time_ms = node.processing_time
-                self.stamp_and_metrics[curr_name].append(
-                    [date_time, processing_time_ms]
-                )
-                self.max_metrics[curr_name] = max(
-                    self.max_metrics[curr_name], processing_time_ms
-                )
+                self.stamp_and_metrics[curr_name].append([date_time, processing_time_ms])
+                self.max_metrics[curr_name] = max(self.max_metrics[curr_name], processing_time_ms)
 
 
 def main():

--- a/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/system_performance_plotter_base.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/system_performance_plotter/system_performance_plotter_base.py
@@ -43,6 +43,10 @@ class SystemPerformancePlotterBase:
         self.stamp_and_metrics = {}
         self.max_metrics = {}
 
+        self.additional_args = {}
+        if args.plot_function_level_processing_time:
+            self.additional_args["parse_processing_time_tree"] = True
+
     def run(self):
         # read data from rosbag
         reader = create_reader(self.input_bag_dir)
@@ -60,7 +64,7 @@ class SystemPerformancePlotterBase:
             time_stamp = stamp * to_nanosec
             date_time = datetime.fromtimestamp(time_stamp)
 
-            self.update_metrics_func(topic_name, data, date_time)
+            self.update_metrics_func(topic_name, data, date_time, **self.additional_args)
 
         # sort stamp_and_metrics by alphabetical order
         self.stamp_and_metrics = dict(sorted(self.stamp_and_metrics.items(), key=lambda x: x[0]))
@@ -201,6 +205,13 @@ def create_common_argment(ymax=None):
         default=False,
         action="store_true",
         help="whether to skip plt.show()",
+    )
+    parser.add_argument(
+        "-f",
+        "--plot_function_level_processing_time",
+        default=False,
+        action="store_true",
+        help="whether to plot function level processing time",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Description

Adds a new argument for plotting `autoware::universe_utils::ProcessingTimeDetail`.

I have made changes to `system_performance_plotter_base.py`, but I have implemented it so that the behavior does not change for anything other than `processing_time_plotter.py`.

## Tests performed

I have confirmed that the behavior changes depending on whether or not the option is selected.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
