### PR TITLE
fix(planning_debug_tools): output engage status properly

### DIFF
--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -16,10 +16,10 @@
 
 import time
 
+from autoware_adapi_v1_msgs.msg import OperationModeState
 from autoware_control_msgs.msg import Control as AckermannControlCommand
 from autoware_planning_msgs.msg import Path
 from autoware_planning_msgs.msg import Trajectory
-from autoware_vehicle_msgs.msg import Engage
 from autoware_vehicle_msgs.msg import VelocityReport
 from geometry_msgs.msg import Pose
 from nav_msgs.msg import Odometry
@@ -115,10 +115,10 @@ class VelocityChecker(Node):
 
         # others related to velocity
         self.sub8 = self.create_subscription(
-            Engage, "/autoware/engage", self.CallBackAwEngage, profile
-        )
-        self.sub12 = self.create_subscription(
-            Engage, "/vehicle/engage", self.CallBackVehicleEngage, profile
+            OperationModeState,
+            "/control/vehicle_cmd_gate/operation_mode",
+            self.CallBackAwEngage,
+            profile,
         )
         self.sub9 = self.create_subscription(
             VelocityLimit,
@@ -218,10 +218,8 @@ class VelocityChecker(Node):
         self.printInfo()
 
     def CallBackAwEngage(self, msg):
-        self.autoware_engage = msg.engage
-
-    def CallBackVehicleEngage(self, msg):
-        self.vehicle_engage = msg.engage
+        self.autoware_engage = msg.mode == OperationModeState.AUTONOMOUS
+        self.vehicle_engage = msg.is_autoware_control_enabled
 
     def CallBackExternalVelLim(self, msg):
         self.external_v_lim = msg.max_velocity


### PR DESCRIPTION
## Description

Fix `closest_velocity_checker.py`.  Use `autoware_adapi_v1_msgs` to check engage status.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
