### PR TITLE
fix(lareral_deviation_monitor): update metrics msgs

### DIFF
--- a/control/control_debug_tools/scripts/lateral_deviation_monitor.py
+++ b/control/control_debug_tools/scripts/lateral_deviation_monitor.py
@@ -18,11 +18,11 @@ import time
 
 from autoware_control_msgs.msg import Control
 from autoware_vehicle_msgs.msg import SteeringReport
-from diagnostic_msgs.msg import DiagnosticArray
 import matplotlib.pyplot as plt
 import rclpy
 from rclpy.node import Node
 from termcolor import colored
+from tier4_metric_msgs.msg import MetricArray
 
 
 class SteeringAndLateralDeviationMonitor(Node):
@@ -38,7 +38,7 @@ class SteeringAndLateralDeviationMonitor(Node):
         )
 
         self.create_subscription(
-            DiagnosticArray, "/control/control_evaluator/metrics", self.metrics_callback, 10
+            MetricArray, "/control/control_evaluator/metrics", self.metrics_callback, 10
         )
 
         self.control_steering_angle = None
@@ -77,14 +77,11 @@ class SteeringAndLateralDeviationMonitor(Node):
         self.update_steering_diff()
         self.update_max_values()
 
-    def metrics_callback(self, msg):
-        for status in msg.status:
-            if status.name == "lateral_deviation":
-                for value in status.values:
-                    if value.key == "metric_value":
-                        self.lateral_deviation = float(value.value)
-                        self.update_max_values()
-                        break
+    def metrics_callback(self, msgs):
+        for msg in msgs.metric_array:
+            if msg.name == "lateral_deviation":
+                self.lateral_deviation = float(msg.value)
+                self.update_max_values()
 
     def update_steering_diff(self):
         if self.control_steering_angle is not None and self.vehicle_steering_angle is not None:
@@ -185,7 +182,6 @@ def main(args=None):
     if monitor.plot:
         plt.ion()  # Interactive mode on for real-time plot updates
     rclpy.spin(monitor)
-
     monitor.destroy_node()
     rclpy.shutdown()
     if monitor.plot:


### PR DESCRIPTION
## Description

Due to a related links PR, `/control/contol_evaluator/metrics` was changed from DiagnosticArray to MetricArray.
This change caused B to not take msgs well and not receive msgs, which has been corrected.

## Related links

* https://github.com/autowarefoundation/autoware.universe/pull/9180

## Tests performed

![image (5)](https://github.com/user-attachments/assets/95928ca6-51f4-4a1f-8f29-1ca4e3f054fc)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
