### PR TITLE
feat(autoware_static_centerline_generator): rename autoware_mission_planner to autoware_mission_planner_universe

### DIFF
--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -35,7 +35,7 @@
   />
   <arg name="path_smoother_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml"/>
   <arg name="path_optimizer_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/autoware_path_optimizer/path_optimizer.param.yaml"/>
-  <arg name="mission_planner_param" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
+  <arg name="mission_planner_param" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner_universe/mission_planner.param.yaml"/>
 
   <!-- Global parameters (for PathFootprint in tier4_planning_rviz_plugin) -->
   <!-- Do not add "group" in order to propagate global parameters -->

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -22,7 +22,7 @@
   <depend>autoware_map_loader</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_map_projection_loader</depend>
-  <depend>autoware_mission_planner</depend>
+  <depend>autoware_mission_planner_universe</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>
   <depend>autoware_path_optimizer</depend>

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -452,8 +452,8 @@ std::vector<lanelet::Id> StaticCenterlineGeneratorNode::plan_route(
     // create mission_planner plugin
     auto plugin_loader = pluginlib::ClassLoader<autoware::mission_planner_universe::PlannerPlugin>(
       "autoware_mission_planner_universe", "autoware::mission_planner_universe::PlannerPlugin");
-    auto mission_planner =
-      plugin_loader.createSharedInstance("autoware::mission_planner_universe::lanelet2::DefaultPlanner");
+    auto mission_planner = plugin_loader.createSharedInstance(
+      "autoware::mission_planner_universe::lanelet2::DefaultPlanner");
 
     // initialize mission_planner
     auto node = rclcpp::Node("mission_planner");

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -32,7 +32,7 @@
 #include "utils.hpp"
 
 #include <autoware/geography_utils/lanelet2_projector.hpp>
-#include <autoware/mission_planner/mission_planner_plugin.hpp>
+#include <autoware/mission_planner_universe/mission_planner_plugin.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
 #include <pluginlib/class_loader.hpp>
 
@@ -450,10 +450,10 @@ std::vector<lanelet::Id> StaticCenterlineGeneratorNode::plan_route(
       std::vector<geometry_msgs::msg::Pose>{start_center_pose, end_center_pose};
 
     // create mission_planner plugin
-    auto plugin_loader = pluginlib::ClassLoader<autoware::mission_planner::PlannerPlugin>(
-      "autoware_mission_planner", "autoware::mission_planner::PlannerPlugin");
+    auto plugin_loader = pluginlib::ClassLoader<autoware::mission_planner_universe::PlannerPlugin>(
+      "autoware_mission_planner_universe", "autoware::mission_planner_universe::PlannerPlugin");
     auto mission_planner =
-      plugin_loader.createSharedInstance("autoware::mission_planner::lanelet2::DefaultPlanner");
+      plugin_loader.createSharedInstance("autoware::mission_planner_universe::lanelet2::DefaultPlanner");
 
     // initialize mission_planner
     auto node = rclcpp::Node("mission_planner");

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -45,7 +45,7 @@ def generate_test_description():
             {"start_lanelet_id": 215},
             {"end_lanelet_id": 216},
             os.path.join(
-                get_package_share_directory("autoware_mission_planner"),
+                get_package_share_directory("autoware_mission_planner_universe"),
                 "config",
                 "mission_planner.param.yaml",
             ),

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
@@ -92,7 +92,7 @@ def generate_test_description():
             DeclareLaunchArgument(
                 "mission_planner_param",
                 default_value=os.path.join(
-                    get_package_share_directory("autoware_mission_planner"),
+                    get_package_share_directory("autoware_mission_planner_universe"),
                     "config/mission_planner.param.yaml",
                 ),
             ),


### PR DESCRIPTION
## Description
This updates the packages that depends on autoware_mission_planner to use updated name in https://github.com/autowarefoundation/autoware.universe/pull/9941

## How was this PR tested?
Tested with planning simulator

## Notes for reviewers

None.

## Effects on system behavior

None.
