### PR TITLE
feat(deviation_estimation_tools): replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
@@ -24,13 +24,13 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 #include "autoware_vehicle_msgs/msg/velocity_report.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
-#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <iostream>
 #include <memory>

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/deviation_estimator.hpp
@@ -30,7 +30,7 @@
 #include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
-#include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <iostream>
 #include <memory>
@@ -71,7 +71,7 @@ private:
 
   std::string imu_link_frame_;
 
-  std::vector<tier4_debug_msgs::msg::Float64Stamped> vx_all_;
+  std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> vx_all_;
   std::vector<geometry_msgs::msg::Vector3Stamped> gyro_all_;
   std::vector<geometry_msgs::msg::PoseStamped> pose_buf_;
   std::vector<TrajectoryData> traj_data_list_for_gyro_;

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/utils.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/utils.hpp
@@ -21,7 +21,7 @@
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <tf2/transform_datatypes.h>
 
@@ -39,7 +39,7 @@
 struct TrajectoryData
 {
   std::vector<geometry_msgs::msg::PoseStamped> pose_list;
-  std::vector<tier4_debug_msgs::msg::Float64Stamped> vx_list;
+  std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> vx_list;
   std::vector<geometry_msgs::msg::Vector3Stamped> gyro_list;
 };
 
@@ -95,12 +95,12 @@ double calculate_std_mean_const(const std::vector<T> & v, const double mean)
 
 struct CompareMsgTimestamp
 {
-  bool operator()(tier4_debug_msgs::msg::Float64Stamped const & t1, double const & t2) const
+  bool operator()(autoware_internal_debug_msgs::msg::Float64Stamped const & t1, double const & t2) const
   {
     return rclcpp::Time(t1.stamp).seconds() < t2;
   }
 
-  bool operator()(tier4_debug_msgs::msg::Float64Stamped const & t1, rclcpp::Time const & t2) const
+  bool operator()(autoware_internal_debug_msgs::msg::Float64Stamped const & t1, rclcpp::Time const & t2) const
   {
     return rclcpp::Time(t1.stamp).seconds() < t2.seconds();
   }
@@ -163,7 +163,7 @@ double norm_xy(const T p1, const U p2)
 double clip_radian(const double rad);
 
 geometry_msgs::msg::Point integrate_position(
-  const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list,
+  const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list,
   const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list, const double coef_vx,
   const double yaw_init);
 
@@ -176,9 +176,9 @@ geometry_msgs::msg::Vector3 integrate_orientation(
   const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list,
   const geometry_msgs::msg::Vector3 & gyro_bias);
 
-double get_mean_abs_vx(const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list);
+double get_mean_abs_vx(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list);
 double get_mean_abs_wz(const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list);
-double get_mean_accel(const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list);
+double get_mean_accel(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list);
 
 geometry_msgs::msg::Vector3 transform_vector3(
   const geometry_msgs::msg::Vector3 & vec, const geometry_msgs::msg::TransformStamped & transform);

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/utils.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/utils.hpp
@@ -18,10 +18,10 @@
 #include "deviation_estimator/autoware_universe_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
-#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <tf2/transform_datatypes.h>
 
@@ -95,12 +95,14 @@ double calculate_std_mean_const(const std::vector<T> & v, const double mean)
 
 struct CompareMsgTimestamp
 {
-  bool operator()(autoware_internal_debug_msgs::msg::Float64Stamped const & t1, double const & t2) const
+  bool operator()(
+    autoware_internal_debug_msgs::msg::Float64Stamped const & t1, double const & t2) const
   {
     return rclcpp::Time(t1.stamp).seconds() < t2;
   }
 
-  bool operator()(autoware_internal_debug_msgs::msg::Float64Stamped const & t1, rclcpp::Time const & t2) const
+  bool operator()(
+    autoware_internal_debug_msgs::msg::Float64Stamped const & t1, rclcpp::Time const & t2) const
   {
     return rclcpp::Time(t1.stamp).seconds() < t2.seconds();
   }
@@ -176,9 +178,11 @@ geometry_msgs::msg::Vector3 integrate_orientation(
   const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list,
   const geometry_msgs::msg::Vector3 & gyro_bias);
 
-double get_mean_abs_vx(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list);
+double get_mean_abs_vx(
+  const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list);
 double get_mean_abs_wz(const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list);
-double get_mean_accel(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list);
+double get_mean_accel(
+  const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list);
 
 geometry_msgs::msg::Vector3 transform_vector3(
   const geometry_msgs::msg::Vector3 & vec, const geometry_msgs::msg::TransformStamped & transform);

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/velocity_coef_module.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/velocity_coef_module.hpp
@@ -17,9 +17,9 @@
 
 #include "deviation_estimator/utils.hpp"
 
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/vector3_stamped.hpp"
-#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <utility>
 #include <vector>

--- a/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/velocity_coef_module.hpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/include/deviation_estimator/velocity_coef_module.hpp
@@ -19,7 +19,7 @@
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/vector3_stamped.hpp"
-#include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <utility>
 #include <vector>

--- a/localization/deviation_estimation_tools/deviation_estimator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_estimator/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -28,7 +29,6 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_debug_msgs</depend>
   <exec_depend>rosbag2_storage_mcap</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/localization/deviation_estimation_tools/deviation_estimator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_estimator/package.xml
@@ -28,7 +28,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <exec_depend>rosbag2_storage_mcap</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator.cpp
@@ -202,7 +202,7 @@ void DeviationEstimator::callback_pose_with_covariance(
 void DeviationEstimator::callback_wheel_odometry(
   const autoware_vehicle_msgs::msg::VelocityReport::ConstSharedPtr wheel_odometry_msg_ptr)
 {
-  tier4_debug_msgs::msg::Float64Stamped vx;
+  autoware_internal_debug_msgs::msg::Float64Stamped vx;
   vx.stamp = wheel_odometry_msg_ptr->header.stamp;
   vx.data = wheel_odometry_msg_ptr->longitudinal_velocity;
 

--- a/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator_main.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/deviation_estimator_main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char ** argv)
       if (index >= static_cast<int64_t>(trajectory_data_list.size())) {
         trajectory_data_list.resize(index + 1);
       }
-      tier4_debug_msgs::msg::Float64Stamped vx;
+      autoware_internal_debug_msgs::msg::Float64Stamped vx;
       vx.stamp = velocity_status_msg->header.stamp;
       vx.data = velocity_status_msg->longitudinal_velocity;
       trajectory_data_list[index].vx_list.push_back(vx);

--- a/localization/deviation_estimation_tools/deviation_estimator/src/utils.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/utils.cpp
@@ -87,7 +87,7 @@ geometry_msgs::msg::Vector3 interpolate_vector3_stamped(
  * point
  */
 geometry_msgs::msg::Point integrate_position(
-  const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list,
+  const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list,
   const std::vector<geometry_msgs::msg::Vector3Stamped> & gyro_list, const double coef_vx,
   const double yaw_init)
 {
@@ -153,7 +153,7 @@ geometry_msgs::msg::Vector3 integrate_orientation(
 /**
  * @brief calculate mean of |vx|
  */
-double get_mean_abs_vx(const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list)
+double get_mean_abs_vx(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list)
 {
   double mean_abs_vx = 0;
   for (const auto & msg : vx_list) {
@@ -179,7 +179,7 @@ double get_mean_abs_wz(const std::vector<geometry_msgs::msg::Vector3Stamped> & g
 /**
  * @brief calculate mean of acceleration
  */
-double get_mean_accel(const std::vector<tier4_debug_msgs::msg::Float64Stamped> & vx_list)
+double get_mean_accel(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list)
 {
   const double dt =
     (rclcpp::Time(vx_list.back().stamp) - rclcpp::Time(vx_list.front().stamp)).seconds();

--- a/localization/deviation_estimation_tools/deviation_estimator/src/utils.cpp
+++ b/localization/deviation_estimation_tools/deviation_estimator/src/utils.cpp
@@ -153,7 +153,8 @@ geometry_msgs::msg::Vector3 integrate_orientation(
 /**
  * @brief calculate mean of |vx|
  */
-double get_mean_abs_vx(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list)
+double get_mean_abs_vx(
+  const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list)
 {
   double mean_abs_vx = 0;
   for (const auto & msg : vx_list) {
@@ -179,7 +180,8 @@ double get_mean_abs_wz(const std::vector<geometry_msgs::msg::Vector3Stamped> & g
 /**
  * @brief calculate mean of acceleration
  */
-double get_mean_accel(const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list)
+double get_mean_accel(
+  const std::vector<autoware_internal_debug_msgs::msg::Float64Stamped> & vx_list)
 {
   const double dt =
     (rclcpp::Time(vx_list.back().stamp) - rclcpp::Time(vx_list.front().stamp)).seconds();

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -27,7 +27,7 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "std_srvs/srv/set_bool.hpp"
-#include "tier4_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <tf2/utils.h>
 

--- a/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
+++ b/localization/deviation_estimation_tools/deviation_evaluator/include/deviation_evaluator/deviation_evaluator.hpp
@@ -20,6 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/LinearMath/Quaternion.h"
 
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
 #include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
@@ -27,7 +28,6 @@
 #include "sensor_msgs/msg/imu.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include "std_srvs/srv/set_bool.hpp"
-#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 
 #include <tf2/utils.h>
 

--- a/localization/deviation_estimation_tools/deviation_evaluator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/package.xml
@@ -25,7 +25,7 @@
   <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/deviation_estimation_tools/deviation_evaluator/package.xml
+++ b/localization/deviation_estimation_tools/deviation_evaluator/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
@@ -25,7 +26,6 @@
   <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change

None. It seems like it is only used for internal calculation.

## How was this PR tested?

I have tested that the node launch without an error with 
```sh
ros2 launch deviation_estimator deviation_estimator.launch.xml
```

## Notes for reviewers

None.

## Effects on system behavior

None.
