### PR TITLE
feat(planning/perception_reproducer): publish initial ego pose

### DIFF
--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer.py
@@ -21,7 +21,6 @@ import sys
 
 from PyQt5.QtWidgets import QApplication
 from geometry_msgs.msg import PoseStamped
-from geometry_msgs.msg import PoseWithCovarianceStamped
 from perception_replayer_common import PerceptionReplayerCommon
 import rclpy
 from time_manager_widget import TimeManagerWidget
@@ -118,51 +117,7 @@ class PerceptionReplayer(PerceptionReplayerCommon):
         ego_odom = self.find_ego_odom_by_timestamp(self.bag_timestamp)
         if not ego_odom:
             return
-
-        recorded_ego_pose = PoseWithCovarianceStamped()
-        recorded_ego_pose.header.stamp = self.get_clock().now().to_msg()
-        recorded_ego_pose.header.frame_id = "map"
-        recorded_ego_pose.pose.pose = ego_odom.pose.pose
-        recorded_ego_pose.pose.covariance = [
-            0.25,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.25,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.06853892326654787,
-        ]
-
-        self.recorded_ego_pub_as_initialpose.publish(recorded_ego_pose)
+        self.publish_initial_ego_pose(ego_odom)
         print("Published recorded ego pose as /initialpose")
 
     def publish_goal(self):

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_replayer_common.py
@@ -73,7 +73,7 @@ class PerceptionReplayerCommon(Node):
         self.pointcloud_pub = self.create_publisher(
             PointCloud2, "/perception/obstacle_segmentation/pointcloud", 1
         )
-        self.recorded_ego_pub_as_initialpose = self.create_publisher(
+        self.initial_ego_pose_publisher = self.create_publisher(
             PoseWithCovarianceStamped, "/initialpose", 1
         )
 
@@ -222,3 +222,48 @@ class PerceptionReplayerCommon(Node):
 
     def find_ego_odom_by_timestamp(self, timestamp):
         return self.binary_search(self.rosbag_ego_odom_data, timestamp)
+
+    def publish_initial_ego_pose(self, ego_odom):
+        initial_pose = PoseWithCovarianceStamped()
+        initial_pose.header.stamp = self.get_clock().now().to_msg()
+        initial_pose.header.frame_id = "map"
+        initial_pose.pose.pose = ego_odom.pose.pose
+        initial_pose.pose.covariance = [
+            0.25,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.25,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.06853892326654787,
+        ]
+        self.initial_ego_pose_publisher.publish(initial_pose)

--- a/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_replayer/perception_reproducer.py
@@ -99,7 +99,8 @@ class PerceptionReproducer(PerceptionReplayerCommon):
             self.pointcloud_pub.publish(pointcloud_msg)
 
         if not self.ego_odom:
-            print("No ego odom found.")
+            print("No ego odom found. Setting initial pose from the first recorded ego pose.")
+            self.publish_initial_ego_pose(self.rosbag_ego_odom_data[0][1])
             return
 
         ego_pose = self.ego_odom.pose.pose


### PR DESCRIPTION
## Description

- Define common function to publish an initial pose.
- new feature: with `perception_reproducer.py`, if the ego pose is not set, publish the first recorded one.

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Effects on system behavior

None.
