### PR TITLE
test(static_centerline_generator): add launch test with autoware_sample_vehicle_launch package

### DIFF
--- a/common/autoware_sample_vehicle_description/CMakeLists.txt
+++ b/common/autoware_sample_vehicle_description/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_sample_vehicle_description)
+
+find_package(autoware_cmake REQUIRED)
+find_package(xacro REQUIRED)
+autoware_package()
+
+ament_auto_package(INSTALL_TO_SHARE
+  mesh
+  urdf
+  config
+)

--- a/common/autoware_sample_vehicle_description/config/mirror.param.yaml
+++ b/common/autoware_sample_vehicle_description/config/mirror.param.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    mirror:
+      min_longitudinal_offset: 7.00
+      max_longitudinal_offset: 8.00
+      min_lateral_offset: -1.60
+      max_lateral_offset: 1.55
+      min_height_offset: 1.65
+      max_height_offset: 2.60
+    tire:
+      min_longitudinal_offset: 4.60
+      max_longitudinal_offset: 5.80
+      min_lateral_offset: -1.55
+      max_lateral_offset: 1.55
+      min_height_offset: 0.00
+      max_height_offset: 1.20

--- a/common/autoware_sample_vehicle_description/config/simulator_model.param.yaml
+++ b/common/autoware_sample_vehicle_description/config/simulator_model.param.yaml
@@ -1,0 +1,18 @@
+/**:
+  ros__parameters:
+    simulated_frame_id: "base_link"
+    origin_frame_id: "map"
+    vehicle_model_type: "IDEAL_STEER_ACC_GEARED"
+    initialize_source: "INITIAL_POSE_TOPIC"
+    timer_sampling_time_ms: 25
+    add_measurement_noise: False
+    vel_lim: 40.0
+    vel_rate_lim: 7.0
+    steer_lim: 1.0
+    steer_rate_lim: 0.35
+    acc_time_delay: 0.1
+    acc_time_constant: 0.1
+    steer_time_delay: 0.24
+    steer_time_constant: 0.27
+    x_stddev: 0.0001 # x standard deviation for dummy covariance in map coordinate
+    y_stddev: 0.0001 # y standard deviation for dummy covariance in map coordinate

--- a/common/autoware_sample_vehicle_description/config/vehicle_info.param.yaml
+++ b/common/autoware_sample_vehicle_description/config/vehicle_info.param.yaml
@@ -1,0 +1,23 @@
+/**:
+  ros__parameters:
+    wheel_radius: 0.529
+    wheel_width: 0.279
+    wheel_base: 5.3
+    wheel_tread: 2.065
+    front_overhang: 2.8 #pcd crop -0.50
+    rear_overhang: 2.83 #pcd crop + 0.07
+    left_overhang: 0.25 #pcd crop + 0.13
+    right_overhang: 0.25 #pcd crop + 0.13
+    vehicle_height: 3.1
+    max_steer_angle: 0.785
+
+    # original
+    # wheel_radius: 0.529
+    # wheel_width: 0.279
+    # wheel_base: 5.3
+    # wheel_tread: 2.065
+    # front_overhang: 2.255
+    # rear_overhang: 2.83
+    # left_overhang: 0.21
+    # right_overhang: 0.21
+    # vehicle_height: 3.096

--- a/common/autoware_sample_vehicle_description/package.xml
+++ b/common/autoware_sample_vehicle_description/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>autoware_sample_vehicle_description</name>
+  <version>0.1.0</version>
+  <description>The autoware_sample_vehicle_description package</description>
+
+  <maintainer email="temkei.kem@tier4.jp">Temkei Kem</maintainer>
+  <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <license>Apache2</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_sample_vehicle_description/urdf/vehicle.xacro
+++ b/common/autoware_sample_vehicle_description/urdf/vehicle.xacro
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <!-- load parameter -->
+  <xacro:property name="vehicle_info" value="${xacro.load_yaml('$(find autoware_sample_vehicle_description)/config/vehicle_info.param.yaml')}"/>
+
+  <!-- vehicle body -->
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 ${pi/2.0}"/>
+      <geometry>
+        <mesh filename="package://autoware_sample_vehicle_description/mesh/autoware_sample_vehicle.dae" scale="1 1 1"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>

--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -52,6 +52,10 @@ if(BUILD_TESTING)
     test/test_static_centerline_generator.test.py
     TIMEOUT "30"
   )
+  add_launch_test(
+    test/test_static_centerline_generator_launch.test.py
+    TIMEOUT "30"
+  )
   install(DIRECTORY
     test/data/
     DESTINATION share/${PROJECT_NAME}/test/data/

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -19,8 +19,12 @@
   <!-- topic -->
   <arg name="lanelet2_map_topic" default="/map/vector_map"/>
   <arg name="lanelet2_map_marker_topic" default="/map/vector_map_marker"/>
-  <!-- param -->
-  <arg name="map_loader_param" default="$(find-pkg-share autoware_map_loader)/config/lanelet2_map_loader.param.yaml"/>
+
+  <!-- common param -->
+  <arg name="common_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common/common.param.yaml"/>
+  <arg name="nearest_search_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common/nearest_search.param.yaml"/>
+  <!-- component param -->
+  <arg name="map_loader_param" default="$(find-pkg-share autoware_launch)/config/map/lanelet2_map_loader.param.yaml"/>
   <arg
     name="behavior_path_planner_param"
     default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml"
@@ -64,8 +68,8 @@
     <param name="start_lanelet_id" value="$(var start_lanelet_id)"/>
     <param name="end_lanelet_id" value="$(var end_lanelet_id)"/>
     <!-- common param -->
-    <param from="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common/common.param.yaml"/>
-    <param from="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common/nearest_search.param.yaml"/>
+    <param from="$(var common_param)"/>
+    <param from="$(var nearest_search_param)"/>
     <!-- component param -->
     <param from="$(var map_loader_param)"/>
     <param from="$(var behavior_path_planner_param)"/>

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- mandatory arguments for planning-->
-  <arg name="vehicle_model"/>
+  <arg name="vehicle_model" default="autoware_sample_vehicle"/>
 
   <!-- flag -->
   <arg name="mode" default="AUTO" description="select from AUTO, GUI, and VMB"/>

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_static_centerline_generator</name>
-  <version>0.40.0</version>
+  <version>0.38.0</version>
   <description>The autoware_static_centerline_generator package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
@@ -17,14 +17,11 @@
 
   <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_geography_utils</depend>
-  <depend>autoware_global_parameter_loader</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
-  <depend>autoware_lanelet2_map_visualizer</depend>
   <depend>autoware_map_loader</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_map_projection_loader</depend>
-  <depend>autoware_map_tf_generator</depend>
   <depend>autoware_mission_planner</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>
@@ -36,8 +33,10 @@
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
+  <depend>global_parameter_loader</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_map_msgs</depend>
 
   <exec_depend>python3-flask-cors</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
@@ -47,7 +46,10 @@
   <test_depend>autoware_behavior_path_planner</test_depend>
   <test_depend>autoware_behavior_velocity_planner</test_depend>
   <test_depend>autoware_global_parameter_loader</test_depend>
+  <test_depend>autoware_lanelet2_map_visualizer</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>autoware_map_tf_generator</test_depend>
+  <test_depend>autoware_sample_vehicle_description</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -33,7 +33,6 @@
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
-  <depend>global_parameter_loader</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_map_msgs</depend>

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -27,21 +27,20 @@ import pytest
 
 @pytest.mark.launch_test
 def generate_test_description():
-    lanelet2_map_path = os.path.join(
-        get_package_share_directory("autoware_static_centerline_generator"),
-        "test/data/lanelet2_map.osm",
-    )
-
     static_centerline_generator_node = Node(
         package="autoware_static_centerline_generator",
         executable="main",
         output="screen",
         parameters=[
-            {"lanelet2_map_path": lanelet2_map_path},
             {"mode": "AUTO"},
             {"rviz": False},
             {"centerline_source": "optimization_trajectory_base"},
-            {"lanelet2_input_file_path": lanelet2_map_path},
+            {
+                "lanelet2_input_file_path": os.path.join(
+                    get_package_share_directory("autoware_static_centerline_generator"),
+                    "test/data/lanelet2_map.osm",
+                )
+            },
             {"lanelet2_output_file_path": "/tmp/lanelet2_map.osm"},
             {"start_lanelet_id": 215},
             {"end_lanelet_id": 216},

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
@@ -55,7 +55,60 @@ def generate_test_description():
             DeclareLaunchArgument("start_lanelet_id", default_value="215"),
             DeclareLaunchArgument("end_lanelet_id", default_value="216"),
             DeclareLaunchArgument(
-                "centerline_source", default_value="optimization_trajectory_base"
+                "map_loader_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_map_loader"),
+                    "config/lanelet2_map_loader.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "behavior_path_planner_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_behavior_path_planner"),
+                    "config/behavior_path_planner.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "behavior_velocity_planner_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_behavior_velocity_planner"),
+                    "config/behavior_velocity_planner.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "path_smoother_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_path_smoother"),
+                    "config/path_smoother.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "path_optimizer_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_path_optimizer"),
+                    "config/path_optimizer.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "mission_planner_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_mission_planner"),
+                    "config/mission_planner.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "common_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_static_centerline_generator"),
+                    "config/common.param.yaml",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "nearest_search_param",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_static_centerline_generator"),
+                    "config/nearest_search.param.yaml",
+                ),
             ),
             static_centerline_generator,
             # Start test after 1s - gives time for the autoware_static_centerline_generator to finish initialization

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ament_index_python import get_package_share_directory
+import launch
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+import launch_testing
+import pytest
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    test_static_centerline_generator_launch_file = os.path.join(
+        get_package_share_directory("autoware_static_centerline_generator"),
+        "launch",
+        "static_centerline_generator.launch.xml",
+    )
+
+    static_centerline_generator = IncludeLaunchDescription(
+        AnyLaunchDescriptionSource(test_static_centerline_generator_launch_file),
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "lanelet2_input_file_path",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_static_centerline_generator"),
+                    "test/data/lanelet2_map.osm",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "lanelet2_output_file_path", default_value="/tmp/lanelet2_map.osm"
+            ),
+            DeclareLaunchArgument("rviz", default_value="false"),
+            DeclareLaunchArgument("start_lanelet_id", default_value="215"),
+            DeclareLaunchArgument("end_lanelet_id", default_value="216"),
+            DeclareLaunchArgument(
+                "centerline_source", default_value="optimization_trajectory_base"
+            ),
+            static_centerline_generator,
+            # Start test after 1s - gives time for the autoware_static_centerline_generator to finish initialization
+            launch.actions.TimerAction(period=1.0, actions=[launch_testing.actions.ReadyToTest()]),
+        ]
+    )
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_code(self, proc_info):
+        # Check that process exits with code 0: no error
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
## Description
depends on https://github.com/autowarefoundation/autoware_tools/pull/189

Added a test for static_centerline_generator.launch.xml.
Since the launch.xml uses the global_parameter_loader of vehicle_launch, this PR also added a sample_vehicle_launch just for testing.


## How was this PR tested?

Unit test passed.

## Notes for reviewers

None.

## Effects on system behavior

None.
