### PR TITLE
feat(vehicle_cmd_analyzer)!: replace tier4_debug_msgs with tier4_internal_debug_msgs

### DIFF
--- a/control/vehicle_cmd_analyzer/include/vehicle_cmd_analyzer/vehicle_cmd_analyzer.hpp
+++ b/control/vehicle_cmd_analyzer/include/vehicle_cmd_analyzer/vehicle_cmd_analyzer.hpp
@@ -21,7 +21,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_control_msgs/msg/control.hpp"
-#include "tier4_debug_msgs/msg/float32_multi_array_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 
 #include <algorithm>
 #include <memory>
@@ -33,7 +33,7 @@ class VehicleCmdAnalyzer : public rclcpp::Node
 {
 private:
   rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr sub_vehicle_cmd_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
   rclcpp::TimerBase::SharedPtr timer_control_;
 
   std::shared_ptr<autoware_control_msgs::msg::Control> vehicle_cmd_ptr_{nullptr};

--- a/control/vehicle_cmd_analyzer/include/vehicle_cmd_analyzer/vehicle_cmd_analyzer.hpp
+++ b/control/vehicle_cmd_analyzer/include/vehicle_cmd_analyzer/vehicle_cmd_analyzer.hpp
@@ -33,7 +33,8 @@ class VehicleCmdAnalyzer : public rclcpp::Node
 {
 private:
   rclcpp::Subscription<autoware_control_msgs::msg::Control>::SharedPtr sub_vehicle_cmd_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr pub_debug_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr
+    pub_debug_;
   rclcpp::TimerBase::SharedPtr timer_control_;
 
   std::shared_ptr<autoware_control_msgs::msg::Control> vehicle_cmd_ptr_{nullptr};

--- a/control/vehicle_cmd_analyzer/package.xml
+++ b/control/vehicle_cmd_analyzer/package.xml
@@ -12,10 +12,10 @@
   <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_control_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/control/vehicle_cmd_analyzer/package.xml
+++ b/control/vehicle_cmd_analyzer/package.xml
@@ -15,7 +15,7 @@
   <depend>autoware_vehicle_info_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tier4_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/control/vehicle_cmd_analyzer/src/vehicle_cmd_analyzer.cpp
+++ b/control/vehicle_cmd_analyzer/src/vehicle_cmd_analyzer.cpp
@@ -33,7 +33,7 @@ VehicleCmdAnalyzer::VehicleCmdAnalyzer(const rclcpp::NodeOptions & options)
   sub_vehicle_cmd_ = this->create_subscription<autoware_control_msgs::msg::Control>(
     "/control/command/control_cmd", rclcpp::QoS(10),
     std::bind(&VehicleCmdAnalyzer::callbackVehicleCommand, this, std::placeholders::_1));
-  pub_debug_ = create_publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>(
+  pub_debug_ = create_publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>(
     "~/debug_values", rclcpp::QoS{1});
 
   // Timer
@@ -83,7 +83,7 @@ void VehicleCmdAnalyzer::publishDebugData()
   debug_values_.setValues(DebugValues::TYPE::CURRENT_TARGET_LATERAL_ACC, a_lat);
 
   // publish debug values
-  tier4_debug_msgs::msg::Float32MultiArrayStamped debug_msg{};
+  autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_msg{};
   debug_msg.stamp = this->now();
   for (const auto & v : debug_values_.getValues()) {
     debug_msg.data.push_back(v);


### PR DESCRIPTION
## Description
This replaces tier4_debug_msgs with tier4_internal_debug_msgs.
This is a PR to resolve https://github.com/autowarefoundation/autoware/issues/5580.

## Interface Change
|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `~/debug_values` | `tier4_debug_msgs/Float32MultiArrayStamped` | `autoware_internal_debug_msgs/Float32MultiArrayStamped` |

## How was this PR tested?

I have tested with the following:
* launch planning simulator
* launch `ros2 launch vehicle_cmd_analyzer vehicle_cmd_analyzer.launch.xml vehicle_model:=lexus`

Confirmed that there are no tier4_debug_msgs
![image](https://github.com/user-attachments/assets/85df4536-d21c-449b-a227-576f05791843)


## Notes for reviewers

None.

## Effects on system behavior

None.
