### PR TITLE
feat(autoware_planning_data_analyzer)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -12,8 +12,8 @@ ros2 launch autoware_planning_data_analyzer behavior_analyzer.launch.xml bag_pat
 
 ## Output
 
-| Name                      | Type                                              | Description                                                     |
-| ------------------------- | ------------------------------------------------- | --------------------------------------------------------------- |
+| Name                      | Type                                                          | Description                                                     |
+| ------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------- |
 | `~/output/manual_metrics` | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Metrics calculated from the driver's driving trajectory.        |
 | `~/output/system_metrics` | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Metrics calculated from the autoware output.                    |
 | `~/output/manual_score`   | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Driving scores calculated from the driver's driving trajectory. |

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -14,7 +14,7 @@ ros2 launch autoware_planning_data_analyzer behavior_analyzer.launch.xml bag_pat
 
 | Name                      | Type                                              | Description                                                     |
 | ------------------------- | ------------------------------------------------- | --------------------------------------------------------------- |
-| `~/output/manual_metrics` | `tier4_debug_msgs::msg::Float32MultiArrayStamped` | Metrics calculated from the driver's driving trajectory.        |
-| `~/output/system_metrics` | `tier4_debug_msgs::msg::Float32MultiArrayStamped` | Metrics calculated from the autoware output.                    |
-| `~/output/manual_score`   | `tier4_debug_msgs::msg::Float32MultiArrayStamped` | Driving scores calculated from the driver's driving trajectory. |
-| `~/output/system_score`   | `tier4_debug_msgs::msg::Float32MultiArrayStamped` | Driving scores calculated from the autoware output.             |
+| `~/output/manual_metrics` | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Metrics calculated from the driver's driving trajectory.        |
+| `~/output/system_metrics` | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Metrics calculated from the autoware output.                    |
+| `~/output/manual_score`   | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Driving scores calculated from the driver's driving trajectory. |
+| `~/output/system_score`   | `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped` | Driving scores calculated from the autoware output.             |

--- a/planning/autoware_planning_data_analyzer/package.xml
+++ b/planning/autoware_planning_data_analyzer/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_frenet_planner</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_path_sampler</depend>

--- a/planning/autoware_planning_data_analyzer/src/type_alias.hpp
+++ b/planning/autoware_planning_data_analyzer/src/type_alias.hpp
@@ -26,7 +26,7 @@
 #include "autoware_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include <std_srvs/srv/set_bool.hpp>
@@ -60,7 +60,7 @@ using nav_msgs::msg::Odometry;
 using std_srvs::srv::SetBool;
 using std_srvs::srv::Trigger;
 using tf2_msgs::msg::TFMessage;
-using tier4_debug_msgs::msg::Float32MultiArrayStamped;
+using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 }  // namespace autoware::behavior_analyzer

--- a/planning/autoware_planning_data_analyzer/src/type_alias.hpp
+++ b/planning/autoware_planning_data_analyzer/src/type_alias.hpp
@@ -18,6 +18,7 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
+#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_map_msgs/msg/lanelet_map_bin.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/lanelet_route.hpp"
@@ -26,7 +27,6 @@
 #include "autoware_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "visualization_msgs/msg/marker.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include <std_srvs/srv/set_bool.hpp>
@@ -51,6 +51,7 @@ using autoware_vehicle_msgs::msg::SteeringReport;
 using route_handler::RouteHandler;
 
 // ros2
+using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
@@ -60,7 +61,6 @@ using nav_msgs::msg::Odometry;
 using std_srvs::srv::SetBool;
 using std_srvs::srv::Trigger;
 using tf2_msgs::msg::TFMessage;
-using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 }  // namespace autoware::behavior_analyzer


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `~/output/manual_metrics` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |
|  Pub | `~/output/system_metrics` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |
|  Pub | `~/output/manual_score` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |
|  Pub | `~/output/system_score` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |

## How was this PR tested?

I have confirmed that the node launches without crashing and publishes the data with the new topic type:


```sh
ros2 launch autoware_planning_data_analyzer behavior_analyzer.launch.xml bag_path:=<ROSBAG>
```

![image](https://github.com/user-attachments/assets/7937c693-b274-4923-99c6-112272134e34)


NOTE: There were errors regarding glog component from the same launch file, but that could be fixed in a separate PR.

## Notes for reviewers

None.

## Effects on system behavior

None.
