### PR TITLE
feat(stop_accel_evaluator)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/control/stop_accel_evaluator/include/stop_accel_evaluator/stop_accel_evaluator_node.hpp
+++ b/control/stop_accel_evaluator/include/stop_accel_evaluator/stop_accel_evaluator_node.hpp
@@ -22,8 +22,8 @@
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/imu.hpp"
-#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
-#include "tier4_debug_msgs/msg/float32_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 
 #include <deque>
 #include <memory>
@@ -34,8 +34,8 @@ using autoware::universe_utils::SelfPoseListener;
 using geometry_msgs::msg::TwistStamped;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::Imu;
-using tier4_debug_msgs::msg::Float32MultiArrayStamped;
-using tier4_debug_msgs::msg::Float32Stamped;
+using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
+using autoware_internal_debug_msgs::msg::Float32Stamped;
 
 class StopAccelEvaluatorNode : public rclcpp::Node
 {

--- a/control/stop_accel_evaluator/include/stop_accel_evaluator/stop_accel_evaluator_node.hpp
+++ b/control/stop_accel_evaluator/include/stop_accel_evaluator/stop_accel_evaluator_node.hpp
@@ -19,11 +19,11 @@
 #include "autoware/universe_utils/ros/self_pose_listener.hpp"
 #include "rclcpp/rclcpp.hpp"
 
+#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/imu.hpp"
-#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
-#include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 
 #include <deque>
 #include <memory>
@@ -31,11 +31,11 @@
 namespace stop_accel_evaluator
 {
 using autoware::universe_utils::SelfPoseListener;
+using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
+using autoware_internal_debug_msgs::msg::Float32Stamped;
 using geometry_msgs::msg::TwistStamped;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::Imu;
-using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
-using autoware_internal_debug_msgs::msg::Float32Stamped;
 
 class StopAccelEvaluatorNode : public rclcpp::Node
 {

--- a/control/stop_accel_evaluator/package.xml
+++ b/control/stop_accel_evaluator/package.xml
@@ -18,7 +18,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/control/stop_accel_evaluator/package.xml
+++ b/control/stop_accel_evaluator/package.xml
@@ -10,6 +10,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_universe_utils</depend>
   <depend>geometry_msgs</depend>
@@ -18,7 +19,6 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `~/stop_accel` | `tier4_debug_msgs/Float32Stamped` | `autoware_internal_debug_msgs/Float32Stamped` |
|  Pub | `~/stop_accel_with_gravity` | `tier4_debug_msgs/Float32Stamped` | `autoware_internal_debug_msgs/Float32Stamped` |


## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
