### PR TITLE
feat(build_depends.repos): use fixed version for autoware and universe repository

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,7 +3,7 @@ repositories:
   autoware/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
-    version: 1.0.2
+    version: main
     base: true
   # core
   core/autoware_utils:
@@ -29,7 +29,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.7.0
+    version: main
   # universe
   universe/autoware.universe:
     type: git


### PR DESCRIPTION
## Description

- Some packages related to Autoware are version-locked

- Some Autoware-related packages are branch specific
  This situation makes it difficult to pass builds when changes are made that depend on multiple repositories.

To solve this, revert all Autoware and universe packages to branches.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
