### PR TITLE
feat(proccesing_time_visualizer): use autoware_internal_debug_msgs 

### DIFF
--- a/common/autoware_debug_tools/README.md
+++ b/common/autoware_debug_tools/README.md
@@ -4,7 +4,7 @@ This package provides tools for debugging Autoware.
 
 ## Processing Time Visualizer
 
-This tool visualizes `tier4_debug_msgs/msg/ProcessingTimeTree` messages.
+This tool visualizes `autoware_internal_debug_msgs/msg/ProcessingTimeTree` messages.
 
 ### Usage
 

--- a/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/node.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/node.py
@@ -9,7 +9,7 @@ import pyperclip
 import rclpy
 import rclpy.executors
 from rclpy.node import Node
-from tier4_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
+from autoware_internal_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
 
 from .print_tree import print_trees
 from .topic_selector import select_topic
@@ -40,7 +40,7 @@ class ProcessingTimeVisualizer(Node):
             for topic_name, topic_types in self.get_topic_names_and_types():
                 if (
                     topic_name == self.topic_name
-                    and "tier4_debug_msgs/msg/ProcessingTimeTree" in topic_types
+                    and "autoware_internal_debug_msgs/msg/ProcessingTimeTree" in topic_types
                 ):
                     topic_found = True
                     break
@@ -63,7 +63,7 @@ class ProcessingTimeVisualizer(Node):
                 for topic_name, topic_types in self.get_topic_names_and_types():
                     for topic_type in topic_types:
                         if (
-                            topic_type == "tier4_debug_msgs/msg/ProcessingTimeTree"
+                            topic_type == "autoware_internal_debug_msgs/msg/ProcessingTimeTree"
                             and topic_name not in topics
                         ):
                             topics.append(topic_name)

--- a/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/tree.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/tree.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from tier4_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
+from autoware_internal_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
 
 
 class ProcessingTimeTree:


### PR DESCRIPTION
## Description

Curretrly autoware_internal_debug_msgs is used for proccesing time, tools should use that too.
Without this PR we can't use proccesing time visualizer for latest autoware.
- https://github.com/autowarefoundation/autoware_internal_msgs/pull/41
- https://github.com/autowarefoundation/autoware.universe/pull/10191
- https://github.com/autowarefoundation/autoware_utils/pull/23

## How was this PR tested?

ros2 run autoware_debug_tools processing_time_visualizer

![image](https://github.com/user-attachments/assets/daf736d3-1a5a-4ff5-86b8-f54890863e52)


## Notes for reviewers

None.

## Effects on system behavior

None.
