### PR TITLE
fix(autoware_lanelet2_map_validator): removed redundant appendIssues()

### DIFF
--- a/map/autoware_lanelet2_map_validator/src/common/validation.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/validation.cpp
@@ -95,7 +95,6 @@ std::vector<lanelet::validation::DetectedIssues> validateMap(
                         }));
   }
 
-  appendIssues(issues, lanelet::validation::validateMap(*map, val_config));
   return issues;
 }
 


### PR DESCRIPTION
## Description

In the previous PR https://github.com/autowarefoundation/autoware_tools/pull/147, I've put a bug that `appendIssues()` will be executed twice. This PR removes the second `appendIssues()`.

(Output screen with bug)
![Screenshot from 2024-11-08 14-15-15](https://github.com/user-attachments/assets/a1d5e028-9942-49ca-8b6b-724b626cc5c7)

(Output screen without bug)
![Screenshot from 2024-11-11 17-47-00](https://github.com/user-attachments/assets/86f12280-d207-4b25-bd26-e8a0cb5daf5d)

## Related links

This PR https://github.com/autowarefoundation/autoware_tools/pull/147 has a second `appendIssues()` in the final part of `lanelet::autoware::validation::validateMap()` while the one before that PR https://github.com/autowarefoundation/autoware_tools/pull/144 doesn't.

## Tests performed

Checked that redundant issues disappear from the console output as shown in the upper image.
Checked that `colcon test` passed.

## Notes for reviewers

This bug doesn't affect the JSON output but affects the output from `lanelet::validation::printAllIssues(issues);` only.

## Interface changes

None

## Effects on system behavior

Redundant console outputs no longer appear.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
