### PR TITLE
feat(build_depends.repos): update autoware_lanelet2_extension v0.7.0

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,4 +1,10 @@
 repositories:
+  # autoware
+  autoware/autoware_cmake:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_cmake.git
+    version: 1.0.2
+    base: true
   # core
   core/autoware_utils:
     type: git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -23,7 +23,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.6.1
+    version: 0.7.0
   # universe
   universe/autoware.universe:
     type: git

--- a/common/autoware_sample_vehicle_description/package.xml
+++ b/common/autoware_sample_vehicle_description/package.xml
@@ -11,7 +11,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
-  <exec_depend>xacro</exec_depend>
+  <depend>xacro</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

[Build error](https://github.com/autowarefoundation/autoware_tools/actions/runs/14583882988/job/40905811547?pr=234) in `autoware_geography_utils`

```
--- stderr: autoware_geography_utils
/__w/autoware_tools/autoware_tools/dependency_ws/core/autoware.core/common/autoware_geography_utils/src/lanelet2_projector.cpp: In function ‘std::unique_ptr<lanelet::Projector> autoware::geography_utils::get_lanelet2_projector(const MapProjectorInfo&)’:
/__w/autoware_tools/autoware_tools/dependency_ws/core/autoware.core/common/autoware_geography_utils/src/lanelet2_projector.cpp:52:42: error: no matching function for call to ‘lanelet::projection::format_v2::TransverseMercatorProjector::TransverseMercatorProjector(<brace-enclosed initializer list>)’
   52 |       origin, projector_info.scale_factor};
      |                                          ^
In file included from /__w/autoware_tools/autoware_tools/dependency_ws/core/autoware.core/common/autoware_geography_utils/src/lanelet2_projector.cpp:18:
/__w/autoware_tools/autoware_tools/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp:36:12: note: candidate: ‘lanelet::projection::format_v2::TransverseMercatorProjector::TransverseMercatorProjector(lanelet::Origin)’
   36 |   explicit TransverseMercatorProjector(Origin origin = Origin({0.0, 0.0}));
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/autoware_tools/autoware_tools/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp:36:12: note:   candidate expects 1 argument, 2 provided
/__w/autoware_tools/autoware_tools/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp:33:7: note: candidate: ‘constexpr lanelet::projection::format_v2::TransverseMercatorProjector::TransverseMercatorProjector(const lanelet::projection::format_v2::TransverseMercatorProjector&)’
   33 | class TransverseMercatorProjector : public Projector
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/autoware_tools/autoware_tools/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp:33:7: note:   candidate expects 1 argument, 2 provided
/__w/autoware_tools/autoware_tools/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp:33:7: note: candidate: ‘constexpr lanelet::projection::format_v2::TransverseMercatorProjector::TransverseMercatorProjector(lanelet::projection::format_v2::TransverseMercatorProjector&&)’
/__w/autoware_tools/autoware_tools/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp:33:7: note:   candidate expects 1 argument, 2 provided
gmake[2]: *** [CMakeFiles/autoware_geography_utils.dir/build.make:104: CMakeFiles/autoware_geography_utils.dir/src/lanelet2_projector.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:157: CMakeFiles/autoware_geography_utils.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< autoware_geography_utils [36.7s, exited with code 2]
```

The [build error](https://github.com/autowarefoundation/autoware_tools/actions/runs/14583882988/job/40905811547?pr=234) was caused by using  v0.6.1 which does not contain this [PR](https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/54).

Therefore, the version was raised to v0.7.0.

https://github.com/autowarefoundation/autoware_lanelet2_extension/compare/0.6.1...0.7.0

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
