### PR TITLE
feat(planning_debug_tools)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
+++ b/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
@@ -24,7 +24,7 @@
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "tier4_debug_msgs/msg/float64_multi_array_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp"
 #include "tier4_planning_msgs/msg/path_with_lane_id.hpp"
 
 #include <iostream>

--- a/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
+++ b/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
@@ -21,10 +21,10 @@
 #include "planning_debug_tools/util.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp"
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp"
 #include "tier4_planning_msgs/msg/path_with_lane_id.hpp"
 
 #include <iostream>

--- a/planning/planning_debug_tools/package.xml
+++ b/planning/planning_debug_tools/package.xml
@@ -17,6 +17,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
@@ -25,7 +26,6 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>autoware_internal_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/planning_debug_tools/package.xml
+++ b/planning/planning_debug_tools/package.xml
@@ -25,7 +25,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -18,6 +18,8 @@ import time
 
 from autoware_adapi_v1_msgs.msg import OperationModeState
 from autoware_control_msgs.msg import Control as AckermannControlCommand
+from autoware_internal_debug_msgs.msg import Float32MultiArrayStamped
+from autoware_internal_debug_msgs.msg import Float32Stamped
 from autoware_planning_msgs.msg import Path
 from autoware_planning_msgs.msg import Trajectory
 from autoware_vehicle_msgs.msg import VelocityReport
@@ -29,8 +31,6 @@ from rclpy.node import Node
 from tf2_ros import LookupException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-from autoware_internal_debug_msgs.msg import Float32MultiArrayStamped
-from autoware_internal_debug_msgs.msg import Float32Stamped
 from tier4_planning_msgs.msg import PathWithLaneId
 from tier4_planning_msgs.msg import VelocityLimit
 

--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -29,8 +29,8 @@ from rclpy.node import Node
 from tf2_ros import LookupException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-from tier4_debug_msgs.msg import Float32MultiArrayStamped
-from tier4_debug_msgs.msg import Float32Stamped
+from autoware_internal_debug_msgs.msg import Float32MultiArrayStamped
+from autoware_internal_debug_msgs.msg import Float32Stamped
 from tier4_planning_msgs.msg import PathWithLaneId
 from tier4_planning_msgs.msg import VelocityLimit
 

--- a/planning/planning_debug_tools/scripts/processing_time_checker.py
+++ b/planning/planning_debug_tools/scripts/processing_time_checker.py
@@ -20,9 +20,9 @@ from collections import deque
 import os
 import sys
 
+from autoware_internal_debug_msgs.msg import Float64Stamped
 import rclpy
 from rclpy.node import Node
-from autoware_internal_debug_msgs.msg import Float64Stamped
 
 
 class ProcessingTimeSubscriber(Node):

--- a/planning/planning_debug_tools/scripts/processing_time_checker.py
+++ b/planning/planning_debug_tools/scripts/processing_time_checker.py
@@ -22,7 +22,7 @@ import sys
 
 import rclpy
 from rclpy.node import Node
-from tier4_debug_msgs.msg import Float64Stamped
+from autoware_internal_debug_msgs.msg import Float64Stamped
 
 
 class ProcessingTimeSubscriber(Node):


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change

velocity_checker
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `~/closest_speeds` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |
|  Sub | `scenario + "/motion_velocity_smoother/distance_to_stopline` | `tier4_debug_msgs/Float32Stamped` | `autoware_internal_debug_msgs/Float32Stamped` |

processing_time_checker
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Sub | topic that ends with `processing_time_ms` | `tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped` |

## How was this PR tested?

I have confirmed that the topics are updated.

### velocity_checker:
```bash
ros2 run planning_debug_tools closest_velocity_checker.py
```
![image](https://github.com/user-attachments/assets/c5363277-c96b-4919-9002-7c260e1bf1bb)

### processing_time_checker:
```bash
ros2 run planning_debug_tools processing_time_checker.py
```

![image](https://github.com/user-attachments/assets/14533cb0-6fc4-4299-8106-804ebe55d40f)

![image](https://github.com/user-attachments/assets/cfd68373-b8b7-4121-a137-50dda900892c)


## Notes for reviewers

None.

## Effects on system behavior

None.
