### PR TITLE
feat: handle tiny resolution by tp manager and point cloud divider

### DIFF
--- a/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_divider.hpp
+++ b/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_divider.hpp
@@ -120,7 +120,7 @@ public:
     return std::pair<double, double>(grid_size_x_, grid_size_y_);
   }
 
-  void run();
+  void run(bool meta_gen = false);
   void run(const std::vector<std::string> & pcd_names);
 
 private:
@@ -159,7 +159,7 @@ private:
 
   std::string makeFileName(const GridInfo<2> & grid) const;
 
-  PclCloudPtr loadPCD(const std::string & pcd_name);
+  PclCloudPtr loadPCD(const std::string & pcd_name, bool load_all = false);
   void savePCD(const std::string & pcd_name, const pcl::PointCloud<PointT> & cloud);
   void dividePointCloud(const PclCloudPtr & cloud_ptr);
   void paramInitialize();
@@ -171,6 +171,8 @@ private:
   void mergeAndDownsample();
   void mergeAndDownsample(
     const std::string & dir_path, std::list<std::string> & pcd_list, size_t total_point_num);
+
+  void meta_generator(const std::vector<std::string> & pcd_names);
 };
 
 }  // namespace autoware::pointcloud_divider

--- a/map/autoware_pointcloud_divider/launch/pointcloud_divider.launch.xml
+++ b/map/autoware_pointcloud_divider/launch/pointcloud_divider.launch.xml
@@ -8,6 +8,7 @@
   <arg name="output_pcd_dir" description="The path to the folder containing the output PCD files and metadata files"/>
   <arg name="prefix" default="" description="The prefix for output PCD files"/>
   <arg name="point_type" default="point_xyzi" description="The type of map points"/>
+  <arg name="metadata_generate" default="false" description="Generate a metadata file without segmentation the PCDs"/>
 
   <group>
     <node pkg="autoware_pointcloud_divider" exec="autoware_pointcloud_divider_node" name="pointcloud_divider" output="screen">
@@ -20,6 +21,7 @@
       <param name="output_pcd_dir" value="$(var output_pcd_dir)"/>
       <param name="prefix" value="$(var prefix)"/>
       <param name="point_type" value="$(var point_type)"/>
+      <param name="metadata_generate" value="$(var metadata_generate)"/>
     </node>
   </group>
 </launch>

--- a/map/autoware_pointcloud_divider/src/pointcloud_divider_node.cpp
+++ b/map/autoware_pointcloud_divider/src/pointcloud_divider_node.cpp
@@ -35,6 +35,7 @@ PointCloudDivider::PointCloudDivider(const rclcpp::NodeOptions & node_options)
   std::string output_pcd_dir = declare_parameter<std::string>("output_pcd_dir");
   std::string file_prefix = declare_parameter<std::string>("prefix");
   std::string point_type = declare_parameter<std::string>("point_type");
+  bool meta_gen = declare_parameter<bool>("metadata_generate", false);
   // Enter a new line and clear it
   // This is to get rid of the prefix of RCLCPP_INFO
   std::string line_breaker(102, ' ');
@@ -73,7 +74,7 @@ PointCloudDivider::PointCloudDivider(const rclcpp::NodeOptions & node_options)
     pcd_divider_exe.setOutputDir(output_pcd_dir);
     pcd_divider_exe.setPrefix(file_prefix);
 
-    pcd_divider_exe.run();
+    pcd_divider_exe.run(meta_gen);
   } else if (point_type == "point_xyzi") {
     autoware::pointcloud_divider::PCDDivider<pcl::PointXYZI> pcd_divider_exe(get_logger());
 
@@ -84,7 +85,7 @@ PointCloudDivider::PointCloudDivider(const rclcpp::NodeOptions & node_options)
     pcd_divider_exe.setOutputDir(output_pcd_dir);
     pcd_divider_exe.setPrefix(file_prefix);
 
-    pcd_divider_exe.run();
+    pcd_divider_exe.run(meta_gen);
   }
 
   rclcpp::shutdown();

--- a/map/autoware_tp_manager/scripts/tp_collector.py
+++ b/map/autoware_tp_manager/scripts/tp_collector.py
@@ -35,6 +35,7 @@ class TPCollector(Node):
         self.pcd_path = None
         self.yaml_path = None
         self.score_path = None
+        self.map_path_file = None
         self.segment_df = None
         self.segment_dict = {}  # Pairs of 2D coordinate and index
         self.resolution = None
@@ -51,6 +52,7 @@ class TPCollector(Node):
                 os.makedirs(output_path)
 
         self.output_path = output_path
+        self.map_path_file = os.path.join(output_path, "map_path.txt")
         self.resolution = resolution
 
         if not os.path.exists(pcd_map_dir):
@@ -75,27 +77,58 @@ class TPCollector(Node):
         self.yaml_path = os.path.join(self.output_path, "pointcloud_map_metadata.yaml")
 
         if not os.path.exists(self.yaml_path):
-            ds_cmd = (
-                "ros2 launch autoware_pointcloud_divider pointcloud_divider.launch.xml "
-                + "input_pcd_or_dir:="
-                + self.pcd_path
-                + " output_pcd_dir:="
-                + self.output_path
-                + " prefix:=test leaf_size:=0.5"
-                + " grid_size_x:="
-                + str(self.resolution)
-                + " grid_size_y:="
-                + str(self.resolution)
-            )
-            call(ds_cmd, shell=True)
+            if self.resolution >= 5.0:
+                ds_cmd = (
+                    "ros2 launch autoware_pointcloud_divider pointcloud_divider.launch.xml "
+                    + "input_pcd_or_dir:="
+                    + self.pcd_path
+                    + " output_pcd_dir:="
+                    + self.output_path
+                    + " prefix:=test leaf_size:=0.5"
+                    + " grid_size_x:="
+                    + str(self.resolution)
+                    + " grid_size_y:="
+                    + str(self.resolution)
+                )
+                call(ds_cmd, shell=True)
+            else:
+                ds_cmd = (
+                    "ros2 launch autoware_pointcloud_divider pointcloud_divider.launch.xml "
+                    + "input_pcd_or_dir:="
+                    + self.pcd_path
+                    + " output_pcd_dir:="
+                    + self.output_path
+                    + " prefix:=test leaf_size:=0.5"
+                    + " grid_size_x:="
+                    + str(50.0)
+                    + " grid_size_y:="
+                    + str(50.0)
+                )
+                call(ds_cmd, shell=True)
+
+                meta_gen = (
+                    "ros2 launch autoware_pointcloud_divider pointcloud_divider.launch.xml "
+                    + "input_pcd_or_dir:="
+                    + self.pcd_path
+                    + " output_pcd_dir:="
+                    + self.output_path
+                    + " prefix:=test leaf_size:=0.5"
+                    + " grid_size_x:="
+                    + str(self.resolution)
+                    + " grid_size_y:="
+                    + str(self.resolution)
+                    + " metadata_generate:=true"
+                )
+                call(meta_gen, shell=True)
             self.pcd_path = os.path.join(self.output_path, "pointcloud_map.pcd")
+
 
         # Now scan the downsample directory and get the segment list
         with open(self.yaml_path, "r") as f:
             for key, value in yaml.safe_load(f).items():
                 if key != "x_resolution" and key != "y_resolution":
-                    self.segment_df.append([key, 0, 0])
                     seg_key = str(value[0]) + "_" + str(value[1])
+                    self.segment_df.append([seg_key, 0, 0])
                     self.segment_dict[seg_key] = len(self.segment_df) - 1
 
         self.segment_df = np.array(self.segment_df, dtype=object)
@@ -205,6 +238,11 @@ class TPCollector(Node):
                 p = self.output_pose[i]
                 f.write("{0},{1},{2}\n".format(p[3, 0], p[3, 1], p[3, 2]))
         print("Done. Poses are saved at {0}".format(self.trajectory_path))
+
+        print("Saving a path to the map")
+        with open(self.map_path_file, "w") as f:
+            f.write(self.pcd_path)
+        print("Done. The map path is saved at {0}".format(self.map_path_file))
 
     def processing(
         self,


### PR DESCRIPTION
## Description
- Add an option to generate a metadata file by point cloud divider. Sometimes we just want a metadata file without actually dividing PCD files.
- Enable the tp manager to handle tiny resolution, which provides more accurate TP estimation, without sacrifying much processing time.

## How was this PR tested?
- Refer the README
- [Data (Odaiba-rinkai)](https://drive.google.com/drive/u/1/folders/1keAQtGBayqrg4Eju26kLNpA9GRBPRBpu)

## Notes for reviewers

- Run the tp manager to collect average TPs of map segments
- Run the tp checker to compare rosbags TPs with the expected TPs computed from the map TPs
- Visualize the results by rviz2

## Effects on system behavior

None.
