### PR TITLE
feat(lanelet2_map_validator): check local coordinates declaration

### DIFF
--- a/map/autoware_lanelet2_map_validator/docs/lane/local_coordinates_declaration.md
+++ b/map/autoware_lanelet2_map_validator/docs/lane/local_coordinates_declaration.md
@@ -1,0 +1,24 @@
+# local_coordinates_declaration
+
+## Validator name
+
+mapping.lane.local_coordinates_declaration
+
+## Feature
+
+This validator checks whether local coordinates are declared to each point in a Lanelet2 map if one or more points have local coordinates. If a Lanelet2 map is made to have local coordinates, each point MUST have both a `local_x` tag and a `local_y` tag.
+
+If the Lanelet2 map is NOT made to have local coordinates and doesn't have a single point with `local_x` or `local_y` declared, this validator ignores the map and outputs no issues.
+
+The validator outputs the following issue with the corresponding ID of the primitive.
+
+| Issue Code                           | Message                                                    | Severity | Primitive | Description                                                                                                                                                  | Approach                                                                                   |
+| ------------------------------------ | ---------------------------------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| Lane.LocalCoordinatesDeclaration-001 | This point doesn't have local coordinates while others do. | Error    | Point     | The map has a point that has tags `local_x` and `local_y` but this point doesn't have them. All points in a map must be set to have both tags or not at all. | Be sure to align whether each point has or does not have both tabs `local_x` and `local_y` |
+| Lane.LocalCoordinatesDeclaration-002 | "local_x" is declared but "local_y" is not."               | Error    | Point     | The point has a `local_x` tag but doesn't have a `local_y` tag.                                                                                              | Be sure that all points have both tags `local_x` and `local_y`.                            |
+| Lane.LocalCoordinatesDeclaration-003 | "local_y" is declared but "local_x" is not."               | Error    | Point     | The point has a `local_y` tag but doesn't have a `local_x` tag.                                                                                              | Be sure that all points have both tags `local_x` and `local_y`.                            |
+
+## Related source codes
+
+- local_coordinates_declaration.cpp
+- local_coordinates_declaration.hpp

--- a/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/lane/local_coordinates_declaration.hpp
+++ b/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validators/lane/local_coordinates_declaration.hpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__LOCAL_COORDINATES_DECLARATION_HPP_
+#define LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__LOCAL_COORDINATES_DECLARATION_HPP_
+
+#include <lanelet2_validation/Validation.h>
+#include <lanelet2_validation/ValidatorFactory.h>
+
+namespace lanelet::autoware::validation
+{
+class LocalCoordinatesDeclarationValidator : public lanelet::validation::MapValidator
+{
+public:
+  // Write the validator's name here
+  constexpr static const char * name() { return "mapping.lane.local_coordinates_declaration"; }
+
+  lanelet::validation::Issues operator()(const lanelet::LaneletMap & map) override;
+
+private:
+  lanelet::validation::Issues check_local_coordinates_declaration(const lanelet::LaneletMap & map);
+};
+}  // namespace lanelet::autoware::validation
+
+#endif  // LANELET2_MAP_VALIDATOR__VALIDATORS__LANE__LOCAL_COORDINATES_DECLARATION_HPP_

--- a/map/autoware_lanelet2_map_validator/src/validators/lane/local_coordinates_declaration.cpp
+++ b/map/autoware_lanelet2_map_validator/src/validators/lane/local_coordinates_declaration.cpp
@@ -1,0 +1,96 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/validators/lane/local_coordinates_declaration.hpp"
+
+#include "lanelet2_core/LaneletMap.h"
+#include "lanelet2_map_validator/utils.hpp"
+
+#include <set>
+
+namespace lanelet::autoware::validation
+{
+namespace
+{
+lanelet::validation::RegisterMapValidator<LocalCoordinatesDeclarationValidator> reg;
+}
+
+lanelet::validation::Issues LocalCoordinatesDeclarationValidator::operator()(
+  const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  lanelet::autoware::validation::appendIssues(issues, check_local_coordinates_declaration(map));
+
+  return issues;
+}
+
+lanelet::validation::Issues
+LocalCoordinatesDeclarationValidator::check_local_coordinates_declaration(
+  const lanelet::LaneletMap & map)
+{
+  lanelet::validation::Issues issues;
+
+  bool is_local_mode = false;
+
+  std::set<lanelet::Id> non_local_point_ids;
+
+  for (const lanelet::ConstPoint3d & point : map.pointLayer) {
+    bool local_x = point.hasAttribute("local_x");
+    bool local_y = point.hasAttribute("local_y");
+
+    if (!is_local_mode) {
+      if (local_x || local_y) {
+        is_local_mode = true;
+        for (const lanelet::Id & id : non_local_point_ids) {
+          issues.emplace_back(
+            lanelet::validation::Severity::Error, lanelet::validation::Primitive::Point, id,
+            append_issue_code_prefix(
+              this->name(), 1, "This point doesn't have local coordinates while others do."));
+        }
+      } else {
+        non_local_point_ids.insert(point.id());
+      }
+      continue;
+    }
+
+    // Points are assumed to have local_x and local_y from here
+    if (!local_x && !local_y) {
+      issues.emplace_back(
+        lanelet::validation::Severity::Error, lanelet::validation::Primitive::Point, point.id(),
+        append_issue_code_prefix(
+          this->name(), 1, "This point doesn't have local coordinates while others do."));
+    }
+
+    // Only one coordinate (local_x or local_y) is defined
+    if (local_x && !local_y) {
+      issues.emplace_back(
+        lanelet::validation::Severity::Error, lanelet::validation::Primitive::Point, point.id(),
+        append_issue_code_prefix(
+          this->name(), 2, "\"local_x\" is declared but \"local_y\" is not."));
+      continue;
+    }
+
+    if (!local_x && local_y) {
+      issues.emplace_back(
+        lanelet::validation::Severity::Error, lanelet::validation::Primitive::Point, point.id(),
+        append_issue_code_prefix(
+          this->name(), 3, "\"local_y\" is declared but \"local_x\" is not."));
+      continue;
+    }
+  }
+
+  return issues;
+}
+}  // namespace lanelet::autoware::validation

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet.osm
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_first_three_points_missing_local_coordinates.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_first_three_points_missing_local_coordinates.osm
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_partially_defected_local_coordinates.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_partially_defected_local_coordinates.osm
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_without_local_coordinates.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_without_local_coordinates.osm
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/src/lane/test_local_coordinates_declaration.cpp
+++ b/map/autoware_lanelet2_map_validator/test/src/lane/test_local_coordinates_declaration.cpp
@@ -1,0 +1,130 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/validators/lane/local_coordinates_declaration.hpp"
+#include "map_validation_tester.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+
+#include <string>
+
+class TestLocalCoordinatesDeclarationValidator : public MapValidationTester
+{
+private:
+};
+
+TEST_F(TestLocalCoordinatesDeclarationValidator, ValidatorAvailability)  // NOLINT for gtest
+{
+  std::string expected_validator_name =
+    lanelet::autoware::validation::LocalCoordinatesDeclarationValidator::name();
+
+  lanelet::validation::Strings validators =
+    lanelet::validation::availabeChecks(expected_validator_name);  // cspell:disable-line
+
+  const uint32_t expected_validator_num = 1;
+  EXPECT_EQ(expected_validator_num, validators.size());
+  EXPECT_EQ(expected_validator_name, validators[0]);
+}
+
+TEST_F(TestLocalCoordinatesDeclarationValidator, NotLocalFromStart)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet_first_three_points_missing_local_coordinates.osm");
+
+  lanelet::autoware::validation::LocalCoordinatesDeclarationValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 3);
+
+  EXPECT_EQ(issues[0].id, 8);
+  EXPECT_EQ(issues[0].severity, lanelet::validation::Severity::Error);
+  EXPECT_EQ(issues[0].primitive, lanelet::validation::Primitive::Point);
+  EXPECT_EQ(
+    issues[0].message,
+    "[Lane.LocalCoordinatesDeclaration-001] This point doesn't have local coordinates while others "
+    "do.");
+
+  EXPECT_EQ(issues[1].id, 9);
+  EXPECT_EQ(issues[1].severity, lanelet::validation::Severity::Error);
+  EXPECT_EQ(issues[1].primitive, lanelet::validation::Primitive::Point);
+  EXPECT_EQ(
+    issues[1].message,
+    "[Lane.LocalCoordinatesDeclaration-001] This point doesn't have local coordinates while others "
+    "do.");
+
+  EXPECT_EQ(issues[2].id, 11);
+  EXPECT_EQ(issues[2].severity, lanelet::validation::Severity::Error);
+  EXPECT_EQ(issues[2].primitive, lanelet::validation::Primitive::Point);
+  EXPECT_EQ(
+    issues[2].message,
+    "[Lane.LocalCoordinatesDeclaration-001] This point doesn't have local coordinates while others "
+    "do.");
+}
+
+TEST_F(TestLocalCoordinatesDeclarationValidator, PartiallyDefected)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet_partially_defected_local_coordinates.osm");
+
+  lanelet::autoware::validation::LocalCoordinatesDeclarationValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 2);
+
+  EXPECT_EQ(issues[0].id, 8);
+  EXPECT_EQ(issues[0].severity, lanelet::validation::Severity::Error);
+  EXPECT_EQ(issues[0].primitive, lanelet::validation::Primitive::Point);
+  EXPECT_EQ(
+    issues[0].message,
+    "[Lane.LocalCoordinatesDeclaration-002] \"local_x\" is declared but \"local_y\" is not.");
+
+  EXPECT_EQ(issues[1].id, 17);
+  EXPECT_EQ(issues[1].severity, lanelet::validation::Severity::Error);
+  EXPECT_EQ(issues[1].primitive, lanelet::validation::Primitive::Point);
+  EXPECT_EQ(
+    issues[1].message,
+    "[Lane.LocalCoordinatesDeclaration-003] \"local_y\" is declared but \"local_x\" is not.");
+}
+
+TEST_F(
+  TestLocalCoordinatesDeclarationValidator, NormalLaneletWithLocalCoordinates)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet.osm");
+
+  lanelet::autoware::validation::LocalCoordinatesDeclarationValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0);
+}
+
+TEST_F(
+  TestLocalCoordinatesDeclarationValidator,
+  NormalLaneletWithoutLocalCoordinates)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet_without_local_coordinates.osm");
+
+  lanelet::autoware::validation::LocalCoordinatesDeclarationValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0);
+}
+
+TEST_F(TestLocalCoordinatesDeclarationValidator, SampleMap)  // NOLINT for gtest
+{
+  load_target_map("sample_map.osm");
+
+  lanelet::autoware::validation::LocalCoordinatesDeclarationValidator checker;
+  const auto & issues = checker(*map_);
+
+  EXPECT_EQ(issues.size(), 0);
+}


### PR DESCRIPTION
## Description

This PR adds a validator `mapping.intersection.local_coordinates_declaration` that checks whether all points have `local_x` & `local_y` or all points don't have `local_x` and `local_y`.

In short, this PR adds the following implementation.
- New validator `mapping.intersection.local_coordinates_declaration`.
- A test code for `mapping.intersection.local_coordinates_declaration`.
- A document for `mapping.intersection.local_coordinates_declaration`.

## How was this PR tested?

1. Confirmed that `colcon test --packages-select autoware_lanelet2_map_validator --event-handlers console_cohesion+` passes.
2. Confirmed that the following command shows no mistakes against several lanelet2 maps I have.

```
ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator -p mgrs -m <PATH_TO_sample_map.osm> -i <PATH_TO_autoware_requirement_set.json> -o ./
```

## Notes for reviewers

This validation item is NOT included in the autoware vector map requirements, so it's not included to `autoware_requirement_set.json`.

## Effects on system behavior

None.
