### PR TITLE
fix(autoware_localization_evaluation_scripts): add `plt.close()`

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/plot_diagnostics.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/plot_diagnostics.py
@@ -165,6 +165,7 @@ def main(rosbag_path: Path, save_dir: Path = None) -> None:
     plt.tight_layout()
     save_path = save_dir / f"{diag_name_to_filename(diag_name)}.png"
     plt.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
+    plt.close()
 
     #################
     # ekf_localizer #
@@ -198,6 +199,7 @@ def main(rosbag_path: Path, save_dir: Path = None) -> None:
     plt.tight_layout()
     save_path = save_dir / f"{diag_name_to_filename(diag_name)}.png"
     plt.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
+    plt.close()
 
     #############################
     # pose_instability_detector #
@@ -242,6 +244,7 @@ def main(rosbag_path: Path, save_dir: Path = None) -> None:
     plt.tight_layout()
     save_path = save_dir / f"{diag_name_to_filename(diag_name)}.png"
     plt.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
+    plt.close()
 
     ##############################
     # localization_error_monitor #
@@ -267,6 +270,7 @@ def main(rosbag_path: Path, save_dir: Path = None) -> None:
     plt.tight_layout()
     save_path = save_dir / f"{diag_name_to_filename(diag_name)}.png"
     plt.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
+    plt.close()
 
     #######################
     # gyro_bias_validator #
@@ -303,6 +307,7 @@ def main(rosbag_path: Path, save_dir: Path = None) -> None:
     plt.tight_layout()
     save_path = save_dir / f"{diag_name_to_filename(diag_name)}.png"
     plt.savefig(save_path, bbox_inches="tight", pad_inches=0.05)
+    plt.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix a bug.

|Before|After|
|:-------:|:-----:|
|<img src="https://github.com/user-attachments/assets/e6f9bb7e-107d-46f9-8261-a1afaf6919a6" width=500 />|<img src="https://github.com/user-attachments/assets/5d6e541c-7d8c-4274-8ac1-47a3054d7446" width=500 />|

## How was this PR tested?

```bash
ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
    $HOME/driving_log_replayer_v2/out/latest \
    --parallel_num 2 \
    --topic_subject "/localization/kinematic_state" \
    --topic_reference "/localization/reference_kinematic_state"
```

## Notes for reviewers

None.

## Effects on system behavior

None.
