### PR TITLE
ci(spell-check*): add missing .cspell-partial reference and missing dicts

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -17,7 +17,6 @@
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml
-    - source: .github/workflows/spell-check-differential.yaml
     - source: .github/workflows/sync-files.yaml
     - source: .clang-format
     - source: .markdown-link-check.json

--- a/.github/workflows/spell-check-all.yaml
+++ b/.github/workflows/spell-check-all.yaml
@@ -16,4 +16,8 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
           cspell-json-url: https://raw.githubusercontent.com/autowarefoundation/autoware-spell-check-dict/main/.cspell.json
+          local-cspell-json: .cspell-partial.json
+          dict-packages: |
+            https://github.com/autowarefoundation/autoware-spell-check-dict
+            https://github.com/tier4/cspell-dicts
           incremental-files-only: false

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -1,7 +1,3 @@
-# This file is automatically synced from:
-# https://github.com/autowarefoundation/sync-file-templates
-# To make changes, update the source repository and follow the guidelines in its README.
-
 name: spell-check-differential
 
 on:

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/spell-check@v1
         with:
           cspell-json-url: https://raw.githubusercontent.com/autowarefoundation/autoware-spell-check-dict/main/.cspell.json
+          local-cspell-json: .cspell-partial.json
           dict-packages: |
             https://github.com/autowarefoundation/autoware-spell-check-dict
             https://github.com/tier4/cspell-dicts


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware_tools/pull/11 has updated these files but it seems we forgot to add the existing local `.cspell-partial.json` file.

This PR adds that.

Related PR that made us realize this issue:
- https://github.com/autowarefoundation/autoware_tools/pull/231

Additional changes:
- Updated `spell-check-all.yaml` dict-packages to match `spell-check-differential.yaml`.
- Removed from the sync-files.yaml to manage these files manually.

## How was this PR tested?

**Also fixed:**

![image](https://github.com/user-attachments/assets/5252b874-bdfd-4230-b796-ded5c6c69567)

## Notes for reviewers

None.

## Effects on system behavior

None.
