### PR TITLE
feat(tier4_screen_capture_rviz_plugin): add buffer change bottom

### DIFF
--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -123,12 +123,12 @@ void AutowareScreenCapturePanel::on_rate_change([[maybe_unused]] const int rate)
   RCLCPP_INFO_STREAM(raw_node_->get_logger(), "RATE:" << rate_->value());
 }
 
-void AutowareScreenCapturePanel::on_buffer_size_change(const int seconds)
+void AutowareScreenCapturePanel::on_buffer_size_change(const int buffer_size)
 {
   update_buffer_size();
   RCLCPP_INFO_STREAM(
     raw_node_->get_logger(),
-    "BUFFER SIZE: " << seconds << "s (" << buffer_size_frames_ << " frames)");
+    "BUFFER SIZE: " << buffer_size << " [sec] with " << buffer_size_frames_ << " frames)");
 }
 
 void AutowareScreenCapturePanel::update_buffer_size()
@@ -139,6 +139,7 @@ void AutowareScreenCapturePanel::update_buffer_size()
 
 void AutowareScreenCapturePanel::on_timer()
 {
+  // update_buffer_size();
   setFormatDate(ros_time_label_, rclcpp::Clock().now().seconds());
 
   if (!main_window_) return;
@@ -156,10 +157,13 @@ void AutowareScreenCapturePanel::on_timer()
     static_cast<size_t>(q_image.bytesPerLine()));
 
   size_ = size;
+  std::cerr << "buffer_size_frames_: " << buffer_size_frames_ << std::endl;
+  std::cerr << "image size: " << image.size() << std::endl;
+  std::cerr << "buffer size: " << buffer_.size() << std::endl;
 
   if (is_buffering_) {
     buffer_.push_back(image.clone());
-    if (buffer_.size() > buffer_size_frames_) {
+    while (buffer_.size() > buffer_size_frames_) {
       buffer_.pop_front();
     }
   }

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -139,7 +139,6 @@ void AutowareScreenCapturePanel::update_buffer_size()
 
 void AutowareScreenCapturePanel::on_timer()
 {
-  // update_buffer_size();
   setFormatDate(ros_time_label_, rclcpp::Clock().now().seconds());
 
   if (!main_window_) return;

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -157,9 +157,6 @@ void AutowareScreenCapturePanel::on_timer()
     static_cast<size_t>(q_image.bytesPerLine()));
 
   size_ = size;
-  std::cerr << "buffer_size_frames_: " << buffer_size_frames_ << std::endl;
-  std::cerr << "image size: " << image.size() << std::endl;
-  std::cerr << "buffer size: " << buffer_.size() << std::endl;
 
   if (is_buffering_) {
     buffer_.push_back(image.clone());

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.cpp
@@ -72,12 +72,32 @@ AutowareScreenCapturePanel::AutowareScreenCapturePanel(QWidget * parent)
     video_cap_layout->addWidget(new QLabel(" [Hz]"));
   }
 
+  // buffer size setting
+  auto * buffer_size_layout = new QHBoxLayout;
+  {
+    buffer_size_layout->addWidget(new QLabel("Buffer Size: "));
+
+    buffer_size_ = new QSpinBox();
+    buffer_size_->setRange(1, 300);  // Maximum 300 seconds buffer
+    buffer_size_->setValue(10);      // Default 10 seconds buffer
+    buffer_size_->setSingleStep(1);
+    buffer_size_layout->addWidget(buffer_size_);
+    buffer_size_layout->addWidget(new QLabel(" [sec]"));
+
+    connect(
+      buffer_size_, SIGNAL(valueChanged(const int)), this, SLOT(on_buffer_size_change(const int)));
+  }
+
   // consider layout
   {
     v_layout->addLayout(cap_layout);
     v_layout->addLayout(video_cap_layout);
+    v_layout->addLayout(buffer_size_layout);
     setLayout(v_layout);
   }
+
+  // Initialize buffer sizes
+  update_buffer_size();
 }
 
 void AutowareScreenCapturePanel::onInitialize()
@@ -99,7 +119,22 @@ void AutowareScreenCapturePanel::on_rate_change([[maybe_unused]] const int rate)
 {
   timer_->cancel();
   create_timer();
+  update_buffer_size();
   RCLCPP_INFO_STREAM(raw_node_->get_logger(), "RATE:" << rate_->value());
+}
+
+void AutowareScreenCapturePanel::on_buffer_size_change(const int seconds)
+{
+  update_buffer_size();
+  RCLCPP_INFO_STREAM(
+    raw_node_->get_logger(),
+    "BUFFER SIZE: " << seconds << "s (" << buffer_size_frames_ << " frames)");
+}
+
+void AutowareScreenCapturePanel::update_buffer_size()
+{
+  // Calculate buffer sizes in frames
+  buffer_size_frames_ = buffer_size_->value() * rate_->value();
 }
 
 void AutowareScreenCapturePanel::on_timer()
@@ -124,7 +159,7 @@ void AutowareScreenCapturePanel::on_timer()
 
   if (is_buffering_) {
     buffer_.push_back(image.clone());
-    if (buffer_.size() > buffer_size_) {
+    if (buffer_.size() > buffer_size_frames_) {
       buffer_.pop_front();
     }
   }
@@ -166,6 +201,16 @@ void AutowareScreenCapturePanel::callback(
 
   if (req->action == Capture::Request::SAVE_BUFFER) {
     res->success = save_buffer(req->file_name);
+    return;
+  }
+
+  if (req->action == Capture::Request::SET_BUFFER) {
+    if (req->buffer_seconds > 0) {
+      buffer_size_->setValue(req->buffer_seconds);
+      res->success = true;
+    } else {
+      res->success = false;
+    }
     return;
   }
 

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -77,7 +77,7 @@ public Q_SLOTS:
 
   void on_rate_change(const int rate);
 
-  void on_buffer_size_change(const int seconds);
+  void on_buffer_size_change(const int buffer_size);
 
 private:
   void create_timer();

--- a/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
+++ b/common/tier4_screen_capture_rviz_plugin/src/screen_capture_panel.hpp
@@ -77,6 +77,8 @@ public Q_SLOTS:
 
   void on_rate_change(const int rate);
 
+  void on_buffer_size_change(const int seconds);
+
 private:
   void create_timer();
 
@@ -98,11 +100,14 @@ private:
 
   void save(const std::deque<cv::Mat> & images, const std::string & file_name);
 
+  void update_buffer_size();
+
   QLabel * ros_time_label_;
   QPushButton * screen_capture_button_ptr_;
   QPushButton * capture_to_mp4_button_ptr_;
   QLineEdit * file_prefix_;
   QSpinBox * rate_;
+  QSpinBox * buffer_size_;
   QMainWindow * main_window_{nullptr};
 
   cv::Size size_;
@@ -113,7 +118,7 @@ private:
 
   // Size of the frame buffer (number of frames to keep in memory)
   // At 10 Hz capture rate, 100 frames correspond to approximately 10 seconds of video
-  const size_t buffer_size_ = 100;
+  size_t buffer_size_frames_{0};
 
   bool is_buffering_{false};
   bool is_recording_{false};

--- a/common/tier4_screen_capture_rviz_plugin/srv/Capture.srv
+++ b/common/tier4_screen_capture_rviz_plugin/srv/Capture.srv
@@ -4,9 +4,12 @@ uint8 STOP_BUFFERING = 2
 uint8 RECORD = 3
 uint8 SAVE = 4
 uint8 SAVE_BUFFER = 5
+uint8 SET_BUFFER=6
+
 
 uint8 action
 string file_name
+uint32 buffer_seconds
 
 ---
 


### PR DESCRIPTION
## Description

add buffer size configuration and update handling
- can change buffer seconds from rviz 
- can change buffer seconds from service communication

## How was this PR tested?

- [x] confirmed saved video duration is changed with rviz plugin bottom


### 1 sec setting and 1 sec video
![image](https://github.com/user-attachments/assets/147ed849-1816-490f-bfc4-867b858a9cfd)

https://github.com/user-attachments/assets/86ecb509-1e38-46d8-b63c-ea2ada53dec7

### 3 sec setting and 1 sec video

![image](https://github.com/user-attachments/assets/7fb3d1ea-9698-4693-a716-b3343238aaf3)

https://github.com/user-attachments/assets/2cf6ca55-edc2-427d-bfc8-94d4d6e33618

- [x] confirmed saved video duration is changed with service communication 

change video duration with following command
```
ros2 service call /debug/capture tier4_screen_capture_rviz_plugin/srv/Capture "{action: 6, buffer_seconds: "5"}"
```
and get 5 sec video

https://github.com/user-attachments/assets/bab80a44-08c0-450e-884e-d978be989ba4



## Notes for reviewers

None.

## Effects on system behavior

None.
