### PR TITLE
fix: mission_planner parameter path in static_centerline_generator launch file

### DIFF
--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -35,7 +35,7 @@
   />
   <arg name="path_smoother_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml"/>
   <arg name="path_optimizer_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/autoware_path_optimizer/path_optimizer.param.yaml"/>
-  <arg name="mission_planner_param" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner_universe/mission_planner.param.yaml"/>
+  <arg name="mission_planner_param" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
 
   <!-- Global parameters (for PathFootprint in tier4_planning_rviz_plugin) -->
   <!-- Do not add "group" in order to propagate global parameters -->


### PR DESCRIPTION
## Description

This PR fix mission_planner parameter path in static_centerline_generator launch file

## How was this PR tested?

[TIER IV internal link](https://star4.slack.com/archives/CEV8XMJBV/p1741067486622319?)  
static path was generated successfully

## Notes for reviewers

None.

## Effects on system behavior

None.
