### PR TITLE
fix: to use autoware_lanelet2_extension

### DIFF
--- a/driving_environment_analyzer/package.xml
+++ b/driving_environment_analyzer/package.xml
@@ -25,7 +25,7 @@
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>lanelet2_extension</depend>
+  <depend>autoware_lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/driving_environment_analyzer/package.xml
+++ b/driving_environment_analyzer/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_lane_departure_checker</depend>
+  <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
@@ -25,7 +26,6 @@
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>autoware_lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/driving_environment_analyzer/src/utils.cpp
+++ b/driving_environment_analyzer/src/utils.cpp
@@ -16,9 +16,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 
-#include <lanelet2_extension/regulatory_elements/Forward.hpp>
-#include <lanelet2_extension/utility/message_conversion.hpp>
-#include <lanelet2_extension/utility/utilities.hpp>
+#include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <magic_enum.hpp>
 
 #include <lanelet2_routing/RoutingGraphContainer.h>


### PR DESCRIPTION
## Description

`lanelet2_extension` has been replaced by `autoware_lanelet2_extension`.

- https://github.com/autowarefoundation/autoware/pull/5578

Without this PR, the following error occurs. 

```bash
+ rosdep install -y --from-paths src --ignore-src --rosdistro humble
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
driving_environment_analyzer: Cannot locate rosdep definition for [lanelet2_extension]
```

## How was this PR tested?

- [x] build in local PC

## Notes for reviewers

None.

## Effects on system behavior

None.
