### PR TITLE
fix(lanelet2_map_validator): fixed issue that invalid prerequisites are not reflected to the results

### DIFF
--- a/map/autoware_lanelet2_map_validator/src/common/validation.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/validation.cpp
@@ -305,7 +305,6 @@ void process_requirements(
 
     // Check prerequisites are OK
     const auto prerequisite_issues = check_prerequisite_completion(validators, validator_name);
-    appendIssues(total_issues, prerequisite_issues);
 
     // NOTE: if prerequisite_issues is not empty, skip the content validation process
     const auto issues =
@@ -313,7 +312,7 @@ void process_requirements(
         ? apply_validation(
             lanelet_map, replace_validator(
                            validator_config.command_line_config.validationConfig, validator_name))
-        : std::vector<lanelet::validation::DetectedIssues>();
+        : std::move(prerequisite_issues);
 
     // Add validation results to the json data
     json & validator_json = find_validator_block(json_data, validator_name);


### PR DESCRIPTION
## Description

This PR fixes the issue that the validation results (lanelet2_validation_results.json) don't reflect the prerequisite failure.
The content in `prerequisite_issues` should be written in the JSON objects, but the process between L319 to L355 (in validation.cpp) is skipped only for `prerequisite_issues`.

## Related links
None

## Tests performed

- Checked that `colcon test` has passed.
- Checked that issues with a message "Prerequisites didn't pass." appear in `lanelet2_map_validation_results.json` when a incomplete lanelet2 map is given.

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Prerequisites failure will appear in the results as expected.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
