### PR TITLE
feat(tier4_debug_rviz_plugin)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/common/tier4_debug_rviz_plugin/README.md
+++ b/common/tier4_debug_rviz_plugin/README.md
@@ -7,6 +7,6 @@ Note that jsk_overlay_utils.cpp and jsk_overlay_utils.hpp are BSD license.
 
 ### Float32MultiArrayStampedPieChart
 
-Pie chart from `tier4_debug_msgs::msg::Float32MultiArrayStamped`.
+Pie chart from `autoware_internal_debug_msgs::msg::Float32MultiArrayStamped`.
 
 ![float32_multi_array_stamped_pie_chart](./images/float32_multi_array_stamped_pie_chart.png)

--- a/common/tier4_debug_rviz_plugin/include/tier4_debug_rviz_plugin/float32_multi_array_stamped_pie_chart.hpp
+++ b/common/tier4_debug_rviz_plugin/include/tier4_debug_rviz_plugin/float32_multi_array_stamped_pie_chart.hpp
@@ -60,7 +60,7 @@
 #include <rviz_common/validate_floats.hpp>
 #include <tier4_debug_rviz_plugin/jsk_overlay_utils.hpp>
 
-#include <tier4_debug_msgs/msg/float32_multi_array_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp>
 
 #include <mutex>
 
@@ -87,7 +87,7 @@ protected:
   virtual void onDisable();
   virtual void onInitialize();
   virtual void processMessage(
-    const tier4_debug_msgs::msg::Float32MultiArrayStamped::ConstSharedPtr msg);
+    const autoware_internal_debug_msgs::msg::Float32MultiArrayStamped::ConstSharedPtr msg);
   virtual void drawPlot(double val);
   virtual void update(float wall_dt, float ros_dt);
   // properties
@@ -114,7 +114,7 @@ protected:
   rviz_common::properties::FloatProperty * med_color_threshold_property_;
   rviz_common::properties::BoolProperty * clockwise_rotate_property_;
 
-  rclcpp::Subscription<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr sub_;
+  rclcpp::Subscription<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr sub_;
   int left_;
   int top_;
   uint16_t texture_size_;

--- a/common/tier4_debug_rviz_plugin/package.xml
+++ b/common/tier4_debug_rviz_plugin/package.xml
@@ -19,7 +19,6 @@
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
   <depend>rviz_rendering</depend>
-  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/tier4_debug_rviz_plugin/package.xml
+++ b/common/tier4_debug_rviz_plugin/package.xml
@@ -19,7 +19,7 @@
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
   <depend>rviz_rendering</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/tier4_debug_rviz_plugin/plugins/plugin_description.xml
+++ b/common/tier4_debug_rviz_plugin/plugins/plugin_description.xml
@@ -2,7 +2,7 @@
   <class name="rviz_plugins/Float32MultiArrayStampedPieChart"
     type="rviz_plugins::Float32MultiArrayStampedPieChartDisplay"
     base_class_type="rviz_common::Display">
-    <description>Display drivable area of tier4_debug_msgs::msg::Float32MultiArrayStamped</description>
+    <description>Display drivable area of autoware_internal_debug_msgs::msg::Float32MultiArrayStamped</description>
   </class>
   <class name="rviz_plugins/StringStampedOverlayDisplay"
     type="rviz_plugins::StringStampedOverlayDisplay"

--- a/common/tier4_debug_rviz_plugin/src/float32_multi_array_stamped_pie_chart.cpp
+++ b/common/tier4_debug_rviz_plugin/src/float32_multi_array_stamped_pie_chart.cpp
@@ -60,7 +60,8 @@ Float32MultiArrayStampedPieChartDisplay::Float32MultiArrayStampedPieChartDisplay
 : rviz_common::Display(), update_required_(false), first_time_(true), data_(0.0)
 {
   update_topic_property_ = new rviz_common::properties::StringProperty(
-    "Topic", "", "autoware_internal_debug_msgs::msg::Float32MultiArrayStamped topic to subscribe to.", this,
+    "Topic", "",
+    "autoware_internal_debug_msgs::msg::Float32MultiArrayStamped topic to subscribe to.", this,
     SLOT(updateTopic()), this);
   data_index_property_ = new rviz_common::properties::IntProperty(
     "data index", 0, "data index in message to visualize", this, SLOT(updateDataIndex()));
@@ -297,10 +298,11 @@ void Float32MultiArrayStampedPieChartDisplay::subscribe()
 
   if (topic_name.length() > 0 && topic_name != "/") {
     rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
-    sub_ = raw_node->create_subscription<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
-      topic_name, 1,
-      std::bind(
-        &Float32MultiArrayStampedPieChartDisplay::processMessage, this, std::placeholders::_1));
+    sub_ =
+      raw_node->create_subscription<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
+        topic_name, 1,
+        std::bind(
+          &Float32MultiArrayStampedPieChartDisplay::processMessage, this, std::placeholders::_1));
   }
 }
 

--- a/common/tier4_debug_rviz_plugin/src/float32_multi_array_stamped_pie_chart.cpp
+++ b/common/tier4_debug_rviz_plugin/src/float32_multi_array_stamped_pie_chart.cpp
@@ -60,7 +60,7 @@ Float32MultiArrayStampedPieChartDisplay::Float32MultiArrayStampedPieChartDisplay
 : rviz_common::Display(), update_required_(false), first_time_(true), data_(0.0)
 {
   update_topic_property_ = new rviz_common::properties::StringProperty(
-    "Topic", "", "tier4_debug_msgs::msg::Float32MultiArrayStamped topic to subscribe to.", this,
+    "Topic", "", "autoware_internal_debug_msgs::msg::Float32MultiArrayStamped topic to subscribe to.", this,
     SLOT(updateTopic()), this);
   data_index_property_ = new rviz_common::properties::IntProperty(
     "data index", 0, "data index in message to visualize", this, SLOT(updateDataIndex()));
@@ -178,7 +178,7 @@ void Float32MultiArrayStampedPieChartDisplay::update(
 }
 
 void Float32MultiArrayStampedPieChartDisplay::processMessage(
-  const tier4_debug_msgs::msg::Float32MultiArrayStamped::ConstSharedPtr msg)
+  const autoware_internal_debug_msgs::msg::Float32MultiArrayStamped::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -297,7 +297,7 @@ void Float32MultiArrayStampedPieChartDisplay::subscribe()
 
   if (topic_name.length() > 0 && topic_name != "/") {
     rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
-    sub_ = raw_node->create_subscription<tier4_debug_msgs::msg::Float32MultiArrayStamped>(
+    sub_ = raw_node->create_subscription<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
       topic_name, 1,
       std::bind(
         &Float32MultiArrayStampedPieChartDisplay::processMessage, this, std::placeholders::_1));


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Sub | selected input topic in plugin | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |

## How was this PR tested?

I have confirmed with planning_simulator that the plugin can be loaded and can be subscribed to autoware_internal_debug_msgs/Float32MultiArrayStamped

![image](https://github.com/user-attachments/assets/dae1eeeb-4a7a-4a07-88ff-b5dc41dc3b6b)


## Notes for reviewers

None.

## Effects on system behavior

None.
