### PR TITLE
feat(tier4_debug_tools)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/common/tier4_debug_tools/include/tier4_debug_tools/lateral_error_publisher.hpp
+++ b/common/tier4_debug_tools/include/tier4_debug_tools/lateral_error_publisher.hpp
@@ -22,9 +22,9 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 
 class LateralErrorPublisher : public rclcpp::Node
 {

--- a/common/tier4_debug_tools/include/tier4_debug_tools/lateral_error_publisher.hpp
+++ b/common/tier4_debug_tools/include/tier4_debug_tools/lateral_error_publisher.hpp
@@ -24,7 +24,7 @@
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <tier4_debug_msgs/msg/float32_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 
 class LateralErrorPublisher : public rclcpp::Node
 {
@@ -50,11 +50,11 @@ private:
     sub_vehicle_pose_;  //!< @brief subscription for vehicle pose
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
     sub_ground_truth_pose_;  //!< @brief subscription for gnss pose
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32Stamped>::SharedPtr
     pub_control_lateral_error_;  //!< @brief publisher for control lateral error
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32Stamped>::SharedPtr
     pub_localization_lateral_error_;  //!< @brief publisher for localization lateral error
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32Stamped>::SharedPtr
     pub_lateral_error_;  //!< @brief publisher for lateral error (control + localization)
 
   /**

--- a/common/tier4_debug_tools/package.xml
+++ b/common/tier4_debug_tools/package.xml
@@ -17,7 +17,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
 
   <exec_depend>launch_ros</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rtree</exec_depend>

--- a/common/tier4_debug_tools/package.xml
+++ b/common/tier4_debug_tools/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
@@ -17,7 +18,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_debug_msgs</depend>
 
   <exec_depend>launch_ros</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rtree</exec_depend>

--- a/common/tier4_debug_tools/src/lateral_error_publisher.cpp
+++ b/common/tier4_debug_tools/src/lateral_error_publisher.cpp
@@ -36,11 +36,11 @@ LateralErrorPublisher::LateralErrorPublisher(const rclcpp::NodeOptions & node_op
     "~/input/ground_truth_pose_with_covariance", rclcpp::QoS{1},
     std::bind(&LateralErrorPublisher::onGroundTruthPose, this, _1));
   pub_control_lateral_error_ =
-    create_publisher<tier4_debug_msgs::msg::Float32Stamped>("~/control_lateral_error", 1);
+    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("~/control_lateral_error", 1);
   pub_localization_lateral_error_ =
-    create_publisher<tier4_debug_msgs::msg::Float32Stamped>("~/localization_lateral_error", 1);
+    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("~/localization_lateral_error", 1);
   pub_lateral_error_ =
-    create_publisher<tier4_debug_msgs::msg::Float32Stamped>("~/lateral_error", 1);
+    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("~/lateral_error", 1);
 }
 
 void LateralErrorPublisher::onTrajectory(
@@ -131,17 +131,17 @@ void LateralErrorPublisher::onGroundTruthPose(
   RCLCPP_DEBUG(this->get_logger(), "localization_error: %f", lateral_error);
 
   // Publish lateral errors
-  tier4_debug_msgs::msg::Float32Stamped control_msg;
+  autoware_internal_debug_msgs::msg::Float32Stamped control_msg;
   control_msg.stamp = this->now();
   control_msg.data = static_cast<float>(control_lateral_error);
   pub_control_lateral_error_->publish(control_msg);
 
-  tier4_debug_msgs::msg::Float32Stamped localization_msg;
+  autoware_internal_debug_msgs::msg::Float32Stamped localization_msg;
   localization_msg.stamp = this->now();
   localization_msg.data = static_cast<float>(localization_lateral_error);
   pub_localization_lateral_error_->publish(localization_msg);
 
-  tier4_debug_msgs::msg::Float32Stamped sum_msg;
+  autoware_internal_debug_msgs::msg::Float32Stamped sum_msg;
   sum_msg.stamp = this->now();
   sum_msg.data = static_cast<float>(lateral_error);
   pub_lateral_error_->publish(sum_msg);

--- a/common/tier4_debug_tools/src/lateral_error_publisher.cpp
+++ b/common/tier4_debug_tools/src/lateral_error_publisher.cpp
@@ -35,10 +35,11 @@ LateralErrorPublisher::LateralErrorPublisher(const rclcpp::NodeOptions & node_op
   sub_ground_truth_pose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "~/input/ground_truth_pose_with_covariance", rclcpp::QoS{1},
     std::bind(&LateralErrorPublisher::onGroundTruthPose, this, _1));
-  pub_control_lateral_error_ =
-    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("~/control_lateral_error", 1);
+  pub_control_lateral_error_ = create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>(
+    "~/control_lateral_error", 1);
   pub_localization_lateral_error_ =
-    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("~/localization_lateral_error", 1);
+    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>(
+      "~/localization_lateral_error", 1);
   pub_lateral_error_ =
     create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("~/lateral_error", 1);
 }


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `~/control_lateral_error` | `tier4_debug_msgs/Float32Stamped` | `autoware_internal_debug_msgs/Float32Stamped` |
|  Pub | `~/localization_lateral_error` | `tier4_debug_msgs/Float32Stamped` | `autoware_internal_debug_msgs/Float32Stamped` |
|  Pub | `~/lateral_error` | `tier4_debug_msgs/Float32Stamped` | `autoware_internal_debug_msgs/Float32Stamped` |

## How was this PR tested?

I have confirmed that the node launch successfully with the following command and confirmed that output topic is autoware_internal_debug_msgs.

```sh
ros2 launch tier4_debug_tools lateral_error_publisher.launch.xml
```
![image](https://github.com/user-attachments/assets/5b548751-d8e7-42df-99d7-d354727e9e05)



## Notes for reviewers

None.

## Effects on system behavior

None.
