### PR TITLE
fix(driving_environment_analyzer): add missing include files for autoware_universe_utils

### DIFF
--- a/driving_environment_analyzer/src/utils.cpp
+++ b/driving_environment_analyzer/src/utils.cpp
@@ -15,6 +15,7 @@
 #include "driving_environment_analyzer/utils.hpp"
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/universe_utils/geometry/geometry.hpp"
 
 #include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>


### PR DESCRIPTION
## Description
This adds include declaration to many packages that are using functions from autoware_universe_utils.

This was found when I was working on removing Autoware.Universe dependencies from autoware_interpolation and autoware_motion_utils packages for Autoware Core porting activity. Currently, many packages seemed to include autoware_universe_utils header files via autoware_interpolation or autoware_motion_utils, and outputs a lot of errors when we modify autoware_interpolation and autoware_motion_utils package dependencies.

This PR will make sure that each package independently includes headers that they use in their code as a preparation.

## How was this PR tested?

I have made sure that it builds without an error.

## Notes for reviewers

None.

## Effects on system behavior

None.
