### PR TITLE
feat(parameter_estimator)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/vehicle/parameter_estimator/include/parameter_estimator/debugger.hpp
+++ b/vehicle/parameter_estimator/include/parameter_estimator/debugger.hpp
@@ -33,11 +33,13 @@ struct Debugger
     rclcpp::QoS durable_qos(queue_size);
     durable_qos.transient_local();  // option for latching
 
-    pub_debug_ = rclcpp::create_publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
-      node, "~/debug_values/" + name, durable_qos);
+    pub_debug_ =
+      rclcpp::create_publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
+        node, "~/debug_values/" + name, durable_qos);
     debug_values_.data.resize(num_debug_values_, 0.0);
   }
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr
+    pub_debug_;
   void publishDebugValue() { pub_debug_->publish(debug_values_); }
   static constexpr std::uint8_t num_debug_values_ = 20;
   mutable autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_values_;

--- a/vehicle/parameter_estimator/include/parameter_estimator/debugger.hpp
+++ b/vehicle/parameter_estimator/include/parameter_estimator/debugger.hpp
@@ -19,7 +19,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #include <iostream>
 #include <string>
@@ -33,14 +33,14 @@ struct Debugger
     rclcpp::QoS durable_qos(queue_size);
     durable_qos.transient_local();  // option for latching
 
-    pub_debug_ = rclcpp::create_publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>(
+    pub_debug_ = rclcpp::create_publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
       node, "~/debug_values/" + name, durable_qos);
     debug_values_.data.resize(num_debug_values_, 0.0);
   }
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
   void publishDebugValue() { pub_debug_->publish(debug_values_); }
   static constexpr std::uint8_t num_debug_values_ = 20;
-  mutable tier4_debug_msgs::msg::Float32MultiArrayStamped debug_values_;
+  mutable autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_values_;
 };
 
 #endif  // PARAMETER_ESTIMATOR__DEBUGGER_HPP_

--- a/vehicle/parameter_estimator/package.xml
+++ b/vehicle/parameter_estimator/package.xml
@@ -17,7 +17,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tier4_calibration_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <exec_depend>plotjuggler</exec_depend>
   <exec_depend>plotjuggler_ros</exec_depend>
 

--- a/vehicle/parameter_estimator/package.xml
+++ b/vehicle/parameter_estimator/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>estimator_utils</depend>
@@ -17,7 +18,6 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tier4_calibration_msgs</depend>
-  <depend>autoware_internal_debug_msgs</depend>
   <exec_depend>plotjuggler</exec_depend>
   <exec_depend>plotjuggler_ros</exec_depend>
 


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `~/debug_values/*` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |

## How was this PR tested?

I have confirmed that the node can be launched with the following command and confirmed that topics are published with the updated message type
```sh
ros2 launch parameter_estimator parameter_estimator.launch.xml vehicle_model:=sample_vehicle
```
![image](https://github.com/user-attachments/assets/be0bdc1a-9d15-4aa0-83fc-987d0ec6de3f)

## Notes for reviewers

None.

## Effects on system behavior

None.
