### PR TITLE
fix(autoware_debug_tools): time keeper does not work with the old message type

### DIFF
--- a/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/node.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/node.py
@@ -5,11 +5,11 @@ import time
 from typing import Dict
 import uuid
 
+from autoware_internal_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
 import pyperclip
 import rclpy
 import rclpy.executors
 from rclpy.node import Node
-from tier4_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
 
 from .print_tree import print_trees
 from .topic_selector import select_topic
@@ -40,7 +40,7 @@ class ProcessingTimeVisualizer(Node):
             for topic_name, topic_types in self.get_topic_names_and_types():
                 if (
                     topic_name == self.topic_name
-                    and "tier4_debug_msgs/msg/ProcessingTimeTree" in topic_types
+                    and "autoware_internal_debug_msgs/msg/ProcessingTimeTree" in topic_types
                 ):
                     topic_found = True
                     break
@@ -63,7 +63,7 @@ class ProcessingTimeVisualizer(Node):
                 for topic_name, topic_types in self.get_topic_names_and_types():
                     for topic_type in topic_types:
                         if (
-                            topic_type == "tier4_debug_msgs/msg/ProcessingTimeTree"
+                            topic_type == "autoware_internal_debug_msgs/msg/ProcessingTimeTree"
                             and topic_name not in topics
                         ):
                             topics.append(topic_name)

--- a/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/node.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/node.py
@@ -27,10 +27,10 @@ class ProcessingTimeVisualizer(Node):
         self.trees: Dict[str, ProcessingTimeTree] = {}
         self.worst_case_tree: Dict[str, ProcessingTimeTree] = {}
         self.total_tree: Dict[str, ProcessingTimeTree] = {}
-        self.stdcscr = init_curses()
+        self.stdscr = init_curses()
         self.show_comment = False
         self.summarize_output = True
-        print_trees("🌲 Processing Time Tree 🌲", self.topic_name, self.trees, self.stdcscr)
+        print_trees("🌲 Processing Time Tree 🌲", self.topic_name, self.trees, self.stdscr)
 
         self.create_timer(0.1, self.update_screen)
 
@@ -87,7 +87,7 @@ class ProcessingTimeVisualizer(Node):
         return subscriber
 
     def update_screen(self):
-        key = self.stdcscr.getch()
+        key = self.stdscr.getch()
 
         self.show_comment = not self.show_comment if key == ord("c") else self.show_comment
         self.summarize_output = (
@@ -97,7 +97,7 @@ class ProcessingTimeVisualizer(Node):
             "🌲 Processing Time Tree 🌲",
             self.topic_name,
             self.trees.values(),
-            self.stdcscr,
+            self.stdscr,
             self.show_comment,
             self.summarize_output,
         )

--- a/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/tree.py
+++ b/common/autoware_debug_tools/autoware_debug_tools/processing_time_visualizer/tree.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from tier4_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
+from autoware_internal_debug_msgs.msg import ProcessingTimeTree as ProcessingTimeTreeMsg
 
 
 class ProcessingTimeTree:


### PR DESCRIPTION
## Description

The "ProcessingTimeXXX" message was ported from tier4_debug_msgs to autoware_internal_debug_msgs, but the autoware_tools which depends on the message was not updated. This PR fixes the issue.

## How was this PR tested?
`ros2 run autoware_debug_tools processing_time_visualizer` can show the processing time tree successfully.

## Notes for reviewers

None.

## Effects on system behavior

None.
