### PR TITLE
fix(autoware_localization_evaluation_scripts): change target directories

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -53,9 +53,11 @@ if __name__ == "__main__":
     topic_subject = args.topic_subject
     topic_reference = args.topic_reference
 
-    directories = sorted(
-        [d for d in args.result_dir.iterdir() if d.is_dir() and not d.is_symlink()]
-    )
+    target_rosbags = list(result_dir.glob("**/*.db3")) + list(result_dir.glob("**/*.mcap"))
+    directories = [path.parent.parent for path in target_rosbags]
+    directories = list(set(directories))
+    directories = [d for d in directories if not d.is_symlink()]
+    directories = sorted(directories)
 
     with Pool(args.parallel_num) as pool:
         pool.starmap(

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/parse_functions.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/parse_functions.py
@@ -58,7 +58,6 @@ def parse_stamp(stamp):
 def parse_msg(msg, msg_type):
     class_name = msg_type.__class__.__name__.replace("Metaclass_", "")
     try:
-        # parse_ + クラス名 の関数を動的に取得して実行
         parser = globals()[f"parse_{class_name}"]
         return parser(msg)
     except KeyError:


### PR DESCRIPTION
## Description

This pull request changes `analyze_rosbags_parallel.py` to be able to specify a rosbag instead of the parent directory.

[NITS]

* I deleted the remaining Japanese comments.

## How was this PR tested?

The following commands both work.

* Specify the parent directory.

```bash
ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
    $HOME/driving_log_replayer_v2/out/ \
    --parallel_num 2 \
    --topic_subject "/localization/kinematic_state" \
    --topic_reference "/localization/pose_estimator/pose_with_covariance"
```

* Specify one directory.

```bash
ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
    $HOME/driving_log_replayer_v2/out/2025-0310-085140 \
    --parallel_num 2 \
    --topic_subject "/localization/kinematic_state" \
    --topic_reference "/localization/pose_estimator/pose_with_covariance"
```

## Notes for reviewers

None.

## Effects on system behavior

None.
