### PR TITLE
feat(planning_debug_tools)!: replace VelocityLimit messages to autoware_internal_planning_msgs

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,8 +1,8 @@
 repositories:
   # core
-  core/autoware_common:
+  core/autoware_utils:
     type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
+    url: https://github.com/autowarefoundation/autoware_utils.git
     version: main
   core/autoware.core:
     type: git

--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -21,6 +21,7 @@ from autoware_control_msgs.msg import Control as AckermannControlCommand
 from autoware_internal_debug_msgs.msg import Float32MultiArrayStamped
 from autoware_internal_debug_msgs.msg import Float32Stamped
 from autoware_internal_planning_msgs.msg import PathWithLaneId
+from autoware_internal_planning_msgs.msg import VelocityLimit
 from autoware_planning_msgs.msg import Path
 from autoware_planning_msgs.msg import Trajectory
 from autoware_vehicle_msgs.msg import VelocityReport
@@ -32,7 +33,6 @@ from rclpy.node import Node
 from tf2_ros import LookupException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-from autoware_internal_planning_msgs.msg import VelocityLimit
 
 REF_LINK = "map"
 SELF_LINK = "base_link"

--- a/planning/planning_debug_tools/scripts/closest_velocity_checker.py
+++ b/planning/planning_debug_tools/scripts/closest_velocity_checker.py
@@ -32,7 +32,7 @@ from rclpy.node import Node
 from tf2_ros import LookupException
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-from tier4_planning_msgs.msg import VelocityLimit
+from autoware_internal_planning_msgs.msg import VelocityLimit
 
 REF_LINK = "map"
 SELF_LINK = "base_link"

--- a/planning/planning_debug_tools/scripts/trajectory_visualizer.py
+++ b/planning/planning_debug_tools/scripts/trajectory_visualizer.py
@@ -33,7 +33,7 @@ import rclpy
 from rclpy.node import Node
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-from tier4_planning_msgs.msg import VelocityLimit
+from autoware_internal_planning_msgs.msg import VelocityLimit
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-l", "--length", help="max arclength in plot")

--- a/planning/planning_debug_tools/scripts/trajectory_visualizer.py
+++ b/planning/planning_debug_tools/scripts/trajectory_visualizer.py
@@ -18,6 +18,7 @@ import argparse
 
 from autoware_internal_planning_msgs.msg import PathPointWithLaneId
 from autoware_internal_planning_msgs.msg import PathWithLaneId
+from autoware_internal_planning_msgs.msg import VelocityLimit
 from autoware_planning_msgs.msg import Path
 from autoware_planning_msgs.msg import PathPoint
 from autoware_planning_msgs.msg import Trajectory
@@ -33,7 +34,6 @@ import rclpy
 from rclpy.node import Node
 from tf2_ros.buffer import Buffer
 from tf2_ros.transform_listener import TransformListener
-from autoware_internal_planning_msgs.msg import VelocityLimit
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-l", "--length", help="max arclength in plot")


### PR DESCRIPTION
## Description
This replaces tier4_planning_msgs with autoware_internal_planning_msgs for VelocityLimit as part of porting packages to Autoware Core.

This must be merged with https://github.com/autowarefoundation/autoware.universe/pull/10273.

## How was this PR tested?

I have ran trajectory_visualizer with planning_simulator
![image](https://github.com/user-attachments/assets/76494866-f251-4e61-b71b-9b4f162e2317)


## Notes for reviewers

None.

## Effects on system behavior

None.
