### PR TITLE
fix: set save dir

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -18,15 +18,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--topic_reference", type=str, default="/localization/pose_estimator/pose_with_covariance"
     )
+    parser.add_argument("--save_dir_relative", type=str, default="")
     return parser.parse_args()
 
 
-def process_directory(directory: Path, topic_subject: str, topic_reference: str) -> None:
+def process_directory(directory: Path, topic_subject: str, topic_reference: str, save_dir_relative: str) -> None:
     target_rosbag = directory / "result_bag"
-    compare_result_dir = directory / "compare_trajectories"
+    save_dir = directory if save_dir_relative == "" else directory / save_dir_relative
+    compare_result_dir = save_dir / "compare_trajectories"
     compare_result_dir.mkdir(parents=True, exist_ok=True)
+    diagnostics_result_dir = save_dir / "diagnostics_result"
 
-    plot_diagnostics.main(rosbag_path=target_rosbag)
+    plot_diagnostics.main(rosbag_path=target_rosbag, save_dir=diagnostics_result_dir)
 
     save_name_subject = extract_pose_from_rosbag.topic_name_to_save_name(topic_subject)
     save_name_reference = extract_pose_from_rosbag.topic_name_to_save_name(topic_reference)
@@ -52,6 +55,7 @@ if __name__ == "__main__":
     parallel_num = args.parallel_num
     topic_subject = args.topic_subject
     topic_reference = args.topic_reference
+    save_dir_relative = args.save_dir_relative
 
     target_rosbags = list(result_dir.glob("**/*.db3")) + list(result_dir.glob("**/*.mcap"))
     directories = [path.parent.parent for path in target_rosbags]
@@ -62,5 +66,5 @@ if __name__ == "__main__":
     with Pool(args.parallel_num) as pool:
         pool.starmap(
             process_directory,
-            [(d, topic_subject, topic_reference) for d in directories],
+            [(d, topic_subject, topic_reference, save_dir_relative) for d in directories],
         )

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -22,7 +22,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def process_directory(directory: Path, topic_subject: str, topic_reference: str, save_dir_relative: str) -> None:
+def process_directory(
+    directory: Path, topic_subject: str, topic_reference: str, save_dir_relative: str
+) -> None:
     target_rosbag = directory / "result_bag"
     save_dir = directory if save_dir_relative == "" else directory / save_dir_relative
     compare_result_dir = save_dir / "compare_trajectories"


### PR DESCRIPTION
## Description

This pull request changes `analyze_rosbags_parallel.py` to be able to specify a specify the destination path relative to the directory where rosbag is located

## How was this PR tested?

```shell
ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
    $HOME/dlr2_data/localization/out/2025-0310-151452 \
    --save_dir_relative \
    result_archive

# output files
~/dlr2_data/localization/out/2025-0310-151452
❯ tree
.
├── result.jsonl
├── result_archive
│   ├── compare_trajectories
│   │   ├── localization__kinematic_state.tsv
│   │   ├── localization__kinematic_state_result
│   │   │   ├── compare_trajectories.png
│   │   │   ├── relative_pose.png
│   │   │   ├── relative_pose.tsv
│   │   │   └── relative_pose_summary.tsv
│   │   └── localization__pose_estimator__pose_with_covariance.tsv
│   └── diagnostics_result
│       ├── gyro_bias_validator__gyro_bias_validator.png
│       ├── gyro_bias_validator__gyro_bias_validator.tsv
│       ├── localization__ekf_localizer.png
│       ├── localization__ekf_localizer.tsv
│       ├── localization__pose_instability_detector.png
│       ├── localization__pose_instability_detector.tsv
│       ├── localization_error_monitor__ellipse_error_status.png
│       ├── localization_error_monitor__ellipse_error_status.tsv
│       ├── ndt_scan_matcher__scan_matching_status.png
│       └── ndt_scan_matcher__scan_matching_status.tsv
└── result_bag
    ├── metadata.yaml
    └── result_bag_0.mcap
```

## Notes for reviewers

According to the Evaluator specification, all files saved under result_archive can be downloaded from report.
Therefore, the analysis results must be placed under result_archive

## Effects on system behavior

None.
