### PR TITLE
feat(lanelet2_map_validator): enable to catch map loading issues such as invalid point elevations

### DIFF
--- a/map/autoware_lanelet2_map_validator/CMakeLists.txt
+++ b/map/autoware_lanelet2_map_validator/CMakeLists.txt
@@ -44,10 +44,6 @@ if(BUILD_TESTING)
     test/src/include
     src/include)
 
-  target_link_libraries(autoware_lanelet2_map_validator_test_lib
-    autoware_lanelet2_map_validator_lib
-  )
-
   # test for general lanelet2 map validators
   function(add_validation_test TEST_FILE)
     get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
@@ -59,6 +55,7 @@ if(BUILD_TESTING)
     target_link_libraries(
       ${VALIDATION_NAME}_test
       autoware_lanelet2_map_validator_test_lib
+      autoware_lanelet2_map_validator_lib
     )
   endfunction()
 

--- a/map/autoware_lanelet2_map_validator/LICENSE
+++ b/map/autoware_lanelet2_map_validator/LICENSE
@@ -1,0 +1,27 @@
+This package is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Portions of this package are based on code licensed under the BSD-3-Clause License:
+
+====================================================================
+Lanelet2 by FZI Forschungszentrum Informatik
+Copyright (c) [2018] [FZI Forschungszentrum Informatik]
+Licensed under the BSD-3-Clause License. See below for the full license text.
+
+BSD-3-Clause License:
+--------------------------------------------------------------------
+Copyright 2018 FZI Forschungszentrum Informatik
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================

--- a/map/autoware_lanelet2_map_validator/README.md
+++ b/map/autoware_lanelet2_map_validator/README.md
@@ -359,3 +359,8 @@ The "Validators" column will be blank if it hasn't be implemented.
 | vm-07-02 | Range of detecting pedestrians who enter the road       | (Not possible to validate because real-world correspondence cannot be determined programmatically.)                                                                                                                                                                                                                                                             |
 | vm-07-03 | Guardrails, guard pipes, fences                         | (Not possible to validate because real-world correspondence cannot be determined programmatically.)                                                                                                                                                                                                                                                             |
 | vm-07-04 | Ellipsoidal height                                      | (Not possible to validate because real-world correspondence cannot be determined programmatically?)                                                                                                                                                                                                                                                             |
+
+## Third-Party Components
+
+Portions of this software are derived from Lanelet2 by FZI Forschungszentrum Informatik, Karlsruhe, Germany, and are licensed under the BSD-3-Clause license.
+See the LICENSE file for the original license details.

--- a/map/autoware_lanelet2_map_validator/src/common/autoware_validator_osm_parser.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/autoware_validator_osm_parser.cpp
@@ -165,12 +165,12 @@ void removeAndFixPlaceholders(
 namespace autoware
 {
 
-class AutowareValidatorOsmParser
+class AutowareValidatorOsmFileParser
 {
 public:
   static File read(const pugi::xml_node & fileNode, Errors * errors = nullptr)
   {
-    AutowareValidatorOsmParser autowareValidatorOsmParser;
+    AutowareValidatorOsmFileParser autowareValidatorOsmParser;
     File file;
     auto osmNode = fileNode.child(keyword::Osm);
     file.nodes = autowareValidatorOsmParser.readNodes(osmNode);
@@ -296,7 +296,7 @@ private:
     return relations;
   }
 
-  AutowareValidatorOsmParser() = default;
+  AutowareValidatorOsmFileParser() = default;
   void reportParseError(Id id, const std::string & what)
   {
     auto errstr = "Error reading primitive with id " + std::to_string(id) + " from file: " + what;
@@ -307,7 +307,7 @@ private:
 
 File read(pugi::xml_document & node, Errors * errors)
 {
-  return AutowareValidatorOsmParser::read(node, errors);
+  return AutowareValidatorOsmFileParser::read(node, errors);
 }
 }  // namespace autoware
 }  // namespace lanelet::osm

--- a/map/autoware_lanelet2_map_validator/src/common/autoware_validator_osm_parser.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/autoware_validator_osm_parser.cpp
@@ -1,16 +1,13 @@
-// Copyright 2025 Autoware Foundation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright (c) 2018
+ * FZI Forschungszentrum Informatik, Karlsruhe, Germany (www.fzi.de)
+ * All rights reserved.
+ *
+ * Modifications by [Taiki Yamada/Autoware Foundation], 2025
+ *
+ * This software is licensed under the BSD-3-Clause license.
+ * See the LICENSE file for details.
+ */
 
 #include "lanelet2_map_validator/autoware_validator_osm_parser.hpp"
 
@@ -53,19 +50,6 @@ void testAndPrintLocaleWarning(ErrorMessages & errors)
   }
 }
 
-Errors buildErrorMessage(const std::string & errorIntro, const Errors & errors)
-{
-  if (errors.empty()) {
-    return {};
-  }
-  Errors message{errorIntro};
-  message.reserve(errors.size() + 1);
-  for (const auto & error : errors) {
-    message.push_back("\t- " + error);
-  }
-  return message;
-}
-
 RegisterParser<AutowareValidatorOsmParser> regParser;
 }  // namespace
 
@@ -87,8 +71,7 @@ std::unique_ptr<LaneletMap> AutowareValidatorOsmParser::parse(
   registerIds(file.nodes);
   registerIds(file.ways);
   registerIds(file.relations);
-  errors = buildErrorMessage(
-    "Errors ocurred while parsing Lanelet Map:", utils::concatenate({osmReadErrors, errors}));
+  errors = utils::concatenate({osmReadErrors, errors});
   return map;
 }
 }  // namespace lanelet::io_handlers

--- a/map/autoware_lanelet2_map_validator/src/common/autoware_validator_osm_parser.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/autoware_validator_osm_parser.cpp
@@ -1,0 +1,330 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_validator/autoware_validator_osm_parser.hpp"
+
+#include <lanelet2_core/utility/Utilities.h>
+#include <lanelet2_io/Exceptions.h>
+#include <lanelet2_io/io_handlers/Factory.h>
+#include <lanelet2_io/io_handlers/OsmFile.h>
+#include <lanelet2_io/io_handlers/OsmHandler.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace lanelet::io_handlers
+{
+using Errors = std::vector<std::string>;
+
+namespace
+{
+template <typename MapT>
+void registerIds(const MapT & map)
+{
+  if (!map.empty()) {
+    utils::registerId(map.rbegin()->first);
+  }
+}
+
+void testAndPrintLocaleWarning(ErrorMessages & errors)
+{
+  auto * decimalPoint = std::localeconv()->decimal_point;
+  if (decimalPoint == nullptr || *decimalPoint != '.') {
+    std::stringstream ss;
+    ss << "Warning: Current decimal point of the C locale is set to \""
+       << (decimalPoint == nullptr ? ' ' : *decimalPoint)
+       << "\". The loaded map will have wrong coordinates!\n";
+    errors.emplace_back(ss.str());
+    std::cerr << errors.back();
+  }
+}
+
+Errors buildErrorMessage(const std::string & errorIntro, const Errors & errors)
+{
+  if (errors.empty()) {
+    return {};
+  }
+  Errors message{errorIntro};
+  message.reserve(errors.size() + 1);
+  for (const auto & error : errors) {
+    message.push_back("\t- " + error);
+  }
+  return message;
+}
+
+RegisterParser<AutowareValidatorOsmParser> regParser;
+}  // namespace
+
+std::unique_ptr<LaneletMap> AutowareValidatorOsmParser::parse(
+  const std::string & filename, ErrorMessages & errors) const
+{
+  // read xml
+  pugi::xml_document doc;
+  auto result = doc.load_file(filename.c_str());
+  if (!result) {
+    throw lanelet::ParseError(
+      std::string("Errors occured while parsing osm file: ") + result.description());
+  }
+  osm::Errors osmReadErrors;
+  testAndPrintLocaleWarning(osmReadErrors);
+  auto file = lanelet::osm::autoware::read(doc, &osmReadErrors);
+  auto map = fromOsmFile(file, errors);
+  // make sure ids in the file are known to Lanelet2 id management.
+  registerIds(file.nodes);
+  registerIds(file.ways);
+  registerIds(file.relations);
+  errors = buildErrorMessage(
+    "Errors ocurred while parsing Lanelet Map:", utils::concatenate({osmReadErrors, errors}));
+  return map;
+}
+}  // namespace lanelet::io_handlers
+
+namespace lanelet::osm
+{
+namespace keyword
+{
+constexpr const char * Osm = "osm";
+constexpr const char * Tag = "tag";
+constexpr const char * Key = "k";
+constexpr const char * Value = "v";
+constexpr const char * Node = "node";
+constexpr const char * Way = "way";
+constexpr const char * Relation = "relation";
+constexpr const char * Member = "member";
+constexpr const char * Role = "role";
+constexpr const char * Type = "type";
+constexpr const char * Nd = "nd";
+constexpr const char * Ref = "ref";
+constexpr const char * Id = "id";
+constexpr const char * Lat = "lat";
+constexpr const char * Lon = "lon";
+constexpr const char * Version = "version";
+constexpr const char * Visible = "visible";
+constexpr const char * Elevation = "ele";
+constexpr const char * Action = "action";
+constexpr const char * Delete = "delete";
+}  // namespace keyword
+
+struct UnresolvedRole
+{
+  Id relation{};
+  Id referencedRelation{};
+  Primitive ** location{};
+};
+
+Attributes tags(const pugi::xml_node & node)
+{
+  Attributes attributes;
+  for (auto tag = node.child(keyword::Tag); tag;  // NOLINT
+       tag = tag.next_sibling(keyword::Tag)) {
+    if (std::string(tag.attribute(keyword::Key).value()) == keyword::Elevation) {
+      continue;
+    }
+    attributes[tag.attribute(keyword::Key).value()] = tag.attribute(keyword::Value).value();
+  }
+  return attributes;
+}
+
+bool isDeleted(const pugi::xml_node & node)
+{
+  auto action = node.attribute(keyword::Action);
+  return action && std::string(action.value()) == keyword::Delete;  // NOLINT
+}
+
+void removeAndFixPlaceholders(
+  Primitive ** toRemove, Roles & fromRoles, std::vector<UnresolvedRole> & placeholders)
+{
+  // find other placeholders that we have to fix
+  auto remIt = std::find_if(fromRoles.begin(), fromRoles.end(), [&](const Role & role) {
+    return &role.second == toRemove;
+  });
+  assert(remIt != fromRoles.end());
+  std::vector<std::pair<size_t, Primitive **>> placeholderLocations;
+  for (auto it = fromRoles.begin(); it != fromRoles.end(); ++it) {
+    if (it->second == nullptr && remIt != it) {
+      auto idx = std::distance(fromRoles.begin(), it);
+      placeholderLocations.emplace_back(it > remIt ? idx - 1 : idx, &it->second);
+    }
+  }
+  fromRoles.erase(remIt);
+  if (placeholderLocations.empty()) {
+    return;  // nothing to update
+  }
+  // get the new locations
+  std::map<Primitive **, Primitive **> newLocations;
+  for (auto & loc : placeholderLocations) {
+    newLocations.emplace(
+      loc.second, &std::next(fromRoles.begin(), static_cast<int64_t>(loc.first))->second);
+  }
+  // adapt existing locations
+  for (auto & placeholder : placeholders) {
+    auto it = newLocations.find(placeholder.location);
+    if (it != newLocations.end()) {
+      placeholder.location = it->second;
+    }
+  }
+}
+
+namespace autoware
+{
+
+class AutowareValidatorOsmParser
+{
+public:
+  static File read(const pugi::xml_node & fileNode, Errors * errors = nullptr)
+  {
+    AutowareValidatorOsmParser autowareValidatorOsmParser;
+    File file;
+    auto osmNode = fileNode.child(keyword::Osm);
+    file.nodes = autowareValidatorOsmParser.readNodes(osmNode);
+    file.ways = autowareValidatorOsmParser.readWays(osmNode, file.nodes);
+    file.relations = autowareValidatorOsmParser.readRelations(osmNode, file.nodes, file.ways);
+    if (errors != nullptr) {
+      *errors = autowareValidatorOsmParser.errors_;
+    }
+    return file;
+  }
+
+private:
+  Nodes readNodes(const pugi::xml_node & osmNode)
+  {
+    Nodes nodes;
+    for (auto node = osmNode.child(keyword::Node); node;  // NOLINT
+         node = node.next_sibling(keyword::Node)) {
+      if (isDeleted(node)) {
+        continue;
+      }
+      const auto id = node.attribute(keyword::Id).as_llong(InvalId);
+      const auto attributes = tags(node);
+      const auto lat = node.attribute(keyword::Lat).as_double(0.);
+      const auto lon = node.attribute(keyword::Lon).as_double(0.);
+      const auto elevationNode =
+        node.find_child_by_attribute(keyword::Tag, keyword::Key, keyword::Elevation);
+      if (!elevationNode) {
+        reportParseError(id, "Elevation tag is not defined for the given node.");
+      } else if (!elevationNode.attribute(keyword::Value)) {
+        reportParseError(id, "Elevation tag exists but does not have a value.");
+      }
+      const auto ele = elevationNode.attribute(keyword::Value).as_double(.0);
+
+      nodes[id] = Node{id, attributes, {lat, lon, ele}};
+    }
+    return nodes;
+  }
+
+  Ways readWays(const pugi::xml_node & osmNode, Nodes & nodes)
+  {
+    Ways ways;
+    for (auto node = osmNode.child(keyword::Way); node;  // NOLINT
+         node = node.next_sibling(keyword::Way)) {
+      if (isDeleted(node)) {
+        continue;
+      }
+      const auto id = node.attribute(keyword::Id).as_llong(InvalId);
+      const auto attributes = tags(node);
+      const auto nodeIds = [&node] {
+        Ids ids;
+        for (auto refNode = node.child(keyword::Nd); refNode;  // NOLINT
+             refNode = refNode.next_sibling(keyword::Nd)) {
+          ids.push_back(refNode.attribute(keyword::Ref).as_llong());
+        }
+        return ids;
+      }();
+      std::vector<Node *> wayNodes;
+      try {
+        wayNodes =
+          utils::transform(nodeIds, [&nodes](const auto & elem) { return &nodes.at(elem); });
+      } catch (std::out_of_range &) {
+        reportParseError(id, "Way references nonexisting points");
+      }
+      ways[id] = Way{id, attributes, wayNodes};
+    }
+    return ways;
+  }
+
+  Relations readRelations(const pugi::xml_node & osmNode, Nodes & nodes, Ways & ways)
+  {
+    Relations relations;
+    // Two-pass approach: We can resolve all roles except where relations reference relations. We
+    // insert a dummy nullptr and resolve that later on.
+    std::vector<UnresolvedRole> unresolvedRoles;
+    for (auto node = osmNode.child(keyword::Relation); node;  // NOLINT
+         node = node.next_sibling(keyword::Relation)) {
+      if (isDeleted(node)) {
+        continue;
+      }
+      const auto id = node.attribute(keyword::Id).as_llong(InvalId);
+      const auto attributes = tags(node);
+      auto & relation = relations.emplace(id, Relation{id, attributes, {}}).first->second;
+
+      // resolve members
+      auto & roles = relation.members;
+      for (auto member = node.child(keyword::Member); member;  // NOLINT
+           member = member.next_sibling(keyword::Member)) {
+        Id memberId = member.attribute(keyword::Ref).as_llong();
+        const std::string role = member.attribute(keyword::Role).value();
+        const std::string type = member.attribute(keyword::Type).value();
+        try {
+          if (type == keyword::Node) {
+            roles.emplace_back(role, &nodes.at(memberId));
+          } else if (type == keyword::Way) {
+            roles.emplace_back(role, &ways.at(memberId));
+          } else if (type == keyword::Relation) {
+            // insert a placeholder and store a pointer to it for the second pass
+            roles.emplace_back(role, nullptr);
+            unresolvedRoles.push_back(UnresolvedRole{id, memberId, &roles.back().second});
+          }
+        } catch (std::out_of_range &) {
+          reportParseError(id, "Relation has nonexistent member " + std::to_string(memberId));
+        }
+      }
+    }
+
+    // now resolve all unresolved roles that point to other relations
+    for (const auto & unresolvedRole : unresolvedRoles) {
+      try {
+        assert(*unresolvedRole.location == nullptr);
+        *unresolvedRole.location = &relations.at(unresolvedRole.referencedRelation);
+      } catch (std::out_of_range &) {
+        reportParseError(
+          unresolvedRole.relation, "Relation references nonexistent relation " +
+                                     std::to_string(unresolvedRole.referencedRelation));
+        // now it gets ugly: find placeholder and remove it. Fix all other placeholders because the
+        // pointers are invalidated after moving. This is inefficent, but its the fault of the guy
+        // loading an invalid map, not ours.
+        auto & relation = relations.at(unresolvedRole.relation);
+        removeAndFixPlaceholders(unresolvedRole.location, relation.members, unresolvedRoles);
+      }
+    }
+    return relations;
+  }
+
+  AutowareValidatorOsmParser() = default;
+  void reportParseError(Id id, const std::string & what)
+  {
+    auto errstr = "Error reading primitive with id " + std::to_string(id) + " from file: " + what;
+    errors_.push_back(errstr);
+  }
+  Errors errors_;
+};
+
+File read(pugi::xml_document & node, Errors * errors)
+{
+  return AutowareValidatorOsmParser::read(node, errors);
+}
+}  // namespace autoware
+}  // namespace lanelet::osm

--- a/map/autoware_lanelet2_map_validator/src/common/map_loader.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/map_loader.cpp
@@ -68,16 +68,18 @@ loadAndValidateMap(
       map = lanelet::load(map_file, "autoware_validator_osm_handler", *projector, &errors);
     }
     if (!map) {
-      errors.push_back("Failed to load map!");
+      errors.push_back("Failed to load the entire map!");
     }
     issues.emplace_back("general", utils::transform(errors, [](auto & error) {
                           return lanelet::validation::Issue(
-                            lanelet::validation::Severity::Error, error);
+                            lanelet::validation::Severity::Error,
+                            lanelet::validation::Primitive::Primitive, lanelet::InvalId, error);
                         }));
   } catch (lanelet::LaneletError & err) {
     issues.emplace_back("general", utils::transform(errors, [](auto & error) {
                           return lanelet::validation::Issue(
-                            lanelet::validation::Severity::Error, error);
+                            lanelet::validation::Severity::Error,
+                            lanelet::validation::Primitive::Primitive, lanelet::InvalId, error);
                         }));
   }
 

--- a/map/autoware_lanelet2_map_validator/src/common/map_loader.cpp
+++ b/map/autoware_lanelet2_map_validator/src/common/map_loader.cpp
@@ -65,7 +65,7 @@ loadAndValidateMap(
     if (!projector) {
       errors.push_back("No valid map projection type specified!");
     } else {
-      map = lanelet::load(map_file, *projector, &errors);
+      map = lanelet::load(map_file, "autoware_validator_osm_handler", *projector, &errors);
     }
     if (!map) {
       errors.push_back("Failed to load map!");

--- a/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/autoware_validator_osm_parser.hpp
+++ b/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/autoware_validator_osm_parser.hpp
@@ -1,16 +1,13 @@
-// Copyright 2025 Autoware Foundation
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright (c) 2018
+ * FZI Forschungszentrum Informatik, Karlsruhe, Germany (www.fzi.de)
+ * All rights reserved.
+ *
+ * Modifications by [Taiki Yamada/Autoware Foundation], 2025
+ *
+ * This software is licensed under the BSD-3-Clause license.
+ * See the LICENSE file for details.
+ */
 
 #ifndef LANELET2_MAP_VALIDATOR__AUTOWARE_VALIDATOR_OSM_PARSER_HPP_
 #define LANELET2_MAP_VALIDATOR__AUTOWARE_VALIDATOR_OSM_PARSER_HPP_

--- a/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/autoware_validator_osm_parser.hpp
+++ b/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/autoware_validator_osm_parser.hpp
@@ -1,0 +1,47 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_VALIDATOR__AUTOWARE_VALIDATOR_OSM_PARSER_HPP_
+#define LANELET2_MAP_VALIDATOR__AUTOWARE_VALIDATOR_OSM_PARSER_HPP_
+
+#include <lanelet2_io/io_handlers/OsmHandler.h>
+
+#include <memory>
+#include <string>
+
+namespace lanelet::io_handlers
+{
+class AutowareValidatorOsmParser : public lanelet::io_handlers::OsmParser
+{
+public:
+  std::unique_ptr<LaneletMap> parse(
+    const std::string & filename, ErrorMessages & errors) const override;
+
+  static constexpr const char * extension() { return ".osm"; }
+
+  static constexpr const char * name() { return "autoware_validator_osm_handler"; }
+
+  AutowareValidatorOsmParser(const lanelet::Projector & projector, const io::Configuration & config)
+  : OsmParser(projector, config)
+  {
+  }
+};
+}  // namespace lanelet::io_handlers
+
+namespace lanelet::osm::autoware
+{
+File read(pugi::xml_document & node, lanelet::osm::Errors * errors = nullptr);
+}
+
+#endif  // LANELET2_MAP_VALIDATOR__AUTOWARE_VALIDATOR_OSM_PARSER_HPP_

--- a/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/autoware_validator_osm_parser.hpp
+++ b/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/autoware_validator_osm_parser.hpp
@@ -19,20 +19,16 @@
 
 namespace lanelet::io_handlers
 {
-class AutowareValidatorOsmParser : public lanelet::io_handlers::OsmParser
+class AutowareValidatorOsmParser : public OsmParser
 {
 public:
+  using OsmParser::OsmParser;
   std::unique_ptr<LaneletMap> parse(
     const std::string & filename, ErrorMessages & errors) const override;
 
   static constexpr const char * extension() { return ".osm"; }
 
   static constexpr const char * name() { return "autoware_validator_osm_handler"; }
-
-  AutowareValidatorOsmParser(const lanelet::Projector & projector, const io::Configuration & config)
-  : OsmParser(projector, config)
-  {
-  }
 };
 }  // namespace lanelet::io_handlers
 

--- a/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validation.hpp
+++ b/map/autoware_lanelet2_map_validator/src/include/lanelet2_map_validator/validation.hpp
@@ -68,9 +68,14 @@ void summarize_validator_results(json & json_data);
 lanelet::validation::ValidationConfig replace_validator(
   const lanelet::validation::ValidationConfig & input, const std::string & validator_name);
 
-void process_requirements(
-  json json_data, const lanelet::autoware::validation::MetaConfig & validator_config,
+std::vector<lanelet::validation::DetectedIssues> process_requirements(
+  json & json_data, const lanelet::autoware::validation::MetaConfig & validator_config,
   const lanelet::LaneletMap & lanelet_map);
+
+void export_results(json & json_data, const MetaConfig & validator_config);
+
+void append_map_loading_issues(
+  json & json_data, std::vector<lanelet::validation::DetectedIssues> loading_issues);
 }  // namespace lanelet::autoware::validation
 
 #endif  // LANELET2_MAP_VALIDATOR__VALIDATION_HPP_

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet.osm
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_one_point_having_non_value_ele.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_one_point_having_non_value_ele.osm
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+    <tag k="ele"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_one_point_missing_ele.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_one_point_missing_ele.osm
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+    <tag k="ele" v="19.3488"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+    <tag k="ele" v="19.3413"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+    <tag k="ele" v="19.3397"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+    <tag k="ele" v="19.3724"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+    <tag k="ele" v="19.3259"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+    <tag k="ele" v="19.3117"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+    <tag k="ele" v="19.2979"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_without_ele.osm
+++ b/map/autoware_lanelet2_map_validator/test/data/map/lane/single_lanelet_without_ele.osm
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="8" lat="35.90312398544" lon="139.93324675646">
+    <tag k="local_x" v="3736.8634"/>
+    <tag k="local_y" v="73729.1154"/>
+  </node>
+  <node id="9" lat="35.90313706429" lon="139.93327698894">
+    <tag k="local_x" v="3739.6075"/>
+    <tag k="local_y" v="73730.5363"/>
+  </node>
+  <node id="11" lat="35.90314993972" lon="139.93330675322">
+    <tag k="local_x" v="3742.3091"/>
+    <tag k="local_y" v="73731.9351"/>
+  </node>
+  <node id="12" lat="35.90316376045" lon="139.93333870223">
+    <tag k="local_x" v="3745.209"/>
+    <tag k="local_y" v="73733.4366"/>
+  </node>
+  <node id="13" lat="35.90317715959" lon="139.9333696751">
+    <tag k="local_x" v="3748.0203"/>
+    <tag k="local_y" v="73734.8923"/>
+  </node>
+  <node id="14" lat="35.90319132639" lon="139.93340242399">
+    <tag k="local_x" v="3750.9928"/>
+    <tag k="local_y" v="73736.4314"/>
+  </node>
+  <node id="15" lat="35.90320867521" lon="139.93344252692">
+    <tag k="local_x" v="3754.6328"/>
+    <tag k="local_y" v="73738.3162"/>
+  </node>
+  <node id="16" lat="35.90310010653" lon="139.93326236239">
+    <tag k="local_x" v="3738.2428"/>
+    <tag k="local_y" v="73726.4514"/>
+  </node>
+  <node id="17" lat="35.90311318447" lon="139.93329259488">
+    <tag k="local_x" v="3740.9869"/>
+    <tag k="local_y" v="73727.8722"/>
+  </node>
+  <node id="19" lat="35.9031260608" lon="139.93332235914">
+    <tag k="local_x" v="3743.6885"/>
+    <tag k="local_y" v="73729.2711"/>
+  </node>
+  <node id="20" lat="35.90313988152" lon="139.93335430814">
+    <tag k="local_x" v="3746.5884"/>
+    <tag k="local_y" v="73730.7726"/>
+  </node>
+  <node id="21" lat="35.90315328156" lon="139.933385281">
+    <tag k="local_x" v="3749.3997"/>
+    <tag k="local_y" v="73732.2284"/>
+  </node>
+  <node id="22" lat="35.90316744746" lon="139.93341802989">
+    <tag k="local_x" v="3752.3722"/>
+    <tag k="local_y" v="73733.7674"/>
+  </node>
+  <node id="23" lat="35.90318479537" lon="139.93345813282">
+    <tag k="local_x" v="3756.0122"/>
+    <tag k="local_y" v="73735.6521"/>
+  </node>
+  <way id="10">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="15"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="18">
+    <nd ref="16"/>
+    <nd ref="17"/>
+    <nd ref="19"/>
+    <nd ref="20"/>
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="24">
+    <member type="way" role="left" ref="10"/>
+    <member type="way" role="right" ref="18"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/map/autoware_lanelet2_map_validator/test/src/include/map_validation_tester.hpp
+++ b/map/autoware_lanelet2_map_validator/test/src/include/map_validation_tester.hpp
@@ -15,11 +15,13 @@
 #ifndef MAP_VALIDATION_TESTER_HPP_
 #define MAP_VALIDATION_TESTER_HPP_
 
+#include "lanelet2_map_validator/map_loader.hpp"
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
-#include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>
 
 #include <gtest/gtest.h>
 #include <lanelet2_io/Io.h>
+#include <lanelet2_io/io_handlers/Factory.h>
 
 #include <memory>
 #include <string>
@@ -30,19 +32,20 @@ class MapValidationTester : public ::testing::Test
 protected:
   void load_target_map(std::string file_name)
   {
-    const auto projector = std::make_unique<lanelet::projection::MGRSProjector>();
-
-    std::string package_share_directory =
+    const std::string package_share_directory =
       ament_index_cpp::get_package_share_directory("autoware_lanelet2_map_validator");
 
-    map_ = lanelet::load(
-      package_share_directory + "/data/map/" + file_name, *projector, &loading_errors_);
+    const std::string map_file_path = package_share_directory + "/data/map/" + file_name;
+    lanelet::validation::ValidationConfig config;
+
+    std::tie(map_, loading_issues_) =
+      lanelet::autoware::validation::loadAndValidateMap("mgrs", map_file_path, config);
 
     EXPECT_NE(map_, nullptr);
   }
 
   lanelet::LaneletMapPtr map_{nullptr};
-  std::vector<std::string> loading_errors_;
+  std::vector<lanelet::validation::DetectedIssues> loading_issues_;
 };
 
 #endif  // MAP_VALIDATION_TESTER_HPP_

--- a/map/autoware_lanelet2_map_validator/test/src/lane/test_missing_point_elevation.cpp
+++ b/map/autoware_lanelet2_map_validator/test/src/lane/test_missing_point_elevation.cpp
@@ -1,0 +1,111 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "map_validation_tester.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_validation/ValidatorFactory.h>
+
+#include <string>
+
+class TestMissingPointElevation : public MapValidationTester
+{
+private:
+};
+
+TEST_F(TestMissingPointElevation, CompleteLanelet)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet.osm");
+
+  EXPECT_EQ(loading_issues_[0].issues.size(), 0);
+}
+
+TEST_F(TestMissingPointElevation, PartiallyMissingLanelet)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet_one_point_missing_ele.osm");
+
+  bool found_identical_issue = false;
+  const int target_primitive_id = 13;
+
+  const lanelet::validation::Severity target_severity = lanelet::validation::Severity::Error;
+  const lanelet::validation::Primitive target_primitive = lanelet::validation::Primitive::Primitive;
+  const lanelet::Id target_issue_id = lanelet::InvalId;
+  const std::string target_message = "Error reading primitive with id " +
+                                     std::to_string(target_primitive_id) +
+                                     " from file: Elevation tag is not defined for the given node.";
+
+  for (const auto & issue : loading_issues_[0].issues) {
+    if (
+      issue.severity == target_severity && issue.primitive == target_primitive &&
+      issue.id == target_issue_id && issue.message == target_message) {
+      found_identical_issue = true;
+    }
+  }
+
+  EXPECT_TRUE(found_identical_issue);
+}
+
+TEST_F(TestMissingPointElevation, PartiallyUndefinedLanelet)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet_one_point_having_non_value_ele.osm");
+
+  bool found_identical_issue = false;
+  const int target_primitive_id = 13;
+
+  const lanelet::validation::Severity target_severity = lanelet::validation::Severity::Error;
+  const lanelet::validation::Primitive target_primitive = lanelet::validation::Primitive::Primitive;
+  const lanelet::Id target_issue_id = lanelet::InvalId;
+  const std::string target_message = "Error reading primitive with id " +
+                                     std::to_string(target_primitive_id) +
+                                     " from file: Elevation tag exists but does not have a value.";
+
+  for (const auto & issue : loading_issues_[0].issues) {
+    if (
+      issue.severity == target_severity && issue.primitive == target_primitive &&
+      issue.id == target_issue_id && issue.message == target_message) {
+      found_identical_issue = true;
+    }
+  }
+
+  EXPECT_TRUE(found_identical_issue);
+}
+
+TEST_F(TestMissingPointElevation, EntirelyMissingLanelet)  // NOLINT for gtest
+{
+  load_target_map("lane/single_lanelet_without_ele.osm");
+
+  int ele_issue_count = 0;
+
+  lanelet::validation::Severity target_severity = lanelet::validation::Severity::Error;
+  lanelet::validation::Primitive target_primitive = lanelet::validation::Primitive::Primitive;
+  lanelet::Id target_issue_id = lanelet::InvalId;
+  std::string target_partial_message = "Elevation tag is not defined for the given node.";
+
+  for (const auto & issue : loading_issues_[0].issues) {
+    if (
+      issue.severity == target_severity && issue.primitive == target_primitive &&
+      issue.id == target_issue_id &&
+      issue.message.find(target_partial_message) != std::string::npos) {
+      ele_issue_count++;
+    }
+  }
+
+  EXPECT_EQ(ele_issue_count, 14);  // All fourteen points
+}
+
+TEST_F(TestMissingPointElevation, SampleMap)  // NOLINT for gtest
+{
+  load_target_map("sample_map.osm");
+}

--- a/map/autoware_lanelet2_map_validator/test/src/traffic_light/test_regulatory_elements_details_for_traffic_lights.cpp
+++ b/map/autoware_lanelet2_map_validator/test/src/traffic_light/test_regulatory_elements_details_for_traffic_lights.cpp
@@ -45,20 +45,25 @@ TEST_F(TestRegulatoryElementDetailsForTrafficLights, MissingRefers)  // NOLINT f
   // traffic_light-type regulatory elements that has no refers will not be loaded from the start
   // and should be mentioned in the loading_errors
 
-  bool found_error_on_loading = false;
-  int target_primitive_id = 1025;
-  std::string target_message =
+  bool found_identical_issue = false;
+  const int target_primitive_id = 1025;
+
+  const lanelet::validation::Severity target_severity = lanelet::validation::Severity::Error;
+  const lanelet::validation::Primitive target_primitive = lanelet::validation::Primitive::Primitive;
+  const lanelet::Id target_issue_id = lanelet::InvalId;
+  const std::string target_message =
     "Error parsing primitive " + std::to_string(target_primitive_id) +
     ": Creating a regulatory element of type traffic_light failed: No traffic light defined!";
 
-  for (const auto & error : loading_errors_) {
-    if (error.find(target_message) != std::string::npos) {
-      found_error_on_loading = true;
-      break;
+  for (const auto & issue : loading_issues_[0].issues) {
+    if (
+      issue.severity == target_severity && issue.primitive == target_primitive &&
+      issue.id == target_issue_id && issue.message == target_message) {
+      found_identical_issue = true;
     }
   }
 
-  EXPECT_TRUE(found_error_on_loading);
+  EXPECT_TRUE(found_identical_issue);
 }
 
 TEST_F(TestRegulatoryElementDetailsForTrafficLights, MissingRefLine)  // NOLINT for gtest
@@ -127,6 +132,7 @@ TEST_F(TestRegulatoryElementDetailsForTrafficLights, SampleMap)  // NOLINT for g
   load_target_map("sample_map.osm");
 
   lanelet::autoware::validation::RegulatoryElementsDetailsForTrafficLightsValidator checker;
+
   const auto & issues = checker(*map_);
 
   EXPECT_EQ(issues.size(), 0);


### PR DESCRIPTION
## Description

### Background

Currently, autoware_lanelet2_map_validator can validate a `LaneletMap` class object but cannot validate the osm file itself.
However, Autoware requires all points in the map must have an `ele` tag defined, which is not able to validate from a `LaneletMap` class object.

### Osm Parser for validation
Hence, I've created an original osm parser `autoware_validator_osm_parser` for autoware_lanelet2_map_validator to catch errors that happen in the osm parsing phase. 

I had to copy the portion of the Lanelet 2 library to create a osm_parser that can validate the `ele` tag in the osm file, so I made a license statement that this code copied and modified the ones in the Lanelet2 library.

### Passing errors on map loading
The current autoware_lanelet2_map_validator has a problem that issues happening in the map loading phase will not be passed to the `lanelet2_validation_results.json`. I've reorganized the process in the validation so that the map loading issues can be passed to the final result.

### Main changes in this PR

- Create a new osm parser `autoware_validator_osm_parser` to validate stuff inside in the parsing phase
  - Added a feature that returns errors when a point doesn't have a `ele` tag and its value.
  - Let autoware_lanelet2_map_validator use `autoware_validator_osm_parser` to load the lanelet2 map.
- Reorganized the validation process so that map loading issues can be written to `lanelet2_validation_results.json`.
- Create a test code and test maps to test whether the `autoware_validator_osm_parser` can detect points that have invalid elevation.

## How was this PR tested?

### `colcon test`

Checked that all test codes passes 100%
```bash
colcon test --packages-select autoware_lanelet2_map_validator --event-handlers console_cohesion+
```

### Usual practice

#### 1. Succeed case

Checked that the usual `ros2 run` works against `sample_map.osm`, and see a new item `[map_loading]`.
```bash
ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator -p mgrs -m ./test/data/map/sample_map.osm -i ./autoware_requirement_set.json -o ./
```

![Screenshot from 2025-01-24 15-23-21](https://github.com/user-attachments/assets/883deb2e-eb49-44e7-8a3d-702437ee495d)


#### 2. Fail case

Checked that the usual `ros2 run` works against `single_lanelet_one_point_missing_ele.osm`, and see a new item `[map_loading]`.
```bash
ros2 run autoware_lanelet2_map_validator autoware_lanelet2_map_validator -p mgrs -m ./test/data/map/lane/single_lanelet_one_point_missing_ele.osm -i ./autoware_requirement_set.json -o ./
```

![Screenshot from 2025-01-24 15-31-03](https://github.com/user-attachments/assets/e9eb743a-8289-4591-ad5d-4209142ba1eb)

You can see a new requirement block `map_loading` is created in the `lanelet2_validation_results.json`.
```json
{
    "id": "map_loading",
    "passed": false,
    "validators": [
        {
            "issues": [
                {
                    "id": 0,
                    "issue_code": "General.MapLoading-001",
                    "message": "Error reading primitive with id 13 from file: Elevation tag is not defined for the given node.",
                    "primitive": "primitive",
                    "severity": "Error"
                }
            ],
            "name": "general.map_loading",
            "passed": false
        }
    ]
}
```

## Notes for reviewers

`autoware_validator_osm_parser.cpp` and `autoware_validator_osm_parser.hpp` is based on the code of the [Lanelet2 library](https://github.com/fzi-forschungszentrum-informatik/Lanelet2).

- It is a copy of ...
  - [L403 to L439](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/1d88ad28baa5b6962d80642422c0667ae88bfdae/lanelet2_io/src/OsmHandlerLoad.cpp#L403-L439)  of `OsmHandlerLoad.cpp`
  -  [L13 to L57](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/1d88ad28baa5b6962d80642422c0667ae88bfdae/lanelet2_io/src/OsmFile.cpp#L13-L57), [L66 to L94](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/1d88ad28baa5b6962d80642422c0667ae88bfdae/lanelet2_io/src/OsmFile.cpp#L66-L94), [L189 to L312](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/1d88ad28baa5b6962d80642422c0667ae88bfdae/lanelet2_io/src/OsmFile.cpp#L189-L312), and [L343](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/1d88ad28baa5b6962d80642422c0667ae88bfdae/lanelet2_io/src/OsmFile.cpp#L343) of `OsmFile.cpp`.
- The differences are... 
  - Changed `OsmFileParser` to `AutowareValidatorOsmFileParser` and added `autoware` namespace to it.
  - Created `AutowareValidatorOsmParser` class (inherit from `OsmParser`) and modify the `parse()` method to detect invalid elevation tags.
    - In the `parse()` method `lanelet::osm::read()` changed to `lanelet::osm::autoware::read()` which is redirected to the `read()` method in AutowareValidatorOsmFileParser`.
  - Changed the `readNodes()` method (which is called from the `read()` method) so that invalid elevation can be detected.

## Effects on system behavior

- autoware_lanelet2_map_validator can detect invalid elevation definitions in a osm file.
- autoware_lanelet2_map_validator writes issues that happened in the map loading phase.