### PR TITLE
feat(autoware_localization_evaluation_scripts): add parse accel

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/CMakeLists.txt
+++ b/localization/autoware_localization_evaluation_scripts/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 install(PROGRAMS
     scripts/analyze_rosbags_parallel.py
     scripts/compare_trajectories.py
-    scripts/extract_pose_from_rosbag.py
+    scripts/extract_values_from_rosbag.py
     scripts/plot_diagnostics.py
     DESTINATION lib/${PROJECT_NAME}
 )

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -31,11 +31,12 @@ def process_directory(
     compare_result_dir.mkdir(parents=True, exist_ok=True)
     diagnostics_result_dir = save_dir / "diagnostics_result"
 
+    # (1) Plot diagnostics
     plot_diagnostics.main(rosbag_path=target_rosbag, save_dir=diagnostics_result_dir)
 
+    # (2) Extract values from rosbag
     save_name_subject = extract_values_from_rosbag.topic_name_to_save_name(topic_subject)
     save_name_reference = extract_values_from_rosbag.topic_name_to_save_name(topic_reference)
-
     extract_values_from_rosbag.main(
         rosbag_path=target_rosbag,
         target_topics=[
@@ -45,9 +46,28 @@ def process_directory(
         save_dir=compare_result_dir,
     )
 
+    # (3) Compare trajectories
     compare_trajectories.main(
         subject_tsv=compare_result_dir / f"{save_name_subject}.tsv",
         reference_tsv=compare_result_dir / f"{save_name_reference}.tsv",
+    )
+
+    # (4) Extract twist
+    twist_result_dir = save_dir / "result_twist"
+    twist_result_dir.mkdir(parents=True, exist_ok=True)
+    extract_values_from_rosbag.main(
+        rosbag_path=target_rosbag,
+        target_topics=["/localization/kinematic_state"],
+        save_dir=twist_result_dir,
+    )
+
+    # (5) Extract acceleration
+    acceleration_result_dir = save_dir / "result_acceleration"
+    acceleration_result_dir.mkdir(parents=True, exist_ok=True)
+    extract_values_from_rosbag.main(
+        rosbag_path=target_rosbag,
+        target_topics=["/localization/acceleration"],
+        save_dir=acceleration_result_dir,
     )
 
 

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -6,7 +6,7 @@ from multiprocessing import Pool
 from pathlib import Path
 
 import compare_trajectories
-import extract_pose_from_rosbag
+import extract_values_from_rosbag
 import plot_diagnostics
 
 
@@ -33,10 +33,10 @@ def process_directory(
 
     plot_diagnostics.main(rosbag_path=target_rosbag, save_dir=diagnostics_result_dir)
 
-    save_name_subject = extract_pose_from_rosbag.topic_name_to_save_name(topic_subject)
-    save_name_reference = extract_pose_from_rosbag.topic_name_to_save_name(topic_reference)
+    save_name_subject = extract_values_from_rosbag.topic_name_to_save_name(topic_subject)
+    save_name_reference = extract_values_from_rosbag.topic_name_to_save_name(topic_reference)
 
-    extract_pose_from_rosbag.main(
+    extract_values_from_rosbag.main(
         rosbag_path=target_rosbag,
         target_topics=[
             topic_subject,

--- a/localization/autoware_localization_evaluation_scripts/scripts/extract_values_from_rosbag.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/extract_values_from_rosbag.py
@@ -22,9 +22,9 @@ def topic_name_to_save_name(topic_name: str) -> str:
 def main(rosbag_path: Path, target_topics: list, save_dir: Path = None) -> None:
     if save_dir is None:
         if rosbag_path.is_dir():  # if specified directory containing db3 files
-            save_dir = rosbag_path.parent / "pose_tsv"
+            save_dir = rosbag_path.parent / "tsv"
         else:  # if specified db3 file directly
-            save_dir = rosbag_path.parent.parent / "pose_tsv"
+            save_dir = rosbag_path.parent.parent / "tsv"
     save_dir.mkdir(parents=True, exist_ok=True)
 
     df_dict = parse_rosbag(str(rosbag_path), target_topics)

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/parse_functions.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/parse_functions.py
@@ -167,7 +167,6 @@ def parse_AccelWithCovarianceStamped(msg):
         "angular.x": msg.accel.accel.angular.x,
         "angular.y": msg.accel.accel.angular.y,
         "angular.z": msg.accel.accel.angular.z,
-        "angular.w": msg.accel.accel.angular.w,
         "covariance_accel_pos.xx": msg.accel.covariance[0],
         "covariance_accel_pos.xy": msg.accel.covariance[1],
         "covariance_accel_pos.xz": msg.accel.covariance[2],

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/parse_functions.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/parse_functions.py
@@ -158,6 +158,31 @@ def parse_Odometry(msg):
     }
 
 
+def parse_AccelWithCovarianceStamped(msg):
+    return {
+        "timestamp": parse_stamp(msg.header.stamp),
+        "linear.x": msg.accel.accel.linear.x,
+        "linear.y": msg.accel.accel.linear.y,
+        "linear.z": msg.accel.accel.linear.z,
+        "angular.x": msg.accel.accel.angular.x,
+        "angular.y": msg.accel.accel.angular.y,
+        "angular.z": msg.accel.accel.angular.z,
+        "angular.w": msg.accel.accel.angular.w,
+        "covariance_accel_pos.xx": msg.accel.covariance[0],
+        "covariance_accel_pos.xy": msg.accel.covariance[1],
+        "covariance_accel_pos.xz": msg.accel.covariance[2],
+        "covariance_accel_pos.yx": msg.accel.covariance[6],
+        "covariance_accel_pos.yy": msg.accel.covariance[7],
+        "covariance_accel_pos.yz": msg.accel.covariance[8],
+        "covariance_accel_pos.zx": msg.accel.covariance[12],
+        "covariance_accel_pos.zy": msg.accel.covariance[13],
+        "covariance_accel_pos.zz": msg.accel.covariance[14],
+        "covariance_accel_angle.x": msg.accel.covariance[21],
+        "covariance_accel_angle.y": msg.accel.covariance[28],
+        "covariance_accel_angle.z": msg.accel.covariance[35],
+    }
+
+
 def parse_Float32Stamped(msg):
     return {
         "timestamp": parse_stamp(msg.stamp),


### PR DESCRIPTION
## Description

This pull request changes the script so that the acceleration topic can be extracted. As a result, the script name has been partially revised.

## How was this PR tested?

```
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py \
    play_rate:=1.0 \
    storage:=mcap \
    scenario_path:=$HOME/driving_log_replayer_v2/localization.yaml
```

The results were

```
~/driving_log_replayer_v2/out/latest$ tree .
.
├── result.jsonl
├── result_archive
│   ├── compare_trajectories
│   │   ├── localization__kinematic_state.tsv
│   │   ├── localization__kinematic_state_result
│   │   │   ├── compare_trajectories.png
│   │   │   ├── relative_pose.png
│   │   │   ├── relative_pose.tsv
│   │   │   └── relative_pose_summary.tsv
│   │   └── localization__reference_kinematic_state.tsv
│   ├── diagnostics_result
│   │   ├── gyro_bias_validator__gyro_bias_validator.png
│   │   ├── gyro_bias_validator__gyro_bias_validator.tsv
│   │   ├── localization__ekf_localizer.png
│   │   ├── localization__ekf_localizer.tsv
│   │   ├── localization__pose_instability_detector.png
│   │   ├── localization__pose_instability_detector.tsv
│   │   ├── localization_error_monitor__ellipse_error_status.png
│   │   ├── localization_error_monitor__ellipse_error_status.tsv
│   │   ├── ndt_scan_matcher__scan_matching_status.png
│   │   └── ndt_scan_matcher__scan_matching_status.tsv
│   ├── result_acceleration
│   │   └── localization__acceleration.tsv
│   └── result_twist
│       └── localization__kinematic_state.tsv
└── result_bag
    ├── metadata.yaml
    └── result_bag_0.mcap
```


Related

- https://github.com/tier4/driving_log_replayer_v2/pull/132

## Notes for reviewers

None.

## Effects on system behavior

None.
