### PR TITLE
feat(tier4_xxx_rviz_plugin): use StringStamped in autoware_internal_debug_msgs

### DIFF
--- a/common/tier4_debug_rviz_plugin/include/tier4_debug_rviz_plugin/string_stamped.hpp
+++ b/common/tier4_debug_rviz_plugin/include/tier4_debug_rviz_plugin/string_stamped.hpp
@@ -61,12 +61,12 @@
 
 #endif
 
-#include <tier4_debug_msgs/msg/string_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 
 namespace rviz_plugins
 {
 class StringStampedOverlayDisplay
-: public rviz_common::RosTopicDisplay<tier4_debug_msgs::msg::StringStamped>
+: public rviz_common::RosTopicDisplay<autoware_internal_debug_msgs::msg::StringStamped>
 
 {
   Q_OBJECT
@@ -84,7 +84,8 @@ private Q_SLOTS:
 
 protected:
   void update(float wall_dt, float ros_dt) override;
-  void processMessage(const tier4_debug_msgs::msg::StringStamped::ConstSharedPtr msg_ptr) override;
+  void processMessage(
+    const autoware_internal_debug_msgs::msg::StringStamped::ConstSharedPtr msg_ptr) override;
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
   rviz_common::properties::IntProperty * property_left_;
@@ -100,7 +101,7 @@ private:
   static constexpr int hand_width_ = 4;
 
   std::mutex mutex_;
-  tier4_debug_msgs::msg::StringStamped::ConstSharedPtr last_msg_ptr_;
+  autoware_internal_debug_msgs::msg::StringStamped::ConstSharedPtr last_msg_ptr_;
 };
 }  // namespace rviz_plugins
 

--- a/common/tier4_debug_rviz_plugin/package.xml
+++ b/common/tier4_debug_rviz_plugin/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/common/tier4_debug_rviz_plugin/plugins/plugin_description.xml
+++ b/common/tier4_debug_rviz_plugin/plugins/plugin_description.xml
@@ -7,6 +7,6 @@
   <class name="rviz_plugins/StringStampedOverlayDisplay"
     type="rviz_plugins::StringStampedOverlayDisplay"
     base_class_type="rviz_common::Display">
-    <description>Display drivable area of tier4_debug_msgs::msg::StringStamped</description>
+    <description>Display drivable area of autoware_internal_debug_msgs::msg::StringStamped</description>
   </class>
 </library>

--- a/common/tier4_debug_rviz_plugin/src/string_stamped.cpp
+++ b/common/tier4_debug_rviz_plugin/src/string_stamped.cpp
@@ -170,7 +170,7 @@ void StringStampedOverlayDisplay::update(float wall_dt, float ros_dt)
 }
 
 void StringStampedOverlayDisplay::processMessage(
-  const tier4_debug_msgs::msg::StringStamped::ConstSharedPtr msg_ptr)
+  const autoware_internal_debug_msgs::msg::StringStamped::ConstSharedPtr msg_ptr)
 {
   if (!isEnabled()) {
     return;

--- a/common/tier4_string_viewer_rviz_plugin/README.md
+++ b/common/tier4_string_viewer_rviz_plugin/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This plugin displays the ROS message whose topic type is `tier4_debug_msgs::msg::StringStamped` in rviz.
+This plugin displays the ROS message whose topic type is `autoware_internal_debug_msgs::msg::StringStamped` in rviz.
 
 ## Assumptions / Known limits
 

--- a/common/tier4_string_viewer_rviz_plugin/package.xml
+++ b/common/tier4_string_viewer_rviz_plugin/package.xml
@@ -10,13 +10,13 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>
   <depend>qtbase5-dev</depend>
   <depend>rclcpp</depend>
   <depend>rviz_common</depend>
-  <depend>tier4_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/tier4_string_viewer_rviz_plugin/src/string_viewer_panel.hpp
+++ b/common/tier4_string_viewer_rviz_plugin/src/string_viewer_panel.hpp
@@ -22,12 +22,12 @@
 #include <rviz_common/ros_integration/ros_node_abstraction_iface.hpp>
 #include <rviz_common/ros_topic_display.hpp>
 
-#include <tier4_debug_msgs/msg/string_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 
 namespace tier4_string_viewer_rviz_plugin
 {
 
-using tier4_debug_msgs::msg::StringStamped;
+using autoware_internal_debug_msgs::msg::StringStamped;
 
 class QLineEdit;
 


### PR DESCRIPTION
## Description

The message used in this repository will be moved by https://github.com/autowarefoundation/autoware_internal_msgs/pull/30
This PR will handle this change.


Run the following command, and manually add autoware_internal_debug_msgs in the package.xml
```
find ./ -type f -exec sed -i -e 's/tier4_debug_msgs::msg::StringStamped/autoware_internal_debug_msgs::msg::StringStamped/g' {} \;
find ./ -type f -exec sed -i -e 's/tier4_debug_msgs\/msg\/string_stamped/autoware_internal_debug_msgs\/msg\/string_stamped/g' {} \;
```
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
