### PR TITLE
feat(static_centerline_generator): add goal modify function

### DIFF
--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(glog REQUIRED)
 
 rosidl_generate_interfaces(
   autoware_static_centerline_generator
@@ -33,7 +34,7 @@ if(${rosidl_cmake_VERSION} VERSION_LESS 2.5.0)
 else()
     rosidl_get_typesupport_target(
             cpp_typesupport_target autoware_static_centerline_generator "rosidl_typesupport_cpp")
-    target_link_libraries(main "${cpp_typesupport_target}")
+    target_link_libraries(main "${cpp_typesupport_target}" glog::glog)
 endif()
 
 ament_auto_package(

--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -56,6 +56,14 @@ if(BUILD_TESTING)
     test/test_static_centerline_generator_launch.test.py
     TIMEOUT "30"
   )
+  add_launch_test(
+    test/test_static_centerline_generator_launch_path_generator.test.py
+    TIMEOUT "30"
+  )
+  add_launch_test(
+    test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
+    TIMEOUT "30"
+  )
   install(DIRECTORY
     test/data/
     DESTINATION share/${PROJECT_NAME}/test/data/

--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -67,7 +67,7 @@ Only `path_generator` or `fixed_goal_planner` can be entered for `<goal_method>`
 If used in `fixed_goal_planner`, `refine_goal_search_radius_range` cna be entered from `search-radius-range`.
 
 > [!WARNING]
-> If the start pose is off the center of the lane, it is necessary to manually embed a centerline that smoothly connects the start pose and the start lane in advance using VMB, etc. 
+> If the start pose is off the center of the lane, it is necessary to manually embed a centerline that smoothly connects the start pose and the start lane in advance using VMB, etc.
 
 ## Visualization
 

--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -46,15 +46,28 @@ The optimized centerline can be generated from the command line interface by des
 - `<input-osm-path>`
 - `<output-osm-path>` (not mandatory)
 - `<start-lanelet-id>`
+- `<start-pose>` (not mandatory)
 - `<end-lanelet-id>`
+- `<end-pose>` (not mandatory)
 - `<vehicle-model>`
+- `<goal-method>` (not mandatory, `path_generator` or `fixed_goal_planner` only)
+- `<search-radius-range>` (not mandatory)
 
 ```sh
-ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> end_lanelet_id:=<end-lane-id> vehicle_model:=<vehicle-model>
+ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> goal_pose:=<goal-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method> search_radius_range:=<search-radius-range>
 ```
 
 The default output map path containing the optimized centerline locates `/tmp/lanelet2_map.osm`.
 If you want to change the output map path, you can remap the path by designating `<output-osm-path>`.
+
+By specifying `start-pose`, `goal-pose`, and `goal-method`, the centerline from `start-pose` to `goal-pose` can be embedded.
+`<start-pose>`, `<goal-pose>` are entered like `[position.x, position.y, position.z, orientation.x, orientation.y, orientation.z, orientation.w]` with double type.
+In order to run smoothly to the goal pose, `goal-method` is used.
+Only `path_generator` or `fixed_goal_planner` can be entered for `<goal_method>`.
+If used in `fixed_goal_planner`, `refine_goal_search_radius_range` cna be entered from `search-radius-range`.
+
+> [!WARNING]
+> If the start pose is off the center of the lane, it is necessary to manually embed a centerline that smoothly connects the start pose and the start lane in advance using VMB, etc. 
 
 ## Visualization
 

--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -50,11 +50,10 @@ The optimized centerline can be generated from the command line interface by des
 - `<end-lanelet-id>`
 - `<end-pose>` (not mandatory)
 - `<vehicle-model>`
-- `<goal-method>` (not mandatory, `path_generator` or `fixed_goal_planner` only)
-- `<search-radius-range>` (not mandatory)
+- `<goal-method>` (not mandatory, `path_generator` or `behavior_path_planner` only)
 
 ```sh
-ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> goal_pose:=<goal-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method> search_radius_range:=<search-radius-range>
+ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> goal_pose:=<goal-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method>
 ```
 
 The default output map path containing the optimized centerline locates `/tmp/lanelet2_map.osm`.
@@ -63,8 +62,7 @@ If you want to change the output map path, you can remap the path by designating
 By specifying `start-pose`, `goal-pose`, and `goal-method`, the centerline from `start-pose` to `goal-pose` can be embedded.
 `<start-pose>`, `<goal-pose>` are entered like `[position.x, position.y, position.z, orientation.x, orientation.y, orientation.z, orientation.w]` with double type.
 In order to run smoothly to the goal pose, `goal-method` is used.
-Only `path_generator` or `fixed_goal_planner` can be entered for `<goal_method>`.
-If used in `fixed_goal_planner`, `refine_goal_search_radius_range` cna be entered from `search-radius-range`.
+Only `path_generator` or `behavior_path_planner` can be entered for `<goal_method>`.
 
 > [!WARNING]
 > If the start pose is off the center of the lane, it is necessary to manually embed a centerline that smoothly connects the start pose and the start lane in advance using VMB, etc.

--- a/planning/autoware_static_centerline_generator/config/static_centerline_generator.param.yaml
+++ b/planning/autoware_static_centerline_generator/config/static_centerline_generator.param.yaml
@@ -7,3 +7,6 @@
     validation:
       dist_threshold_to_road_border: 0.0
       max_steer_angle_margin: 0.0 # [rad] NOTE: Positive value makes max steer angle threshold to decrease.
+
+    debug:
+      wait_time_during_planning_iteration: 300 # [ms]

--- a/planning/autoware_static_centerline_generator/config/static_centerline_generator.param.yaml
+++ b/planning/autoware_static_centerline_generator/config/static_centerline_generator.param.yaml
@@ -9,4 +9,4 @@
       max_steer_angle_margin: 0.0 # [rad] NOTE: Positive value makes max steer angle threshold to decrease.
 
     debug:
-      wait_time_during_planning_iteration: 300 # [ms]
+      wait_time_during_planning_iteration: 10 # [ms]

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -14,8 +14,7 @@
   <arg name="start_pose" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"/>
   <arg name="end_lanelet_id" default=""/>
   <arg name="end_pose" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"/>
-  <arg name="goal_method" default=""/>
-  <arg name="search_radius_range" default="-1.0"/>
+  <arg name="goal_method" default="None"/>
 
   <!-- mandatory arguments when mode is GUI -->
   <arg name="bag_filename" default="bag.db3"/>
@@ -75,7 +74,6 @@
     <param name="end_lanelet_id" value="$(var end_lanelet_id)"/>
     <param name="end_pose" value="$(var end_pose)"/>
     <param name="goal_method" value="$(var goal_method)"/>
-    <param name="search_radius_range" value="$(var search_radius_range)"/>
     <!-- common param -->
     <param from="$(var common_param)"/>
     <param from="$(var nearest_search_param)"/>

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -99,5 +99,5 @@
   </group>
 
   <!-- rviz -->
-  <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share autoware_static_centerline_generator)/rviz/static_centerline_generator.rviz" if="$(var rviz)"/>
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share autoware_static_centerline_generator)/rviz/static_centerline_generator.rviz" if="$(var rviz)" respawn="true"/>
 </launch>

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -11,7 +11,11 @@
   <arg name="lanelet2_input_file_path" default=""/>
   <arg name="lanelet2_output_file_path" default="/tmp/autoware_static_centerline_generator/lanelet2_map.osm"/>
   <arg name="start_lanelet_id" default=""/>
+  <arg name="start_pose" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"/>
   <arg name="end_lanelet_id" default=""/>
+  <arg name="end_pose" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"/>
+  <arg name="goal_method" default=""/>
+  <arg name="search_radius_range" default="-1.0"/>
 
   <!-- mandatory arguments when mode is GUI -->
   <arg name="bag_filename" default="bag.db3"/>
@@ -33,6 +37,7 @@
     name="behavior_velocity_planner_param"
     default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml"
   />
+  <arg name="path_generator_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/path_generator/path_generator.param.yaml"/>
   <arg name="path_smoother_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml"/>
   <arg name="path_optimizer_param" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning/autoware_path_optimizer/path_optimizer.param.yaml"/>
   <arg name="mission_planner_param" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
@@ -66,7 +71,11 @@
     <param name="lanelet2_input_file_path" value="$(var lanelet2_input_file_path)"/>
     <param name="lanelet2_output_file_path" value="$(var lanelet2_output_file_path)"/>
     <param name="start_lanelet_id" value="$(var start_lanelet_id)"/>
+    <param name="start_pose" value="$(var start_pose)"/>
     <param name="end_lanelet_id" value="$(var end_lanelet_id)"/>
+    <param name="end_pose" value="$(var end_pose)"/>
+    <param name="goal_method" value="$(var goal_method)"/>
+    <param name="search_radius_range" value="$(var search_radius_range)"/>
     <!-- common param -->
     <param from="$(var common_param)"/>
     <param from="$(var nearest_search_param)"/>
@@ -74,6 +83,7 @@
     <param from="$(var map_loader_param)"/>
     <param from="$(var behavior_path_planner_param)"/>
     <param from="$(var behavior_velocity_planner_param)"/>
+    <param from="$(var path_generator_param)"/>
     <param from="$(var path_smoother_param)"/>
     <param from="$(var path_optimizer_param)"/>
     <param from="$(var mission_planner_param)"/>

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -15,8 +15,8 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
-  <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_behavior_path_goal_planner_module</depend>
+  <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
@@ -26,8 +26,8 @@
   <depend>autoware_mission_planner_universe</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>
-  <depend>autoware_path_optimizer</depend>
   <depend>autoware_path_generator</depend>
+  <depend>autoware_path_optimizer</depend>
   <depend>autoware_path_smoother</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -35,6 +35,7 @@
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
+  <depend>glog</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_map_msgs</depend>

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -16,6 +16,7 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_behavior_path_planner_common</depend>
+  <depend>autoware_behavior_path_goal_planner_module</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
@@ -26,6 +27,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>
   <depend>autoware_path_optimizer</depend>
+  <depend>autoware_path_generator</depend>
   <depend>autoware_path_smoother</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/autoware_static_centerline_generator/rviz/static_centerline_generator.rviz
+++ b/planning/autoware_static_centerline_generator/rviz/static_centerline_generator.rviz
@@ -258,6 +258,52 @@ Visualization Manager:
             Constant Color: false
             Scale: 0.30000001192092896
             Value: true
+        - Class: rviz_plugins/Path
+          Color Border Vel Max: 3
+          Enabled: true
+          Name: Iterative Path
+          Topic:
+            Depth: 5
+            Durability Policy: Transient Local
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /static_centerline_generator/debug/iterative_path
+          Value: false
+          View Drivable Area:
+            Alpha: 0.9990000128746033
+            Color: 0; 148; 205
+            Value: false
+            Width: 0.30000001192092896
+          View Footprint:
+            Alpha: 1
+            Color: 230; 130; 130
+            Offset from BaseLink: 0
+            Rear Overhang: 1.0299999713897705
+            Value: true
+            Vehicle Length: 4.769999980926514
+            Vehicle Width: 1.8300000429153442
+          View Path:
+            Alpha: 1
+            Color: 0; 0; 0
+            Constant Color: false
+            Value: false
+            Width: 2
+          View Point:
+            Alpha: 1
+            Color: 0; 60; 255
+            Offset: 0
+            Radius: 0.10000000149011612
+            Value: false
+          View Text Velocity:
+            Scale: 0.30000001192092896
+            Value: false
+          View Velocity:
+            Alpha: 1
+            Color: 0; 0; 0
+            Constant Color: false
+            Scale: 0.30000001192092896
+            Value: false
         - Class: rviz_plugins/Trajectory
           Color Border Vel Max: 3
           Enabled: true

--- a/planning/autoware_static_centerline_generator/rviz/static_centerline_generator.rviz
+++ b/planning/autoware_static_centerline_generator/rviz/static_centerline_generator.rviz
@@ -258,6 +258,106 @@ Visualization Manager:
             Constant Color: false
             Scale: 0.30000001192092896
             Value: true
+        - Class: rviz_plugins/Trajectory
+          Color Border Vel Max: 3
+          Enabled: true
+          Name: Iterative Smoothed Trajectory
+          Topic:
+            Depth: 5
+            Durability Policy: Transient Local
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /static_centerline_generator/debug/iterative_smoothed_trajectory
+          Value: true
+          View Footprint:
+            Alpha: 1
+            Color: 230; 200; 120
+            Offset from BaseLink: 0
+            Rear Overhang: 0.375
+            Value: true
+            Vehicle Length: 2.240000009536743
+            Vehicle Width: 1.100000023841858
+          View Path:
+            Alpha: 1
+            Constant Width: false
+            Fade Out Distance: 0
+            Max Velocity Color: 0; 230; 120
+            Mid Velocity Color: 32; 138; 174
+            Min Velocity Color: 63; 46; 227
+            Value: false
+            Width: 2
+          View Point:
+            Alpha: 1
+            Color: 0; 60; 255
+            Offset: 0
+            Radius: 0.10000000149011612
+            Value: false
+          View Text Slope:
+            Scale: 0.30000001192092896
+            Value: false
+          View Text Time:
+            Scale: 0.30000001192092896
+            Value: false
+          View Text Velocity:
+            Scale: 0.30000001192092896
+            Value: false
+          View Velocity:
+            Alpha: 1
+            Color: 0; 0; 0
+            Constant Color: false
+            Scale: 0.30000001192092896
+            Value: false
+        - Class: rviz_plugins/Trajectory
+          Color Border Vel Max: 3
+          Enabled: true
+          Name: Iterative Optimized Trajectory
+          Topic:
+            Depth: 5
+            Durability Policy: Transient Local
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /static_centerline_generator/debug/iterative_optimized_trajectory
+          Value: true
+          View Footprint:
+            Alpha: 1
+            Color: 100; 150; 230
+            Offset from BaseLink: 0
+            Rear Overhang: 0.375
+            Value: true
+            Vehicle Length: 2.240000009536743
+            Vehicle Width: 1.100000023841858
+          View Path:
+            Alpha: 1
+            Constant Width: false
+            Fade Out Distance: 0
+            Max Velocity Color: 0; 230; 120
+            Mid Velocity Color: 32; 138; 174
+            Min Velocity Color: 63; 46; 227
+            Value: false
+            Width: 2
+          View Point:
+            Alpha: 1
+            Color: 0; 60; 255
+            Offset: 0
+            Radius: 0.10000000149011612
+            Value: false
+          View Text Slope:
+            Scale: 0.30000001192092896
+            Value: false
+          View Text Time:
+            Scale: 0.30000001192092896
+            Value: false
+          View Text Velocity:
+            Scale: 0.30000001192092896
+            Value: false
+          View Velocity:
+            Alpha: 1
+            Color: 0; 0; 0
+            Constant Color: false
+            Scale: 0.30000001192092896
+            Value: false
         - Class: rviz_default_plugins/MarkerArray
           Enabled: true
           Name: MarkerArray

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::static_centerline_generator

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -103,7 +103,7 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
     node, "refine_goal_search_radius_range");
 
   // get start pose, goal pose, and goal method
-  getGoalPlanPlameters(node, *route_handler_ptr, route_lane_ids);
+  getGoalPlanParameters(node, *route_handler_ptr, route_lane_ids);
 
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = [&]() {
@@ -177,7 +177,7 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
         .pose;
 
     // create path_with_lane_id by goal_method
-    const PathWithLaneId path_with_lane_id_poins = goalPathGenerate(
+    const PathWithLaneId path_with_lane_id_points = goalPathGenerate(
       raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, virtual_ego_pose);
 
     // convert trajectory
@@ -222,7 +222,7 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   return whole_optimized_traj_points;
 }
 
-void OptimizationTrajectoryBasedCenterline::getGoalPlanPlameters(
+void OptimizationTrajectoryBasedCenterline::getGoalPlanParameters(
   rclcpp::Node & node, const RouteHandler & route_handler,
   const std::vector<lanelet::Id> & route_lane_ids)
 {
@@ -260,7 +260,6 @@ OptimizationTrajectoryBasedCenterline::createRoutePtr(
   for (size_t i = 1; i < raw_path.points.size(); i++) {
     const auto start_point = raw_path.points.at(i - 1);
     const auto goal_point = raw_path.points.at(i);
-    // std::cerr << "iketa goal_pose" << goal_point.pose.position.x << std::endl;
     lanelet::ConstLanelets path_lanelets;
     if (!route_handler_ptr->planPathLaneletsBetweenCheckpoints(
           start_point.pose, goal_point.pose, &path_lanelets)) { /* do nothing */
@@ -276,7 +275,7 @@ OptimizationTrajectoryBasedCenterline::createRoutePtr(
   std::vector<autoware_planning_msgs::msg::LaneletSegment> route_sections =
     route_handler_ptr->createMapSegments(all_lanelets);
 
-  // set nessary data
+  // set necessary data
   route_ptr_->header.frame_id = "map";
   route_ptr_->set__start_pose(start_pose);
   route_ptr_->set__goal_pose(goal_pose);

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -260,6 +260,13 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
       whole_optimized_traj_points.push_back(valid_optimized_traj_point);
     }
 
+    // 5. finish if the valid_optimized_traj_point contains the goal.
+    const double dist_to_goal =
+      autoware::universe_utils::calcDistance2d(valid_optimized_traj_points.back(), route.goal_pose);
+    if (dist_to_goal < 0.1) {
+      break;
+    }
+
     // wait for debugging purpose to visualize the iteration.
     if (1e-5 < static_cast<double>(wait_time_during_planning_iteration)) {
       std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_during_planning_iteration));

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -103,9 +103,9 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 
   // update route_handler
   const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr, route_lane_ids);
-  route_ptr_ = create_route_ptr(route_handler_ptr, start_pose, goal_pose);
+  route_ptr = create_route(route_handler_ptr, start_pose, goal_pose);
   route_handler_ptr->setRouteLanelets(route_lanelets);
-  route_handler_ptr->setRoute(*route_ptr_);
+  route_handler_ptr->setRoute(*route_ptr);
 
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = [&]() {
@@ -144,7 +144,7 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
 {
   // create path_with_lane_id by goal_method
   const PathWithLaneId path_with_lane_id_points = modify_goal_connection(
-    raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose);
+    raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
 
   // convert trajectory
   const auto traj_points = convert_to_trajectory_points(path_with_lane_id_points);
@@ -177,7 +177,7 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
 
     // create path_with_lane_id by goal_method
     const auto path_with_lane_id_points = modify_goal_connection(
-      raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, virtual_ego_pose);
+      raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, virtual_ego_pose, goal_pose);
 
     // convert trajectory
     const auto traj_points = convert_to_trajectory_points(path_with_lane_id_points);
@@ -239,25 +239,14 @@ std::pair<Pose, Pose> OptimizationTrajectoryBasedCenterline::get_start_and_goal_
   return {start_pose, goal_pose};
 }
 
-<<<<<<< HEAD
-std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>
-OptimizationTrajectoryBasedCenterline::create_route(
-  const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr,
-  const Pose & start_pose, const Pose & goal_pose) const
-{
-  // create route_ptr
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> route_ptr =
-    std::make_shared<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>();
-=======
 std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute>
 OptimizationTrajectoryBasedCenterline::create_route(
   std::shared_ptr<RouteHandler> & route_handler_ptr,
-  const Pose & start_pose, const Pose & goal_pose) const
+  const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose) const
 {
-  // create route_ptr_
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr_ =
+  // create route_ptr
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr =
     std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
->>>>>>> c5d1573 (refactoring version 1)
 
   lanelet::ConstLanelets all_lanelets;
   lanelet::ConstLanelets path_lanelets;
@@ -283,15 +272,9 @@ OptimizationTrajectoryBasedCenterline::create_route(
 }
 
 std::shared_ptr<autoware::path_generator::PathGenerator>
-<<<<<<< HEAD
-OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
-  const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr)
-  const
-=======
 OptimizationTrajectoryBasedCenterline::create_path_generator_node(
-  const Pose start_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr) const
->>>>>>> c5d1573 (refactoring version 1)
+  const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr) const
 {
   const auto path_generator_node =
     std::make_shared<autoware::path_generator::PathGenerator>(create_node_options());
@@ -299,24 +282,15 @@ OptimizationTrajectoryBasedCenterline::create_path_generator_node(
   // set data in path_generator
   autoware::path_generator::PathGenerator::InputData path_generator_input;
   path_generator_input.lanelet_map_bin_ptr = map_bin_ptr;
-<<<<<<< HEAD
   path_generator_input.odometry_ptr = utils::convert_to_odometry(current_pose);
   path_generator_input.route_ptr = route_ptr;
-=======
-  path_generator_input.odometry_ptr = utils::convert_to_odometry(start_pose);
-  path_generator_input.route_ptr = route_ptr_;
->>>>>>> c5d1573 (refactoring version 1)
   path_generator_node->set_planner_data(path_generator_input);
 
   return path_generator_node;
 }
 
 std::shared_ptr<autoware::behavior_path_planner::PlannerData>
-<<<<<<< HEAD
 OptimizationTrajectoryBasedCenterline::create_behavior_path_planner_data(
-=======
-OptimizationTrajectoryBasedCenterline::create_planner_data(
->>>>>>> c5d1573 (refactoring version 1)
   std::shared_ptr<RouteHandler> & route_handler_ptr) const
 {
   // create planner_data
@@ -351,47 +325,26 @@ path_generator::Params OptimizationTrajectoryBasedCenterline::create_params(
   return param_listener_->get_params();
 }
 
-<<<<<<< HEAD
 PathWithLaneId OptimizationTrajectoryBasedCenterline::modify_goal_connection(
-=======
-PathWithLaneId OptimizationTrajectoryBasedCenterline::goal_path_generate(
->>>>>>> c5d1573 (refactoring version 1)
   const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
   std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-  const Pose & start_pose, const Pose & goal_pose) const
+  const Pose & current_pose, const Pose & goal_pose) const
 {
   if (goal_method == "None") {
     // No goal correction
-<<<<<<< HEAD
     return raw_path_with_lane_id;
-=======
-    path_with_lane_id_points = raw_path_with_lane_id;
-  } else if (goal_method == "path_generator") {
-    auto path_generator_node = create_path_generator_node(start_pose, map_bin_ptr);
-    auto params = create_params(path_generator_node);
-    path_with_lane_id_points =
-      *(path_generator_node->generate_path(raw_path.points[0].pose, params));
-  } else if (goal_method == "behavior_path_planner") {
-    auto planner_data_ = create_planner_data(route_handler_ptr);
-    auto behavior_path_planner = create_fixed_goal_planner(raw_path_with_lane_id);
-    path_with_lane_id_points = behavior_path_planner->plan(planner_data_).path;
-  } else {
-    throw std::logic_error(
-      "The goal_method is not supported in autoware_static_centerline_generator.");
->>>>>>> c5d1573 (refactoring version 1)
   }
 
   // NOTE: The route pointer has to be created to reflect start pose and goal pose
-  auto route_ptr = create_route(raw_path, route_handler_ptr);
+  auto route_ptr = create_route(route_handler_ptr, current_pose, goal_pose);
   if (goal_method == "path_generator") {
-    auto path_generator_node = createPathGeneratorNode(current_pose, map_bin_ptr, route_ptr);
-    const auto params = createParams(path_generator_node);
+    auto path_generator_node = create_path_generator_node(current_pose, map_bin_ptr, route_ptr);
+    const auto params = create_params(path_generator_node);
     return *(path_generator_node->generate_path(raw_path.points[0].pose, params));
   }
   if (goal_method == "behavior_path_planner") {
-    route_handler_ptr->setRoute(*route_ptr);
     const auto planner_data = create_behavior_path_planner_data(route_handler_ptr);
-    auto fixed_goal_planner = createFixedGoalPlanner(raw_path_with_lane_id);
+    auto fixed_goal_planner = create_fixed_goal_planner(raw_path_with_lane_id);
     return fixed_goal_planner->plan(planner_data).path;
   }
   throw std::logic_error(

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -23,13 +23,15 @@
 #include "autoware/path_smoother/elastic_band_smoother.hpp"
 #include "autoware/universe_utils/ros/parameter.hpp"
 #include "autoware_lanelet2_extension/utility/query.hpp"
-#include "autoware_test_utils/autoware_test_utils.hpp"
+#include "autoware_utils_geometry/pose_deviation.hpp"
 #include "static_centerline_generator_node.hpp"
 #include "utils.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -70,14 +72,26 @@ std::vector<TrajectoryPoint> convert_to_trajectory_points(const PathWithLaneId &
 
   return autoware::motion_utils::convertToTrajectoryPointArray(traj);
 }
+
+std_msgs::msg::Header create_header(const rclcpp::Time & now)
+{
+  std_msgs::msg::Header header;
+  header.frame_id = "map";
+  header.stamp = now;
+  return header;
+}
 }  // namespace
 
 OptimizationTrajectoryBasedCenterline::OptimizationTrajectoryBasedCenterline(rclcpp::Node & node)
 {
-  pub_raw_path_with_lane_id_ =
-    node.create_publisher<PathWithLaneId>("input_centerline", utils::create_transient_local_qos());
+  pub_raw_path_with_lane_id_ = node.create_publisher<PathWithLaneId>(
+    "~/input_centerline", utils::create_transient_local_qos());
   pub_raw_path_ =
-    node.create_publisher<Path>("debug/raw_centerline", utils::create_transient_local_qos());
+    node.create_publisher<Path>("~/debug/raw_centerline", utils::create_transient_local_qos());
+  pub_iterative_smoothed_traj_ = node.create_publisher<Trajectory>(
+    "~/debug/iterative_smoothed_trajectory", utils::create_transient_local_qos());
+  pub_iterative_optimized_traj_ = node.create_publisher<Trajectory>(
+    "~/debug/iterative_optimized_trajectory", utils::create_transient_local_qos());
 }
 
 std::vector<TrajectoryPoint>
@@ -139,6 +153,16 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   const Pose & start_pose, const Pose & goal_pose) const
 {
+  const int wait_time_during_planning_iteration =
+    autoware::universe_utils::getOrDeclareParameter<int>(
+      node, "debug.wait_time_during_planning_iteration");
+
+  // convert to trajectory points
+  // const auto raw_traj_points = [&]() {
+  //   const auto raw_traj = convert_to_trajectory(raw_path);
+  //   return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
+  // }();
+
   // create path_with_lane_id by goal_method
   const PathWithLaneId path_with_lane_id_points = modify_goal_connection(
     node, raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
@@ -183,6 +207,8 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
     // smooth trajectory by elastic band in the autoware_path_smoother package
     const auto smoothed_traj_points =
       eb_path_smoother_ptr->smoothTrajectory(traj_points, virtual_ego_pose);
+    pub_iterative_smoothed_traj_->publish(autoware::motion_utils::convertToTrajectory(
+      smoothed_traj_points, create_header(node.get_clock()->now())));
 
     // road collision avoidance by model predictive trajectory in the autoware_path_optimizer
     // package
@@ -190,16 +216,19 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
       raw_path.header, smoothed_traj_points, raw_path.left_bound, raw_path.right_bound,
       virtual_ego_pose};
     const auto optimized_traj_points = mpt_optimizer_ptr->optimizeTrajectory(planner_data);
-
     if (!optimized_traj_points) {
       return whole_optimized_traj_points;
     }
+    pub_iterative_optimized_traj_->publish(autoware::motion_utils::convertToTrajectory(
+      *optimized_traj_points, create_header(node.get_clock()->now())));
 
     // connect the previously and currently optimized trajectory points
     for (size_t j = 0; j < whole_optimized_traj_points.size(); ++j) {
       const double dist = autoware::universe_utils::calcDistance2d(
         whole_optimized_traj_points.at(j), optimized_traj_points->front());
-      if (dist < 0.5) {
+      const double yaw = autoware_utils_geometry::calc_yaw_deviation(
+        whole_optimized_traj_points.at(j).pose, optimized_traj_points->front().pose);
+      if (dist < 0.5 && std::abs(yaw) < 0.17) {
         const std::vector<TrajectoryPoint> extracted_whole_optimized_traj_points{
           whole_optimized_traj_points.begin(),
           whole_optimized_traj_points.begin() + std::max(j, 1UL) - 1};
@@ -210,7 +239,18 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
     for (size_t j = 0; j < optimized_traj_points->size(); ++j) {
       whole_optimized_traj_points.push_back(optimized_traj_points->at(j));
     }
+
+    // wait for debugging purpose to visualize the iteration.
+    if (1e-5 < static_cast<double>(wait_time_during_planning_iteration)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(wait_time_during_planning_iteration));
+    }
   }
+
+  // remove the visualization of iterative trajectories
+  Trajectory empty_traj;
+  empty_traj.header = create_header(node.get_clock()->now());
+  pub_iterative_smoothed_traj_->publish(empty_traj);
+  pub_iterative_optimized_traj_->publish(empty_traj);
 
   return whole_optimized_traj_points;
 }

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -84,12 +84,8 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
   rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr,
   const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr)
 {
-  // set route lanelets
-  const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr, route_lane_ids);
-  route_handler_ptr->setRouteLanelets(route_lanelets);
-
-  // get ego nearest search parameters, resample interval, and search radius range in
-  // behavior_path_planner
+  // get ego nearest search parameters, resample interval, search radius range, and goal method
+  // in behavior_path_planner
   const double ego_nearest_dist_threshold =
     autoware::universe_utils::getOrDeclareParameter<double>(node, "ego_nearest_dist_threshold");
   const double ego_nearest_yaw_threshold =
@@ -100,9 +96,16 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
     autoware::universe_utils::getOrDeclareParameter<double>(node, "behavior_output_path_interval");
   refine_goal_search_radius_range = autoware::universe_utils::getOrDeclareParameter<double>(
     node, "refine_goal_search_radius_range");
+  goal_method = autoware::universe_utils::getOrDeclareParameter<std::string>(node, "goal_method");
 
   // get start pose, goal pose, and goal method
-  getGoalPlanParameters(node, *route_handler_ptr, route_lane_ids);
+  const auto [start_pose, goal_pose] = get_start_and_goal_pose(node, *route_handler_ptr, route_lane_ids);
+
+  // update route_handler
+  const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr, route_lane_ids);
+  route_ptr_ = create_route_ptr(route_handler_ptr, start_pose, goal_pose);
+  route_handler_ptr->setRouteLanelets(route_lanelets);
+  route_handler_ptr->setRoute(*route_ptr_);
 
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = [&]() {
@@ -125,7 +128,7 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 
   // smooth trajectory and road collision avoidance
   const auto optimized_traj_points =
-    optimize_trajectory(raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr);
+    optimize_trajectory(raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
   RCLCPP_INFO(
     node.get_logger(),
     "Smoothed trajectory and made it collision free with the road and published.");
@@ -136,7 +139,8 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_trajectory(
   const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
   std::shared_ptr<RouteHandler> & route_handler_ptr,
-  LaneletMapBin::ConstSharedPtr & map_bin_ptr) const
+  LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+  const Pose & start_pose, const Pose & goal_pose) const
 {
   // create path_with_lane_id by goal_method
   const PathWithLaneId path_with_lane_id_points = modify_goal_connection(
@@ -213,53 +217,57 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   return whole_optimized_traj_points;
 }
 
-void OptimizationTrajectoryBasedCenterline::getGoalPlanParameters(
+std::pair<Pose, Pose> OptimizationTrajectoryBasedCenterline::get_start_and_goal_pose(
   rclcpp::Node & node, const RouteHandler & route_handler,
-  const std::vector<lanelet::Id> & route_lane_ids)
+  const std::vector<lanelet::Id> & route_lane_ids) const
 {
   // get start pose, goal pose, goal method, and search radius range
   const std::vector<double> start_pose_input =
     autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "start_pose");
   const bool start_pose_check = std::all_of(
     start_pose_input.begin(), start_pose_input.end(), [](double x) { return x == 0.0; });
-  if (start_pose_check) {
-    // optimize centerline inside the lane
-    start_pose = utils::get_center_pose(route_handler, route_lane_ids.front());
-  } else {
-    start_pose = utils::create_pose(
-      start_pose_input[0], start_pose_input[1], start_pose_input[2], start_pose_input[3],
-      start_pose_input[4], start_pose_input[5], start_pose_input[6]);
-  }
+  const Pose start_pose = start_pose_check
+    ? utils::get_center_pose(route_handler, route_lane_ids.front())
+    : utils::create_pose(start_pose_input[0], start_pose_input[1], start_pose_input[2],
+      start_pose_input[3], start_pose_input[4], start_pose_input[5], start_pose_input[6]);
+
   const std::vector<double> goal_pose_input =
     autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "end_pose");
-  goal_pose = utils::create_pose(
+  const Pose goal_pose = utils::create_pose(
     goal_pose_input[0], goal_pose_input[1], goal_pose_input[2], goal_pose_input[3],
     goal_pose_input[4], goal_pose_input[5], goal_pose_input[6]);
-  goal_method = autoware::universe_utils::getOrDeclareParameter<std::string>(node, "goal_method");
+  return {start_pose, goal_pose};
 }
 
+<<<<<<< HEAD
 std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>
 OptimizationTrajectoryBasedCenterline::create_route(
-  const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr) const
+  const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr,
+  const Pose & start_pose, const Pose & goal_pose) const
 {
   // create route_ptr
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> route_ptr =
     std::make_shared<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>();
+=======
+std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute>
+OptimizationTrajectoryBasedCenterline::create_route(
+  std::shared_ptr<RouteHandler> & route_handler_ptr,
+  const Pose & start_pose, const Pose & goal_pose) const
+{
+  // create route_ptr_
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr_ =
+    std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
+>>>>>>> c5d1573 (refactoring version 1)
 
   lanelet::ConstLanelets all_lanelets;
+  lanelet::ConstLanelets path_lanelets;
+  if (!route_handler_ptr->planPathLaneletsBetweenCheckpoints(
+        start_pose, goal_pose, &path_lanelets)) { /* do nothing */
+  }
 
-  for (size_t i = 1; i < raw_path.points.size(); i++) {
-    const auto start_point = raw_path.points.at(i - 1);
-    const auto goal_point = raw_path.points.at(i);
-    lanelet::ConstLanelets path_lanelets;
-    if (!route_handler_ptr->planPathLaneletsBetweenCheckpoints(
-          start_point.pose, goal_point.pose, &path_lanelets)) { /* do nothing */
-    }
-
-    for (const auto & lane : path_lanelets) {
-      if (!all_lanelets.empty() && lane.id() == all_lanelets.back().id()) continue;
-      all_lanelets.push_back(lane);
-    }
+  for (const auto & lane : path_lanelets) {
+    if (!all_lanelets.empty() && lane.id() == all_lanelets.back().id()) continue;
+    all_lanelets.push_back(lane);
   }
 
   route_handler_ptr->setRouteLanelets(all_lanelets);
@@ -275,10 +283,15 @@ OptimizationTrajectoryBasedCenterline::create_route(
 }
 
 std::shared_ptr<autoware::path_generator::PathGenerator>
+<<<<<<< HEAD
 OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
   const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr)
   const
+=======
+OptimizationTrajectoryBasedCenterline::create_path_generator_node(
+  const Pose start_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr) const
+>>>>>>> c5d1573 (refactoring version 1)
 {
   const auto path_generator_node =
     std::make_shared<autoware::path_generator::PathGenerator>(create_node_options());
@@ -286,15 +299,24 @@ OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
   // set data in path_generator
   autoware::path_generator::PathGenerator::InputData path_generator_input;
   path_generator_input.lanelet_map_bin_ptr = map_bin_ptr;
+<<<<<<< HEAD
   path_generator_input.odometry_ptr = utils::convert_to_odometry(current_pose);
   path_generator_input.route_ptr = route_ptr;
+=======
+  path_generator_input.odometry_ptr = utils::convert_to_odometry(start_pose);
+  path_generator_input.route_ptr = route_ptr_;
+>>>>>>> c5d1573 (refactoring version 1)
   path_generator_node->set_planner_data(path_generator_input);
 
   return path_generator_node;
 }
 
 std::shared_ptr<autoware::behavior_path_planner::PlannerData>
+<<<<<<< HEAD
 OptimizationTrajectoryBasedCenterline::create_behavior_path_planner_data(
+=======
+OptimizationTrajectoryBasedCenterline::create_planner_data(
+>>>>>>> c5d1573 (refactoring version 1)
   std::shared_ptr<RouteHandler> & route_handler_ptr) const
 {
   // create planner_data
@@ -306,7 +328,7 @@ OptimizationTrajectoryBasedCenterline::create_behavior_path_planner_data(
 }
 
 std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
-OptimizationTrajectoryBasedCenterline::createFixedGoalPlanner(
+OptimizationTrajectoryBasedCenterline::create_fixed_goal_planner(
   const PathWithLaneId & raw_path_with_lane_id) const
 {
   // create behavior_path_planner
@@ -320,7 +342,7 @@ OptimizationTrajectoryBasedCenterline::createFixedGoalPlanner(
   return behavior_path_planner;
 }
 
-path_generator::Params OptimizationTrajectoryBasedCenterline::createParams(
+path_generator::Params OptimizationTrajectoryBasedCenterline::create_params(
   std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const
 {
   // create params
@@ -329,14 +351,34 @@ path_generator::Params OptimizationTrajectoryBasedCenterline::createParams(
   return param_listener_->get_params();
 }
 
+<<<<<<< HEAD
 PathWithLaneId OptimizationTrajectoryBasedCenterline::modify_goal_connection(
+=======
+PathWithLaneId OptimizationTrajectoryBasedCenterline::goal_path_generate(
+>>>>>>> c5d1573 (refactoring version 1)
   const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
   std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-  const geometry_msgs::msg::Pose & current_pose) const
+  const Pose & start_pose, const Pose & goal_pose) const
 {
   if (goal_method == "None") {
     // No goal correction
+<<<<<<< HEAD
     return raw_path_with_lane_id;
+=======
+    path_with_lane_id_points = raw_path_with_lane_id;
+  } else if (goal_method == "path_generator") {
+    auto path_generator_node = create_path_generator_node(start_pose, map_bin_ptr);
+    auto params = create_params(path_generator_node);
+    path_with_lane_id_points =
+      *(path_generator_node->generate_path(raw_path.points[0].pose, params));
+  } else if (goal_method == "behavior_path_planner") {
+    auto planner_data_ = create_planner_data(route_handler_ptr);
+    auto behavior_path_planner = create_fixed_goal_planner(raw_path_with_lane_id);
+    path_with_lane_id_points = behavior_path_planner->plan(planner_data_).path;
+  } else {
+    throw std::logic_error(
+      "The goal_method is not supported in autoware_static_centerline_generator.");
+>>>>>>> c5d1573 (refactoring version 1)
   }
 
   // NOTE: The route pointer has to be created to reflect start pose and goal pose

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -27,8 +27,6 @@
 #include "static_centerline_generator_node.hpp"
 #include "utils.hpp"
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
-
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -56,19 +54,20 @@ Path convert_to_path(const PathWithLaneId & path_with_lane_id)
   return path;
 }
 
-Trajectory convert_to_trajectory(const Path & path)
+std::vector<TrajectoryPoint> convert_to_trajectory_points(const PathWithLaneId & path_with_lane_id)
 {
   Trajectory traj;
-  for (const auto & point : path.points) {
+  for (const auto & point : path_with_lane_id.points) {
     TrajectoryPoint traj_point;
-    traj_point.pose = point.pose;
-    traj_point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
-    traj_point.lateral_velocity_mps = point.lateral_velocity_mps;
-    traj_point.heading_rate_rps = point.heading_rate_rps;
+    traj_point.pose = point.point.pose;
+    traj_point.longitudinal_velocity_mps = point.point.longitudinal_velocity_mps;
+    traj_point.lateral_velocity_mps = point.point.lateral_velocity_mps;
+    traj_point.heading_rate_rps = point.point.heading_rate_rps;
 
     traj.points.push_back(traj_point);
   }
-  return traj;
+
+  return autoware::motion_utils::convertToTrajectoryPointArray(traj);
 }
 }  // namespace
 
@@ -140,15 +139,11 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   LaneletMapBin::ConstSharedPtr & map_bin_ptr) const
 {
   // create path_with_lane_id by goal_method
-  const PathWithLaneId path_with_lane_id_points =
-    goalPathGenerate(raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose);
+  const PathWithLaneId path_with_lane_id_points = modify_goal_connection(
+    raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose);
 
   // convert trajectory
-  const auto path_points = convert_to_path(path_with_lane_id_points);
-  const auto traj_points = [&]() {
-    const auto raw_traj = convert_to_trajectory(path_points);
-    return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
-  }();
+  const auto traj_points = convert_to_trajectory_points(path_with_lane_id_points);
 
   // create an instance of elastic band and model predictive trajectory.
   const auto eb_path_smoother_ptr =
@@ -177,15 +172,11 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
         .pose;
 
     // create path_with_lane_id by goal_method
-    const PathWithLaneId path_with_lane_id_points = goalPathGenerate(
+    const auto path_with_lane_id_points = modify_goal_connection(
       raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, virtual_ego_pose);
 
     // convert trajectory
-    const auto path_points = convert_to_path(path_with_lane_id_points);
-    const auto traj_points = [&]() {
-      const auto raw_traj = convert_to_trajectory(path_points);
-      return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
-    }();
+    const auto traj_points = convert_to_trajectory_points(path_with_lane_id_points);
 
     // smooth trajectory by elastic band in the autoware_path_smoother package
     const auto smoothed_traj_points =
@@ -229,7 +220,7 @@ void OptimizationTrajectoryBasedCenterline::getGoalPlanParameters(
   // get start pose, goal pose, goal method, and search radius range
   const std::vector<double> start_pose_input =
     autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "start_pose");
-  bool start_pose_check = std::all_of(
+  const bool start_pose_check = std::all_of(
     start_pose_input.begin(), start_pose_input.end(), [](double x) { return x == 0.0; });
   if (start_pose_check) {
     // optimize centerline inside the lane
@@ -248,11 +239,11 @@ void OptimizationTrajectoryBasedCenterline::getGoalPlanParameters(
 }
 
 std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>
-OptimizationTrajectoryBasedCenterline::createRoutePtr(
+OptimizationTrajectoryBasedCenterline::create_route(
   const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr) const
 {
-  // create route_ptr_
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> route_ptr_ =
+  // create route_ptr
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> route_ptr =
     std::make_shared<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>();
 
   lanelet::ConstLanelets all_lanelets;
@@ -276,17 +267,17 @@ OptimizationTrajectoryBasedCenterline::createRoutePtr(
     route_handler_ptr->createMapSegments(all_lanelets);
 
   // set necessary data
-  route_ptr_->header.frame_id = "map";
-  route_ptr_->set__start_pose(start_pose);
-  route_ptr_->set__goal_pose(goal_pose);
-  route_ptr_->set__segments(route_sections);
-  return route_ptr_;
+  route_ptr->header.frame_id = "map";
+  route_ptr->set__start_pose(start_pose);
+  route_ptr->set__goal_pose(goal_pose);
+  route_ptr->set__segments(route_sections);
+  return route_ptr;
 }
 
 std::shared_ptr<autoware::path_generator::PathGenerator>
 OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
   const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_)
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr)
   const
 {
   const auto path_generator_node =
@@ -296,14 +287,14 @@ OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
   autoware::path_generator::PathGenerator::InputData path_generator_input;
   path_generator_input.lanelet_map_bin_ptr = map_bin_ptr;
   path_generator_input.odometry_ptr = utils::convert_to_odometry(current_pose);
-  path_generator_input.route_ptr = route_ptr_;
+  path_generator_input.route_ptr = route_ptr;
   path_generator_node->set_planner_data(path_generator_input);
 
   return path_generator_node;
 }
 
 std::shared_ptr<autoware::behavior_path_planner::PlannerData>
-OptimizationTrajectoryBasedCenterline::createPlannerData(
+OptimizationTrajectoryBasedCenterline::create_behavior_path_planner_data(
   std::shared_ptr<RouteHandler> & route_handler_ptr) const
 {
   // create planner_data
@@ -338,31 +329,30 @@ path_generator::Params OptimizationTrajectoryBasedCenterline::createParams(
   return param_listener_->get_params();
 }
 
-PathWithLaneId OptimizationTrajectoryBasedCenterline::goalPathGenerate(
+PathWithLaneId OptimizationTrajectoryBasedCenterline::modify_goal_connection(
   const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
   std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   const geometry_msgs::msg::Pose & current_pose) const
 {
-  PathWithLaneId path_with_lane_id_points;
   if (goal_method == "None") {
     // No goal correction
-    path_with_lane_id_points = raw_path_with_lane_id;
-  } else if (goal_method == "path_generator") {
-    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr);
-    auto path_generator_node = createPathGeneratorNode(current_pose, map_bin_ptr, route_ptr_);
-    auto params = createParams(path_generator_node);
-    path_with_lane_id_points =
-      *(path_generator_node->generate_path(raw_path.points[0].pose, params));
-  } else if (goal_method == "behavior_path_planner") {
-    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr);
-    route_handler_ptr->setRoute(*route_ptr_);
-    auto planner_data_ = createPlannerData(route_handler_ptr);
-    auto behavior_path_planner = createFixedGoalPlanner(raw_path_with_lane_id);
-    path_with_lane_id_points = behavior_path_planner->plan(planner_data_).path;
-  } else {
-    throw std::logic_error(
-      "The goal_method is not supported in autoware_static_centerline_generator.");
+    return raw_path_with_lane_id;
   }
-  return path_with_lane_id_points;
+
+  // NOTE: The route pointer has to be created to reflect start pose and goal pose
+  auto route_ptr = create_route(raw_path, route_handler_ptr);
+  if (goal_method == "path_generator") {
+    auto path_generator_node = createPathGeneratorNode(current_pose, map_bin_ptr, route_ptr);
+    const auto params = createParams(path_generator_node);
+    return *(path_generator_node->generate_path(raw_path.points[0].pose, params));
+  }
+  if (goal_method == "behavior_path_planner") {
+    route_handler_ptr->setRoute(*route_ptr);
+    const auto planner_data = create_behavior_path_planner_data(route_handler_ptr);
+    auto fixed_goal_planner = createFixedGoalPlanner(raw_path_with_lane_id);
+    return fixed_goal_planner->plan(planner_data).path;
+  }
+  throw std::logic_error(
+    "The goal_method is not supported in autoware_static_centerline_generator.");
 }
 }  // namespace autoware::static_centerline_generator

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -79,14 +79,6 @@ std_msgs::msg::Header create_header(const rclcpp::Time & now)
   header.stamp = now;
   return header;
 }
-
-std_msgs::msg::Header create_header(const rclcpp::Time & now)
-{
-  std_msgs::msg::Header header;
-  header.frame_id = "map";
-  header.stamp = now;
-  return header;
-}
 }  // namespace
 
 OptimizationTrajectoryBasedCenterline::OptimizationTrajectoryBasedCenterline(rclcpp::Node & node)

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -105,7 +105,7 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 
   // update route_handler
   const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr, route_lane_ids);
-  route_ptr = create_route(route_handler_ptr, start_pose, goal_pose);
+  auto route_ptr = create_route(route_handler_ptr, start_pose, goal_pose);
   route_handler_ptr->setRouteLanelets(route_lanelets);
   route_handler_ptr->setRoute(*route_ptr);
 

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -14,6 +14,12 @@
 
 #include "centerline_source/optimization_trajectory_based_centerline.hpp"
 
+#include "autoware/behavior_path_goal_planner_module/default_fixed_goal_planner.hpp"
+#include "autoware/behavior_path_goal_planner_module/fixed_goal_planner_base.hpp"
+#include "autoware/behavior_path_planner_common/data_manager.hpp"
+#include "autoware_lanelet2_extension/utility/query.hpp"
+#include "autoware_test_utils/autoware_test_utils.hpp"
+
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/path_optimizer/node.hpp"
@@ -21,6 +27,8 @@
 #include "autoware/universe_utils/ros/parameter.hpp"
 #include "static_centerline_generator_node.hpp"
 #include "utils.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -73,13 +81,14 @@ OptimizationTrajectoryBasedCenterline::OptimizationTrajectoryBasedCenterline(rcl
 
 std::vector<TrajectoryPoint>
 OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
-  rclcpp::Node & node, const RouteHandler & route_handler,
-  const std::vector<lanelet::Id> & route_lane_ids)
+  rclcpp::Node & node,
+  std::shared_ptr<RouteHandler> & route_handler_ptr_,
+  const std::vector<lanelet::Id> & route_lane_ids,
+  LaneletMapBin::ConstSharedPtr & map_bin_ptr_)
 {
-  const auto route_lanelets = utils::get_lanelets_from_ids(route_handler, route_lane_ids);
-
-  // optimize centerline inside the lane
-  const auto start_center_pose = utils::get_center_pose(route_handler, route_lane_ids.front());
+  // set route lanelets
+  const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr_, route_lane_ids);
+  route_handler_ptr_->setRouteLanelets(route_lanelets);
 
   // get ego nearest search parameters and resample interval in behavior_path_planner
   const double ego_nearest_dist_threshold =
@@ -91,10 +100,28 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
   const double behavior_vel_interval =
     autoware::universe_utils::getOrDeclareParameter<double>(node, "behavior_output_path_interval");
 
+  // get start pose, goal pose, goal method, and search radius range
+  const std::vector<double> start_pose_input =
+    autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "start_pose");
+  bool start_pose_check = std::all_of(start_pose_input.begin(), start_pose_input.end(), [](double x) {return x == 0.0;});
+  if (start_pose_check) {
+    // optimize centerline inside the lane
+    start_pose = utils::get_center_pose(*route_handler_ptr_, route_lane_ids.front());
+  } else {
+    start_pose = utils::createPose(
+      start_pose_input[0], start_pose_input[1], start_pose_input[2], start_pose_input[3], start_pose_input[4], start_pose_input[5], start_pose_input[6]);
+  }
+  const std::vector<double> goal_pose_input =
+    autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "end_pose");
+  goal_pose = utils::createPose(
+    goal_pose_input[0], goal_pose_input[1], goal_pose_input[2], goal_pose_input[3], goal_pose_input[4], goal_pose_input[5], goal_pose_input[6]);
+  const std::string goal_method = autoware::universe_utils::getOrDeclareParameter<std::string>(node, "goal_method");
+  const double refine_goal_search_radius_range = autoware::universe_utils::getOrDeclareParameter<double>(node, "search_radius_range");
+
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = [&]() {
     const auto non_resampled_path_with_lane_id = utils::get_path_with_lane_id(
-      route_handler, route_lanelets, start_center_pose, ego_nearest_dist_threshold,
+      *route_handler_ptr_, route_lanelets, start_pose, ego_nearest_dist_threshold,
       ego_nearest_yaw_threshold);
     return autoware::motion_utils::resamplePath(
       non_resampled_path_with_lane_id, behavior_path_interval);
@@ -109,9 +136,10 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
   }();
   pub_raw_path_->publish(raw_path);
   RCLCPP_INFO(node.get_logger(), "Converted to path and published.");
-
+ 
   // smooth trajectory and road collision avoidance
-  const auto optimized_traj_points = optimize_trajectory(raw_path);
+  const auto optimized_traj_points = optimize_trajectory(
+    raw_path_with_lane_id, raw_path, route_handler_ptr_, map_bin_ptr_, goal_method, refine_goal_search_radius_range);
   RCLCPP_INFO(
     node.get_logger(),
     "Smoothed trajectory and made it collision free with the road and published.");
@@ -120,11 +148,43 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 }
 
 std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_trajectory(
-  const Path & raw_path) const
+  const PathWithLaneId & raw_path_with_lane_id,
+  const Path & raw_path,
+  std::shared_ptr<RouteHandler> & route_handler_ptr_,
+  LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
+  const std::string & goal_method,
+  const double & refine_goal_search_radius_range) const
 {
-  // convert to trajectory points
-  const auto raw_traj_points = [&]() {
-    const auto raw_traj = convert_to_trajectory(raw_path);
+  // create path_with_lane_id by goal_method
+  PathWithLaneId path_with_lane_id_points;
+  if (goal_method == "") {
+    // No goal correction
+    path_with_lane_id_points = raw_path_with_lane_id;
+  }
+  else if (goal_method == "path_generator") {
+    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
+    auto path_generator_node = createPathGeneratorNode(start_pose, map_bin_ptr_, route_ptr_);
+    auto params = createParams(path_generator_node);
+    path_with_lane_id_points = *(path_generator_node->generate_path(raw_path.points[0].pose, params));
+  }
+  else if (goal_method == "fixed_goal_planner") {
+    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
+    route_handler_ptr_->setRoute(*route_ptr_);
+    auto path_generator_node = createPathGeneratorNode(start_pose, map_bin_ptr_, route_ptr_);
+    auto params = createParams(path_generator_node);
+    auto planner_data_ = createPlannerData(route_handler_ptr_, params, refine_goal_search_radius_range);
+    auto fixed_goal_planner = createFixedGoalPlanner(raw_path_with_lane_id);
+    path_with_lane_id_points = fixed_goal_planner->plan(planner_data_).path;
+  }
+  else {
+    throw std::logic_error(
+      "The goal_method is not supported in autoware_static_centerline_generator.");
+  }
+
+  // convert trajectory
+  auto path_points = convert_to_path(path_with_lane_id_points);
+  const auto traj_points = [&]() {
+    const auto raw_traj = convert_to_trajectory(path_points);
     return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
   }();
 
@@ -136,7 +196,7 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
 
   // NOTE: The optimization is executed every valid_optimized_traj_points_num points.
   constexpr int valid_optimized_traj_points_num = 10;
-  const int traj_segment_num = raw_traj_points.size() / valid_optimized_traj_points_num;
+  const int traj_segment_num = traj_points.size() / valid_optimized_traj_points_num;
 
   // NOTE: num_initial_optimization exists to make the both optimizations stable since they may use
   // warm start.
@@ -148,15 +208,44 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
     // calculate virtual ego pose for the optimization
     constexpr int virtual_ego_pose_offset_idx = 1;
     const auto virtual_ego_pose =
-      raw_traj_points
+      traj_points
         .at(
           valid_optimized_traj_points_num * std::max(virtual_ego_pose_idx, 0) +
           virtual_ego_pose_offset_idx)
         .pose;
 
+    if (goal_method == "") {
+      // No goal correction
+      path_with_lane_id_points = raw_path_with_lane_id;
+    }
+    else if (goal_method == "path_generator") {
+      auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
+      auto path_generator_node = createPathGeneratorNode(virtual_ego_pose, map_bin_ptr_, route_ptr_);
+      auto params = createParams(path_generator_node);
+      path_with_lane_id_points = *(path_generator_node->generate_path(raw_path.points[0].pose, params));
+    }
+    else if (goal_method == "fixed_goal_planner") {
+      auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
+      route_handler_ptr_->setRoute(*route_ptr_);
+      auto path_generator_node = createPathGeneratorNode(virtual_ego_pose, map_bin_ptr_, route_ptr_);
+      auto params = createParams(path_generator_node);
+      auto planner_data_ = createPlannerData(route_handler_ptr_, params, refine_goal_search_radius_range);
+      auto fixed_goal_planner = createFixedGoalPlanner(raw_path_with_lane_id);
+      path_with_lane_id_points = fixed_goal_planner->plan(planner_data_).path;
+    }
+    else {
+      throw std::logic_error(
+        "The goal_method is not supported in autoware_static_centerline_generator.");
+    }
+    auto path_points = convert_to_path(path_with_lane_id_points);
+    const auto traj_points = [&]() {
+      const auto raw_traj = convert_to_trajectory(path_points);
+      return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
+    }();
+
     // smooth trajectory by elastic band in the autoware_path_smoother package
     const auto smoothed_traj_points =
-      eb_path_smoother_ptr->smoothTrajectory(raw_traj_points, virtual_ego_pose);
+      eb_path_smoother_ptr->smoothTrajectory(traj_points, virtual_ego_pose);
 
     // road collision avoidance by model predictive trajectory in the autoware_path_optimizer
     // package
@@ -187,5 +276,110 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   }
 
   return whole_optimized_traj_points;
+}
+
+std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>
+  OptimizationTrajectoryBasedCenterline::createRoutePtr(
+  const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr_) const
+{
+  // create route_ptr_
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> route_ptr_ =
+    std::make_shared<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>();
+  
+  lanelet::ConstLanelets all_lanelets;
+
+  for (size_t i = 1; i < raw_path.points.size(); i++) {
+    const auto start_point = raw_path.points.at(i - 1);
+    const auto goal_point = raw_path.points.at(i);
+    // std::cerr << "iketa goal_pose" << goal_point.pose.position.x << std::endl;
+    lanelet::ConstLanelets path_lanelets;
+    if(!route_handler_ptr_->planPathLaneletsBetweenCheckpoints(start_point.pose, goal_point.pose, &path_lanelets)) {
+      // RCLCPP_WARN(node.get_logger(), "Failed to plan route.");
+    }
+
+    for (const auto & lane : path_lanelets) {
+      if (!all_lanelets.empty() && lane.id() == all_lanelets.back().id()) continue;
+      all_lanelets.push_back(lane);
+    }
+  }
+
+  route_handler_ptr_->setRouteLanelets(all_lanelets);
+  std::vector<autoware_planning_msgs::msg::LaneletSegment> route_sections = route_handler_ptr_->createMapSegments(all_lanelets);
+
+  // set nessary data
+  route_ptr_->header.frame_id = "map";
+  route_ptr_->set__start_pose(start_pose);
+  route_ptr_->set__goal_pose(goal_pose);
+  route_ptr_->set__segments(route_sections);
+  return route_ptr_;
+}
+
+std::shared_ptr<autoware::path_generator::PathGenerator>
+  OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
+  const geometry_msgs::msg::Pose current_pose,
+  LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_) const
+{
+  // create path_generator_node
+  const auto path_generator_dir =
+    ament_index_cpp::get_package_share_directory("autoware_path_generator");
+  const auto node_options = rclcpp::NodeOptions{}.arguments(
+    {"--ros-args", "--params-file",
+     path_generator_dir + "/config/path_generator.param.yaml"});
+  const auto path_generator_node = std::make_shared<autoware::path_generator::PathGenerator>(node_options);
+
+  // set data in path_generator
+  autoware::path_generator::PathGenerator::InputData path_generator_input;
+  path_generator_input.lanelet_map_bin_ptr = map_bin_ptr_;
+  path_generator_input.odometry_ptr = utils::convert_to_odometry(current_pose);
+  path_generator_input.route_ptr = route_ptr_;
+  path_generator_node->set_planner_data(path_generator_input);
+
+  return path_generator_node;
+}
+
+std::shared_ptr<autoware::behavior_path_planner::PlannerData>
+  OptimizationTrajectoryBasedCenterline::createPlannerData(
+  std::shared_ptr<RouteHandler> & route_handler_ptr_,
+  path_generator::Params & params,
+  const double & refine_goal_search_radius_range) const
+{
+  // create planner_data
+  std::shared_ptr<autoware::behavior_path_planner::PlannerData> planner_data_ =
+    std::make_shared<autoware::behavior_path_planner::PlannerData>();
+  planner_data_->route_handler = route_handler_ptr_;
+
+  if (refine_goal_search_radius_range < 0) {
+    // default
+    planner_data_->parameters.refine_goal_search_radius_range = params.refine_goal_search_radius_range;
+  } else {
+    // input value
+    planner_data_->parameters.refine_goal_search_radius_range = static_cast<double>(refine_goal_search_radius_range);
+  }
+  return planner_data_;
+}
+
+std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
+  OptimizationTrajectoryBasedCenterline::createFixedGoalPlanner(
+  const PathWithLaneId & raw_path_with_lane_id) const
+{
+  // create fixed_goal_planner
+  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> fixed_goal_planner =
+    std::make_shared<autoware::behavior_path_planner::DefaultFixedGoalPlanner>();
+
+  autoware::behavior_path_planner::BehaviorModuleOutput behavior_module_input_data;
+  behavior_module_input_data.path = raw_path_with_lane_id;
+  fixed_goal_planner->setPreviousModuleOutput(behavior_module_input_data);
+
+  return fixed_goal_planner;
+}
+
+path_generator::Params OptimizationTrajectoryBasedCenterline::createParams(
+  std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const
+{
+  // create params
+  auto param_listener_ =
+    std::make_shared<::path_generator::ParamListener>(path_generator_node->get_node_parameters_interface());
+  return param_listener_->get_params();
 }
 }  // namespace autoware::static_centerline_generator

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -30,6 +30,8 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
 #include <algorithm>
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace autoware::static_centerline_generator
@@ -80,14 +82,15 @@ OptimizationTrajectoryBasedCenterline::OptimizationTrajectoryBasedCenterline(rcl
 
 std::vector<TrajectoryPoint>
 OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
-  rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr_,
-  const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr_)
+  rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr,
+  const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr)
 {
   // set route lanelets
-  const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr_, route_lane_ids);
-  route_handler_ptr_->setRouteLanelets(route_lanelets);
+  const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr, route_lane_ids);
+  route_handler_ptr->setRouteLanelets(route_lanelets);
 
-  // get ego nearest search parameters and resample interval in behavior_path_planner
+  // get ego nearest search parameters, resample interval, and search radius range in
+  // behavior_path_planner
   const double ego_nearest_dist_threshold =
     autoware::universe_utils::getOrDeclareParameter<double>(node, "ego_nearest_dist_threshold");
   const double ego_nearest_yaw_threshold =
@@ -96,34 +99,16 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
     autoware::universe_utils::getOrDeclareParameter<double>(node, "output_path_interval");
   const double behavior_vel_interval =
     autoware::universe_utils::getOrDeclareParameter<double>(node, "behavior_output_path_interval");
+  refine_goal_search_radius_range = autoware::universe_utils::getOrDeclareParameter<double>(
+    node, "refine_goal_search_radius_range");
 
-  // get start pose, goal pose, goal method, and search radius range
-  const std::vector<double> start_pose_input =
-    autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "start_pose");
-  bool start_pose_check = std::all_of(
-    start_pose_input.begin(), start_pose_input.end(), [](double x) { return x == 0.0; });
-  if (start_pose_check) {
-    // optimize centerline inside the lane
-    start_pose = utils::get_center_pose(*route_handler_ptr_, route_lane_ids.front());
-  } else {
-    start_pose = utils::createPose(
-      start_pose_input[0], start_pose_input[1], start_pose_input[2], start_pose_input[3],
-      start_pose_input[4], start_pose_input[5], start_pose_input[6]);
-  }
-  const std::vector<double> goal_pose_input =
-    autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "end_pose");
-  goal_pose = utils::createPose(
-    goal_pose_input[0], goal_pose_input[1], goal_pose_input[2], goal_pose_input[3],
-    goal_pose_input[4], goal_pose_input[5], goal_pose_input[6]);
-  const std::string goal_method =
-    autoware::universe_utils::getOrDeclareParameter<std::string>(node, "goal_method");
-  const double refine_goal_search_radius_range =
-    autoware::universe_utils::getOrDeclareParameter<double>(node, "search_radius_range");
+  // get start pose, goal pose, and goal method
+  getGoalPlanPlameters(node, *route_handler_ptr, route_lane_ids);
 
   // extract path with lane id from lanelets
   const auto raw_path_with_lane_id = [&]() {
     const auto non_resampled_path_with_lane_id = utils::get_path_with_lane_id(
-      *route_handler_ptr_, route_lanelets, start_pose, ego_nearest_dist_threshold,
+      *route_handler_ptr, route_lanelets, start_pose, ego_nearest_dist_threshold,
       ego_nearest_yaw_threshold);
     return autoware::motion_utils::resamplePath(
       non_resampled_path_with_lane_id, behavior_path_interval);
@@ -140,9 +125,8 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
   RCLCPP_INFO(node.get_logger(), "Converted to path and published.");
 
   // smooth trajectory and road collision avoidance
-  const auto optimized_traj_points = optimize_trajectory(
-    raw_path_with_lane_id, raw_path, route_handler_ptr_, map_bin_ptr_, goal_method,
-    refine_goal_search_radius_range);
+  const auto optimized_traj_points =
+    optimize_trajectory(raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr);
   RCLCPP_INFO(
     node.get_logger(),
     "Smoothed trajectory and made it collision free with the road and published.");
@@ -152,36 +136,15 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 
 std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_trajectory(
   const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
-  std::shared_ptr<RouteHandler> & route_handler_ptr_, LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
-  const std::string & goal_method, const double & refine_goal_search_radius_range) const
+  std::shared_ptr<RouteHandler> & route_handler_ptr,
+  LaneletMapBin::ConstSharedPtr & map_bin_ptr) const
 {
   // create path_with_lane_id by goal_method
-  PathWithLaneId path_with_lane_id_points;
-  if (goal_method == "") {
-    // No goal correction
-    path_with_lane_id_points = raw_path_with_lane_id;
-  } else if (goal_method == "path_generator") {
-    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
-    auto path_generator_node = createPathGeneratorNode(start_pose, map_bin_ptr_, route_ptr_);
-    auto params = createParams(path_generator_node);
-    path_with_lane_id_points =
-      *(path_generator_node->generate_path(raw_path.points[0].pose, params));
-  } else if (goal_method == "fixed_goal_planner") {
-    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
-    route_handler_ptr_->setRoute(*route_ptr_);
-    auto path_generator_node = createPathGeneratorNode(start_pose, map_bin_ptr_, route_ptr_);
-    auto params = createParams(path_generator_node);
-    auto planner_data_ =
-      createPlannerData(route_handler_ptr_, params, refine_goal_search_radius_range);
-    auto fixed_goal_planner = createFixedGoalPlanner(raw_path_with_lane_id);
-    path_with_lane_id_points = fixed_goal_planner->plan(planner_data_).path;
-  } else {
-    throw std::logic_error(
-      "The goal_method is not supported in autoware_static_centerline_generator.");
-  }
+  const PathWithLaneId path_with_lane_id_points =
+    goalPathGenerate(raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose);
 
   // convert trajectory
-  auto path_points = convert_to_path(path_with_lane_id_points);
+  const auto path_points = convert_to_path(path_with_lane_id_points);
   const auto traj_points = [&]() {
     const auto raw_traj = convert_to_trajectory(path_points);
     return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
@@ -213,31 +176,12 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
           virtual_ego_pose_offset_idx)
         .pose;
 
-    if (goal_method == "") {
-      // No goal correction
-      path_with_lane_id_points = raw_path_with_lane_id;
-    } else if (goal_method == "path_generator") {
-      auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
-      auto path_generator_node =
-        createPathGeneratorNode(virtual_ego_pose, map_bin_ptr_, route_ptr_);
-      auto params = createParams(path_generator_node);
-      path_with_lane_id_points =
-        *(path_generator_node->generate_path(raw_path.points[0].pose, params));
-    } else if (goal_method == "fixed_goal_planner") {
-      auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr_);
-      route_handler_ptr_->setRoute(*route_ptr_);
-      auto path_generator_node =
-        createPathGeneratorNode(virtual_ego_pose, map_bin_ptr_, route_ptr_);
-      auto params = createParams(path_generator_node);
-      auto planner_data_ =
-        createPlannerData(route_handler_ptr_, params, refine_goal_search_radius_range);
-      auto fixed_goal_planner = createFixedGoalPlanner(raw_path_with_lane_id);
-      path_with_lane_id_points = fixed_goal_planner->plan(planner_data_).path;
-    } else {
-      throw std::logic_error(
-        "The goal_method is not supported in autoware_static_centerline_generator.");
-    }
-    auto path_points = convert_to_path(path_with_lane_id_points);
+    // create path_with_lane_id by goal_method
+    const PathWithLaneId path_with_lane_id_poins = goalPathGenerate(
+      raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, virtual_ego_pose);
+
+    // convert trajectory
+    const auto path_points = convert_to_path(path_with_lane_id_points);
     const auto traj_points = [&]() {
       const auto raw_traj = convert_to_trajectory(path_points);
       return autoware::motion_utils::convertToTrajectoryPointArray(raw_traj);
@@ -278,9 +222,34 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   return whole_optimized_traj_points;
 }
 
+void OptimizationTrajectoryBasedCenterline::getGoalPlanPlameters(
+  rclcpp::Node & node, const RouteHandler & route_handler,
+  const std::vector<lanelet::Id> & route_lane_ids)
+{
+  // get start pose, goal pose, goal method, and search radius range
+  const std::vector<double> start_pose_input =
+    autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "start_pose");
+  bool start_pose_check = std::all_of(
+    start_pose_input.begin(), start_pose_input.end(), [](double x) { return x == 0.0; });
+  if (start_pose_check) {
+    // optimize centerline inside the lane
+    start_pose = utils::get_center_pose(route_handler, route_lane_ids.front());
+  } else {
+    start_pose = utils::create_pose(
+      start_pose_input[0], start_pose_input[1], start_pose_input[2], start_pose_input[3],
+      start_pose_input[4], start_pose_input[5], start_pose_input[6]);
+  }
+  const std::vector<double> goal_pose_input =
+    autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "end_pose");
+  goal_pose = utils::create_pose(
+    goal_pose_input[0], goal_pose_input[1], goal_pose_input[2], goal_pose_input[3],
+    goal_pose_input[4], goal_pose_input[5], goal_pose_input[6]);
+  goal_method = autoware::universe_utils::getOrDeclareParameter<std::string>(node, "goal_method");
+}
+
 std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>>
 OptimizationTrajectoryBasedCenterline::createRoutePtr(
-  const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr_) const
+  const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr) const
 {
   // create route_ptr_
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> route_ptr_ =
@@ -293,9 +262,8 @@ OptimizationTrajectoryBasedCenterline::createRoutePtr(
     const auto goal_point = raw_path.points.at(i);
     // std::cerr << "iketa goal_pose" << goal_point.pose.position.x << std::endl;
     lanelet::ConstLanelets path_lanelets;
-    if (!route_handler_ptr_->planPathLaneletsBetweenCheckpoints(
-          start_point.pose, goal_point.pose, &path_lanelets)) {
-      // RCLCPP_WARN(node.get_logger(), "Failed to plan route.");
+    if (!route_handler_ptr->planPathLaneletsBetweenCheckpoints(
+          start_point.pose, goal_point.pose, &path_lanelets)) { /* do nothing */
     }
 
     for (const auto & lane : path_lanelets) {
@@ -304,9 +272,9 @@ OptimizationTrajectoryBasedCenterline::createRoutePtr(
     }
   }
 
-  route_handler_ptr_->setRouteLanelets(all_lanelets);
+  route_handler_ptr->setRouteLanelets(all_lanelets);
   std::vector<autoware_planning_msgs::msg::LaneletSegment> route_sections =
-    route_handler_ptr_->createMapSegments(all_lanelets);
+    route_handler_ptr->createMapSegments(all_lanelets);
 
   // set nessary data
   route_ptr_->header.frame_id = "map";
@@ -318,21 +286,16 @@ OptimizationTrajectoryBasedCenterline::createRoutePtr(
 
 std::shared_ptr<autoware::path_generator::PathGenerator>
 OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
-  const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
+  const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_)
   const
 {
-  // create path_generator_node
-  const auto path_generator_dir =
-    ament_index_cpp::get_package_share_directory("autoware_path_generator");
-  const auto node_options = rclcpp::NodeOptions{}.arguments(
-    {"--ros-args", "--params-file", path_generator_dir + "/config/path_generator.param.yaml"});
   const auto path_generator_node =
-    std::make_shared<autoware::path_generator::PathGenerator>(node_options);
+    std::make_shared<autoware::path_generator::PathGenerator>(create_node_options());
 
   // set data in path_generator
   autoware::path_generator::PathGenerator::InputData path_generator_input;
-  path_generator_input.lanelet_map_bin_ptr = map_bin_ptr_;
+  path_generator_input.lanelet_map_bin_ptr = map_bin_ptr;
   path_generator_input.odometry_ptr = utils::convert_to_odometry(current_pose);
   path_generator_input.route_ptr = route_ptr_;
   path_generator_node->set_planner_data(path_generator_input);
@@ -342,23 +305,13 @@ OptimizationTrajectoryBasedCenterline::createPathGeneratorNode(
 
 std::shared_ptr<autoware::behavior_path_planner::PlannerData>
 OptimizationTrajectoryBasedCenterline::createPlannerData(
-  std::shared_ptr<RouteHandler> & route_handler_ptr_, path_generator::Params & params,
-  const double & refine_goal_search_radius_range) const
+  std::shared_ptr<RouteHandler> & route_handler_ptr) const
 {
   // create planner_data
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> planner_data_ =
     std::make_shared<autoware::behavior_path_planner::PlannerData>();
-  planner_data_->route_handler = route_handler_ptr_;
-
-  if (refine_goal_search_radius_range < 0) {
-    // default
-    planner_data_->parameters.refine_goal_search_radius_range =
-      params.refine_goal_search_radius_range;
-  } else {
-    // input value
-    planner_data_->parameters.refine_goal_search_radius_range =
-      static_cast<double>(refine_goal_search_radius_range);
-  }
+  planner_data_->route_handler = route_handler_ptr;
+  planner_data_->parameters.refine_goal_search_radius_range = refine_goal_search_radius_range;
   return planner_data_;
 }
 
@@ -366,15 +319,15 @@ std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
 OptimizationTrajectoryBasedCenterline::createFixedGoalPlanner(
   const PathWithLaneId & raw_path_with_lane_id) const
 {
-  // create fixed_goal_planner
-  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> fixed_goal_planner =
+  // create behavior_path_planner
+  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> behavior_path_planner =
     std::make_shared<autoware::behavior_path_planner::DefaultFixedGoalPlanner>();
 
   autoware::behavior_path_planner::BehaviorModuleOutput behavior_module_input_data;
   behavior_module_input_data.path = raw_path_with_lane_id;
-  fixed_goal_planner->setPreviousModuleOutput(behavior_module_input_data);
+  behavior_path_planner->setPreviousModuleOutput(behavior_module_input_data);
 
-  return fixed_goal_planner;
+  return behavior_path_planner;
 }
 
 path_generator::Params OptimizationTrajectoryBasedCenterline::createParams(
@@ -384,5 +337,33 @@ path_generator::Params OptimizationTrajectoryBasedCenterline::createParams(
   auto param_listener_ = std::make_shared<::path_generator::ParamListener>(
     path_generator_node->get_node_parameters_interface());
   return param_listener_->get_params();
+}
+
+PathWithLaneId OptimizationTrajectoryBasedCenterline::goalPathGenerate(
+  const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
+  std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+  const geometry_msgs::msg::Pose & current_pose) const
+{
+  PathWithLaneId path_with_lane_id_points;
+  if (goal_method == "None") {
+    // No goal correction
+    path_with_lane_id_points = raw_path_with_lane_id;
+  } else if (goal_method == "path_generator") {
+    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr);
+    auto path_generator_node = createPathGeneratorNode(current_pose, map_bin_ptr, route_ptr_);
+    auto params = createParams(path_generator_node);
+    path_with_lane_id_points =
+      *(path_generator_node->generate_path(raw_path.points[0].pose, params));
+  } else if (goal_method == "behavior_path_planner") {
+    auto route_ptr_ = createRoutePtr(raw_path, route_handler_ptr);
+    route_handler_ptr->setRoute(*route_ptr_);
+    auto planner_data_ = createPlannerData(route_handler_ptr);
+    auto behavior_path_planner = createFixedGoalPlanner(raw_path_with_lane_id);
+    path_with_lane_id_points = behavior_path_planner->plan(planner_data_).path;
+  } else {
+    throw std::logic_error(
+      "The goal_method is not supported in autoware_static_centerline_generator.");
+  }
+  return path_with_lane_id_points;
 }
 }  // namespace autoware::static_centerline_generator

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -99,7 +99,8 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
   goal_method = autoware::universe_utils::getOrDeclareParameter<std::string>(node, "goal_method");
 
   // get start pose, goal pose, and goal method
-  const auto [start_pose, goal_pose] = get_start_and_goal_pose(node, *route_handler_ptr, route_lane_ids);
+  const auto [start_pose, goal_pose] =
+    get_start_and_goal_pose(node, *route_handler_ptr, route_lane_ids);
 
   // update route_handler
   const auto route_lanelets = utils::get_lanelets_from_ids(*route_handler_ptr, route_lane_ids);
@@ -127,8 +128,8 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
   RCLCPP_INFO(node.get_logger(), "Converted to path and published.");
 
   // smooth trajectory and road collision avoidance
-  const auto optimized_traj_points =
-    optimize_trajectory(raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
+  const auto optimized_traj_points = optimize_trajectory(
+    raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
   RCLCPP_INFO(
     node.get_logger(),
     "Smoothed trajectory and made it collision free with the road and published.");
@@ -138,8 +139,7 @@ OptimizationTrajectoryBasedCenterline::generate_centerline_with_optimization(
 
 std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_trajectory(
   const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
-  std::shared_ptr<RouteHandler> & route_handler_ptr,
-  LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+  std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   const Pose & start_pose, const Pose & goal_pose) const
 {
   // create path_with_lane_id by goal_method
@@ -226,10 +226,12 @@ std::pair<Pose, Pose> OptimizationTrajectoryBasedCenterline::get_start_and_goal_
     autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "start_pose");
   const bool start_pose_check = std::all_of(
     start_pose_input.begin(), start_pose_input.end(), [](double x) { return x == 0.0; });
-  const Pose start_pose = start_pose_check
-    ? utils::get_center_pose(route_handler, route_lane_ids.front())
-    : utils::create_pose(start_pose_input[0], start_pose_input[1], start_pose_input[2],
-      start_pose_input[3], start_pose_input[4], start_pose_input[5], start_pose_input[6]);
+  const Pose start_pose =
+    start_pose_check
+      ? utils::get_center_pose(route_handler, route_lane_ids.front())
+      : utils::create_pose(
+          start_pose_input[0], start_pose_input[1], start_pose_input[2], start_pose_input[3],
+          start_pose_input[4], start_pose_input[5], start_pose_input[6]);
 
   const std::vector<double> goal_pose_input =
     autoware::universe_utils::getOrDeclareParameter<std::vector<double>>(node, "end_pose");
@@ -241,8 +243,8 @@ std::pair<Pose, Pose> OptimizationTrajectoryBasedCenterline::get_start_and_goal_
 
 std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute>
 OptimizationTrajectoryBasedCenterline::create_route(
-  std::shared_ptr<RouteHandler> & route_handler_ptr,
-  const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose) const
+  std::shared_ptr<RouteHandler> & route_handler_ptr, const geometry_msgs::msg::Pose & start_pose,
+  const geometry_msgs::msg::Pose & goal_pose) const
 {
   // create route_ptr
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr =

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -164,8 +164,9 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   // }();
 
   // create path_with_lane_id by goal_method
-  const PathWithLaneId path_with_lane_id_points = modify_goal_connection(
-    node, raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
+  const PathWithLaneId path_with_lane_id_points = raw_path_with_lane_id;
+  // modify_goal_connection(
+  // node, raw_path_with_lane_id, raw_path, route_handler_ptr, map_bin_ptr, start_pose, goal_pose);
 
   // convert trajectory
   const auto traj_points = convert_to_trajectory_points(path_with_lane_id_points);

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -41,8 +41,7 @@ public:
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
-    std::shared_ptr<RouteHandler> & route_handler_ptr,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+    std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const Pose & start_pose, const Pose & goal_pose) const;
 
   // publisher
@@ -54,22 +53,22 @@ private:
     rclcpp::Node & node, const RouteHandler & route_handler,
     const std::vector<lanelet::Id> & route_lane_ids) const;
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> create_route(
-    std::shared_ptr<RouteHandler> & route_handler_ptr,
-    const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose) const;
+    std::shared_ptr<RouteHandler> & route_handler_ptr, const geometry_msgs::msg::Pose & start_pose,
+    const geometry_msgs::msg::Pose & goal_pose) const;
   std::shared_ptr<autoware::path_generator::PathGenerator> create_path_generator_node(
     const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
     std::shared_ptr<RouteHandler> & route_handler_ptr) const;
-  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> create_fixed_goal_planner(
-    const PathWithLaneId & raw_path_with_lane_id) const;
+  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
+  create_fixed_goal_planner(const PathWithLaneId & raw_path_with_lane_id) const;
   path_generator::Params create_params(
     std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const;
 
   PathWithLaneId modify_goal_connection(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-  const Pose & start_pose, const Pose & goal_pose) const;
+    const Pose & start_pose, const Pose & goal_pose) const;
 
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr;
   std::string goal_method;

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -42,36 +42,36 @@ private:
   std::vector<TrajectoryPoint> optimize_trajectory(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr) const;
+    LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+    const Pose & start_pose, const Pose & goal_pose) const;
 
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_raw_path_with_lane_id_{nullptr};
   rclcpp::Publisher<Path>::SharedPtr pub_raw_path_{nullptr};
 
   // data required for goal method
-  void getGoalPlanParameters(
+  std::pair<Pose, Pose> get_start_and_goal_pose(
     rclcpp::Node & node, const RouteHandler & route_handler,
     const std::vector<lanelet::Id> & route_lane_ids);
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> create_route(
     const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr) const;
-  std::shared_ptr<autoware::path_generator::PathGenerator> createPathGeneratorNode(
+  std::shared_ptr<autoware::path_generator::PathGenerator> create_path_generator_node(
     const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr)
     const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
     std::shared_ptr<RouteHandler> & route_handler_ptr) const;
-  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> createFixedGoalPlanner(
+  std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> create_fixed_goal_planner(
     const PathWithLaneId & raw_path_with_lane_id) const;
-  path_generator::Params createParams(
+  path_generator::Params create_params(
     std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const;
 
   PathWithLaneId modify_goal_connection(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-    const geometry_msgs::msg::Pose & current_pose) const;
+  const Pose & start_pose, const Pose & goal_pose) const;
 
-  geometry_msgs::msg::Pose start_pose;
-  geometry_msgs::msg::Pose goal_pose;
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr_;
   std::string goal_method;
   double refine_goal_search_radius_range;
 };

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -48,6 +48,8 @@ private:
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_raw_path_with_lane_id_{nullptr};
   rclcpp::Publisher<Path>::SharedPtr pub_raw_path_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_iterative_smoothed_traj_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_iterative_optimized_traj_{nullptr};
 
   // data required for goal method
   Pose get_pose(

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -35,14 +35,14 @@ public:
   OptimizationTrajectoryBasedCenterline() = default;
   explicit OptimizationTrajectoryBasedCenterline(rclcpp::Node & node);
   std::vector<TrajectoryPoint> generate_centerline_with_optimization(
-    rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr_,
-    const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr_);
+    rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr,
+    const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr);
 
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
-    std::shared_ptr<RouteHandler> & route_handler_ptr_,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr_) const;
+    std::shared_ptr<RouteHandler> & route_handler_ptr,
+    LaneletMapBin::ConstSharedPtr & map_bin_ptr) const;
 
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_raw_path_with_lane_id_{nullptr};
@@ -52,20 +52,20 @@ private:
   void getGoalPlanParameters(
     rclcpp::Node & node, const RouteHandler & route_handler,
     const std::vector<lanelet::Id> & route_lane_ids);
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> createRoutePtr(
-    const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr_) const;
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> create_route(
+    const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr) const;
   std::shared_ptr<autoware::path_generator::PathGenerator> createPathGeneratorNode(
-    const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
-    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_)
+    const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr)
     const;
-  std::shared_ptr<autoware::behavior_path_planner::PlannerData> createPlannerData(
-    std::shared_ptr<RouteHandler> & route_handler_ptr_) const;
+  std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
+    std::shared_ptr<RouteHandler> & route_handler_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> createFixedGoalPlanner(
     const PathWithLaneId & raw_path_with_lane_id) const;
   path_generator::Params createParams(
     std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const;
 
-  PathWithLaneId goalPathGenerate(
+  PathWithLaneId modify_goal_connection(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const geometry_msgs::msg::Pose & current_pose) const;

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -37,14 +37,13 @@ public:
   explicit OptimizationTrajectoryBasedCenterline(rclcpp::Node & node);
   std::vector<TrajectoryPoint> generate_centerline_with_optimization(
     rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr,
-    const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-    const LaneletRoute & route);
+    LaneletMapBin::ConstSharedPtr & map_bin_ptr, const LaneletRoute & route);
 
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
     rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-    const Pose & start_pose, const Pose & goal_pose) const;
+    const LaneletRoute & route) const;
 
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_raw_path_with_lane_id_{nullptr};
@@ -55,27 +54,25 @@ private:
 
   // data required for goal method
   Pose get_pose(
-    rclcpp::Node & node, const RouteHandler & route_handler,
-    const std::vector<lanelet::Id> & route_lane_ids, const std::string dec_param) const;
+    rclcpp::Node & node, const RouteHandler & route_handler, const LaneletRoute & route,
+    const std::string & dec_param) const;
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> create_route(
     std::shared_ptr<RouteHandler> & route_handler_ptr, const geometry_msgs::msg::Pose & start_pose,
     const geometry_msgs::msg::Pose & goal_pose) const;
   void init_path_generator_node(
     const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr) const;
+    const LaneletRoute & route) const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
     rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
   create_fixed_goal_planner(const PathWithLaneId & raw_path_with_lane_id) const;
-  path_generator::Params create_params() const;
 
   PathWithLaneId modify_goal_connection(
-    rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
+    rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-    const Pose & start_pose, const Pose & goal_pose) const;
+    const LaneletRoute & route, const Pose & current_pose) const;
 
   mutable std::shared_ptr<autoware::path_generator::PathGenerator> path_generator_node_;
-  LaneletRoute route_;
 };
 }  // namespace autoware::static_centerline_generator
 // clang-format off

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::static_centerline_generator

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -18,9 +18,8 @@
 #include "autoware/behavior_path_goal_planner_module/default_fixed_goal_planner.hpp"
 #include "autoware/behavior_path_goal_planner_module/fixed_goal_planner_base.hpp"
 #include "autoware/path_generator/common_structs.hpp"
-#include "autoware/path_generator/utils.hpp"
 #include "autoware/path_generator/node.hpp"
-
+#include "autoware/path_generator/utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "type_alias.hpp"
 
@@ -34,18 +33,14 @@ public:
   OptimizationTrajectoryBasedCenterline() = default;
   explicit OptimizationTrajectoryBasedCenterline(rclcpp::Node & node);
   std::vector<TrajectoryPoint> generate_centerline_with_optimization(
-    rclcpp::Node & node,
-    std::shared_ptr<RouteHandler> & route_handler_ptr_,
-    const std::vector<lanelet::Id> & route_lane_ids,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr_);
+    rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr_,
+    const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr_);
 
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
-    const PathWithLaneId & raw_path_with_lane_id,
-    const Path & raw_path,
+    const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr_,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
-    const std::string & goal_method,
+    LaneletMapBin::ConstSharedPtr & map_bin_ptr_, const std::string & goal_method,
     const double & refine_goal_search_radius_range) const;
 
   // publisher
@@ -56,12 +51,11 @@ private:
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> createRoutePtr(
     const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr_) const;
   std::shared_ptr<autoware::path_generator::PathGenerator> createPathGeneratorNode(
-    const geometry_msgs::msg::Pose current_pose,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
-    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_) const;
+    const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr_,
+    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_)
+    const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> createPlannerData(
-    std::shared_ptr<RouteHandler> & route_handler_ptr_,
-    path_generator::Params & params,
+    std::shared_ptr<RouteHandler> & route_handler_ptr_, path_generator::Params & params,
     const double & refine_goal_search_radius_range) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> createFixedGoalPlanner(
     const PathWithLaneId & raw_path_with_lane_id) const;

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -41,7 +41,7 @@ public:
 
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
-    rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
+    rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const LaneletRoute & route) const;
 

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -49,7 +49,7 @@ private:
   rclcpp::Publisher<Path>::SharedPtr pub_raw_path_{nullptr};
 
   // data required for goal method
-  void getGoalPlanPlameters(
+  void getGoalPlanParameters(
     rclcpp::Node & node, const RouteHandler & route_handler,
     const std::vector<lanelet::Id> & route_lane_ids);
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> createRoutePtr(

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -41,7 +41,7 @@ public:
 
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
-    const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
+    rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const Pose & start_pose, const Pose & goal_pose) const;
 
@@ -50,9 +50,9 @@ private:
   rclcpp::Publisher<Path>::SharedPtr pub_raw_path_{nullptr};
 
   // data required for goal method
-  std::pair<Pose, Pose> get_start_and_goal_pose(
+  Pose get_pose(
     rclcpp::Node & node, const RouteHandler & route_handler,
-    const std::vector<lanelet::Id> & route_lane_ids) const;
+    const std::vector<lanelet::Id> & route_lane_ids, const std::string dec_param) const;
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> create_route(
     std::shared_ptr<RouteHandler> & route_handler_ptr, const geometry_msgs::msg::Pose & start_pose,
     const geometry_msgs::msg::Pose & goal_pose) const;
@@ -60,19 +60,16 @@ private:
     const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
-    std::shared_ptr<RouteHandler> & route_handler_ptr) const;
+    rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
   create_fixed_goal_planner(const PathWithLaneId & raw_path_with_lane_id) const;
   path_generator::Params create_params(
     std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const;
 
   PathWithLaneId modify_goal_connection(
-    const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
+    rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const Pose & start_pose, const Pose & goal_pose) const;
-
-  std::string goal_method;
-  double refine_goal_search_radius_range;
 };
 }  // namespace autoware::static_centerline_generator
 // clang-format off

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -23,6 +23,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "type_alias.hpp"
 
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace autoware::static_centerline_generator
@@ -40,14 +42,16 @@ private:
   std::vector<TrajectoryPoint> optimize_trajectory(
     const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr_,
-    LaneletMapBin::ConstSharedPtr & map_bin_ptr_, const std::string & goal_method,
-    const double & refine_goal_search_radius_range) const;
+    LaneletMapBin::ConstSharedPtr & map_bin_ptr_) const;
 
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_raw_path_with_lane_id_{nullptr};
   rclcpp::Publisher<Path>::SharedPtr pub_raw_path_{nullptr};
 
   // data required for goal method
+  void getGoalPlanPlameters(
+    rclcpp::Node & node, const RouteHandler & route_handler,
+    const std::vector<lanelet::Id> & route_lane_ids);
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> createRoutePtr(
     const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr_) const;
   std::shared_ptr<autoware::path_generator::PathGenerator> createPathGeneratorNode(
@@ -55,15 +59,21 @@ private:
     std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr_)
     const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> createPlannerData(
-    std::shared_ptr<RouteHandler> & route_handler_ptr_, path_generator::Params & params,
-    const double & refine_goal_search_radius_range) const;
+    std::shared_ptr<RouteHandler> & route_handler_ptr_) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> createFixedGoalPlanner(
     const PathWithLaneId & raw_path_with_lane_id) const;
   path_generator::Params createParams(
     std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const;
 
+  PathWithLaneId goalPathGenerate(
+    const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
+    std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+    const geometry_msgs::msg::Pose & current_pose) const;
+
   geometry_msgs::msg::Pose start_pose;
   geometry_msgs::msg::Pose goal_pose;
+  std::string goal_method;
+  double refine_goal_search_radius_range;
 };
 }  // namespace autoware::static_centerline_generator
 // clang-format off

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -37,7 +37,8 @@ public:
   explicit OptimizationTrajectoryBasedCenterline(rclcpp::Node & node);
   std::vector<TrajectoryPoint> generate_centerline_with_optimization(
     rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr,
-    const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr);
+    const std::vector<lanelet::Id> & route_lane_ids, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
+    const LaneletRoute & route);
 
 private:
   std::vector<TrajectoryPoint> optimize_trajectory(
@@ -48,6 +49,7 @@ private:
   // publisher
   rclcpp::Publisher<PathWithLaneId>::SharedPtr pub_raw_path_with_lane_id_{nullptr};
   rclcpp::Publisher<Path>::SharedPtr pub_raw_path_{nullptr};
+  rclcpp::Publisher<Path>::SharedPtr pub_iterative_path_{nullptr};
   rclcpp::Publisher<Trajectory>::SharedPtr pub_iterative_smoothed_traj_{nullptr};
   rclcpp::Publisher<Trajectory>::SharedPtr pub_iterative_optimized_traj_{nullptr};
 
@@ -58,20 +60,22 @@ private:
   std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> create_route(
     std::shared_ptr<RouteHandler> & route_handler_ptr, const geometry_msgs::msg::Pose & start_pose,
     const geometry_msgs::msg::Pose & goal_pose) const;
-  std::shared_ptr<autoware::path_generator::PathGenerator> create_path_generator_node(
+  void init_path_generator_node(
     const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
     rclcpp::Node & node, std::shared_ptr<RouteHandler> & route_handler_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner>
   create_fixed_goal_planner(const PathWithLaneId & raw_path_with_lane_id) const;
-  path_generator::Params create_params(
-    std::shared_ptr<autoware::path_generator::PathGenerator> & path_generator_node) const;
+  path_generator::Params create_params() const;
 
   PathWithLaneId modify_goal_connection(
     rclcpp::Node & node, const PathWithLaneId & raw_path_with_lane_id, const Path & raw_path,
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const Pose & start_pose, const Pose & goal_pose) const;
+
+  mutable std::shared_ptr<autoware::path_generator::PathGenerator> path_generator_node_;
+  LaneletRoute route_;
 };
 }  // namespace autoware::static_centerline_generator
 // clang-format off

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -71,7 +71,6 @@ private:
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
     const Pose & start_pose, const Pose & goal_pose) const;
 
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr;
   std::string goal_method;
   double refine_goal_search_radius_range;
 };

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp
@@ -52,13 +52,13 @@ private:
   // data required for goal method
   std::pair<Pose, Pose> get_start_and_goal_pose(
     rclcpp::Node & node, const RouteHandler & route_handler,
-    const std::vector<lanelet::Id> & route_lane_ids);
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> create_route(
-    const Path & raw_path, std::shared_ptr<RouteHandler> & route_handler_ptr) const;
+    const std::vector<lanelet::Id> & route_lane_ids) const;
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> create_route(
+    std::shared_ptr<RouteHandler> & route_handler_ptr,
+    const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose) const;
   std::shared_ptr<autoware::path_generator::PathGenerator> create_path_generator_node(
     const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
-    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute_<std::allocator<void>>> & route_ptr)
-    const;
+    std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::PlannerData> create_behavior_path_planner_data(
     std::shared_ptr<RouteHandler> & route_handler_ptr) const;
   std::shared_ptr<autoware::behavior_path_planner::DefaultFixedGoalPlanner> create_fixed_goal_planner(
@@ -71,7 +71,7 @@ private:
     std::shared_ptr<RouteHandler> & route_handler_ptr, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   const Pose & start_pose, const Pose & goal_pose) const;
 
-  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr_;
+  std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute> route_ptr;
   std::string goal_method;
   double refine_goal_search_radius_range;
 };

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -331,7 +331,7 @@ CenterlineWithRoute StaticCenterlineGeneratorNode::generate_whole_centerline_wit
       const auto route_lane_ids = plan_route_by_lane_ids(start_lanelet_id, end_lanelet_id);
       const auto optimized_centerline =
         optimization_trajectory_based_centerline_.generate_centerline_with_optimization(
-          *this, route_handler_ptr_, route_lane_ids, map_bin_ptr_);
+          *this, route_handler_ptr_, route_lane_ids, map_bin_ptr_, route_);
       return CenterlineWithRoute{optimized_centerline, route_lane_ids};
     } else if (centerline_source_ == CenterlineSource::BagEgoTrajectoryBase) {
       const auto bag_centerline = generate_centerline_with_bag(*this);
@@ -469,6 +469,7 @@ std::vector<lanelet::Id> StaticCenterlineGeneratorNode::plan_route(
     // plan route
     const auto route = mission_planner->plan(check_points);
 
+    route_ = route;
     return route;
   }();
 
@@ -542,7 +543,7 @@ void StaticCenterlineGeneratorNode::on_plan_path(
   // plan path
   const auto optimized_traj_points =
     optimization_trajectory_based_centerline_.generate_centerline_with_optimization(
-      *this, route_handler_ptr_, route_lane_ids, map_bin_ptr_);
+      *this, route_handler_ptr_, route_lane_ids, map_bin_ptr_, route_);
 
   // check calculation result
   if (optimized_traj_points.empty()) {

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -43,6 +43,7 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/distance.hpp>
 
+#include <glog/logging.h>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_io/Io.h>
@@ -197,6 +198,12 @@ StaticCenterlineGeneratorNode::StaticCenterlineGeneratorNode(
   const rclcpp::NodeOptions & node_options)
 : Node("static_centerline_generator", node_options)
 {
+  // glog for debug
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("multi_object_tracker");
+    google::InstallFailureSignalHandler();
+  }
+
   // publishers
   pub_map_bin_ =
     create_publisher<LaneletMapBin>("lanelet2_map_topic", utils::create_transient_local_qos());

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -542,8 +542,8 @@ void StaticCenterlineGeneratorNode::on_plan_path(
 
   // create route
   LaneletRoute route;
-  route.start_pose;  // TODO(murooka)
-  route.goal_pose;   // TODO(murooka)
+  route.start_pose = utils::get_center_pose(*route_handler_ptr_, route_lane_ids.front());
+  route.goal_pose = utils::get_center_pose(*route_handler_ptr_, route_lane_ids.back());
   std::vector<lanelet::Id> lane_ids;
   for (const auto route_lane_id : route_lane_ids) {
     LaneletSegment segment;

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -324,7 +324,7 @@ CenterlineWithRoute StaticCenterlineGeneratorNode::generate_whole_centerline_wit
       const auto route_lane_ids = plan_route_by_lane_ids(start_lanelet_id, end_lanelet_id);
       const auto optimized_centerline =
         optimization_trajectory_based_centerline_.generate_centerline_with_optimization(
-          *this, *route_handler_ptr_, route_lane_ids);
+          *this, route_handler_ptr_, route_lane_ids, map_bin_ptr_);
       return CenterlineWithRoute{optimized_centerline, route_lane_ids};
     } else if (centerline_source_ == CenterlineSource::BagEgoTrajectoryBase) {
       const auto bag_centerline = generate_centerline_with_bag(*this);
@@ -535,7 +535,7 @@ void StaticCenterlineGeneratorNode::on_plan_path(
   // plan path
   const auto optimized_traj_points =
     optimization_trajectory_based_centerline_.generate_centerline_with_optimization(
-      *this, *route_handler_ptr_, route_lane_ids);
+      *this, route_handler_ptr_, route_lane_ids, map_bin_ptr_);
 
   // check calculation result
   if (optimized_traj_points.empty()) {

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.hpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.hpp
@@ -182,6 +182,7 @@ private:
 
   // vehicle info
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+  LaneletRoute route_;
 };
 }  // namespace autoware::static_centerline_generator
 #endif  // STATIC_CENTERLINE_GENERATOR_NODE_HPP_

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.hpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.hpp
@@ -44,7 +44,7 @@ using autoware_static_centerline_generator::srv::PlanRoute;
 struct CenterlineWithRoute
 {
   std::vector<TrajectoryPoint> centerline{};
-  std::vector<lanelet::Id> route_lane_ids{};
+  LaneletRoute route{};
 };
 struct CenterlineHandler
 {
@@ -64,12 +64,12 @@ struct CenterlineHandler
     return std::vector<TrajectoryPoint>(
       centerline_begin + start_index, centerline_begin + end_index + 1);
   }
-  std::vector<lanelet::Id> get_route_lane_ids() const
+  LaneletRoute get_route() const
   {
     if (!whole_centerline_with_route) {
-      return std::vector<lanelet::Id>{};
+      return LaneletRoute{};
     }
-    return whole_centerline_with_route->route_lane_ids;
+    return whole_centerline_with_route->route;
   }
   bool is_valid() const { return whole_centerline_with_route && start_index < end_index; }
   bool update_start_index(const int arg_start_index)
@@ -115,9 +115,9 @@ private:
     const LoadMap::Request::SharedPtr request, const LoadMap::Response::SharedPtr response);
 
   // plan route
-  std::vector<lanelet::Id> plan_route_by_lane_ids(
+  LaneletRoute plan_route_by_lane_ids(
     const lanelet::Id start_lanelet_id, const lanelet::Id end_lanelet_id);
-  std::vector<lanelet::Id> plan_route(
+  LaneletRoute plan_route(
     const geometry_msgs::msg::Pose & start_center_pose,
     const geometry_msgs::msg::Pose & end_center_pose);
 
@@ -182,7 +182,6 @@ private:
 
   // vehicle info
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
-  LaneletRoute route_;
 };
 }  // namespace autoware::static_centerline_generator
 #endif  // STATIC_CENTERLINE_GENERATOR_NODE_HPP_

--- a/planning/autoware_static_centerline_generator/src/type_alias.hpp
+++ b/planning/autoware_static_centerline_generator/src/type_alias.hpp
@@ -33,6 +33,7 @@ using autoware::universe_utils::LinearRing2d;
 using autoware::universe_utils::LineString2d;
 using autoware::universe_utils::Point2d;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
+// using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::LaneletRoute;

--- a/planning/autoware_static_centerline_generator/src/type_alias.hpp
+++ b/planning/autoware_static_centerline_generator/src/type_alias.hpp
@@ -37,6 +37,7 @@ using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::LaneletSegment;
 using autoware_planning_msgs::msg::Path;
 using autoware_planning_msgs::msg::PathPoint;
 using autoware_planning_msgs::msg::Trajectory;

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -95,7 +95,12 @@ geometry_msgs::msg::Pose get_center_pose(
   // get middle idx of the lanelet
   const auto lanelet = route_handler.getLaneletsFromId(lanelet_id);
   const auto center_line = lanelet.centerline();
-  const size_t middle_point_idx = std::floor(center_line.size() / 2.0);
+  if (center_line.size() < 2) {
+    throw std::invalid_argument("center_line's size is less than 2.");
+  }
+
+  // Note: -1 operation is added considering that the size is 2.
+  const size_t middle_point_idx = std::floor((center_line.size() - 1) / 2.0);
 
   // get middle position of the lanelet
   geometry_msgs::msg::Point middle_pos;

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -51,7 +51,7 @@ lanelet::Point3d createPoint3d(const double x, const double y, const double z)
 
 namespace utils
 {
-geometry_msgs::msg::Pose createPose(
+geometry_msgs::msg::Pose create_pose(
   const double px, const double py, const double pz, const double qx, const double qy,
   const double qz, const double qw)
 {

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -52,7 +52,8 @@ lanelet::Point3d createPoint3d(const double x, const double y, const double z)
 namespace utils
 {
 geometry_msgs::msg::Pose createPose(
-  const double px, const double py, const double pz, const double qx, const double qy, const double qz, const double qw)
+  const double px, const double py, const double pz, const double qx, const double qy,
+  const double qz, const double qw)
 {
   geometry_msgs::msg::Pose pose;
   pose.position.x = px;

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -16,7 +16,6 @@
 
 #include "autoware/behavior_path_planner_common/data_manager.hpp"
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/ros/marker_helper.hpp"
 
 #include <lanelet2_core/LaneletMap.h>
@@ -32,13 +31,6 @@ namespace autoware::static_centerline_generator
 {
 namespace
 {
-nav_msgs::msg::Odometry::ConstSharedPtr convert_to_odometry(const geometry_msgs::msg::Pose & pose)
-{
-  auto odometry_ptr = std::make_shared<nav_msgs::msg::Odometry>();
-  odometry_ptr->pose.pose = pose;
-  return odometry_ptr;
-}
-
 lanelet::Point3d createPoint3d(const double x, const double y, const double z)
 {
   lanelet::Point3d point(lanelet::utils::getId());
@@ -59,6 +51,27 @@ lanelet::Point3d createPoint3d(const double x, const double y, const double z)
 
 namespace utils
 {
+geometry_msgs::msg::Pose createPose(
+  const double px, const double py, const double pz, const double qx, const double qy, const double qz, const double qw)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = px;
+  pose.position.y = py;
+  pose.position.z = pz;
+  pose.orientation.x = qx;
+  pose.orientation.y = qy;
+  pose.orientation.z = qz;
+  pose.orientation.w = qw;
+  return pose;
+}
+
+nav_msgs::msg::Odometry::ConstSharedPtr convert_to_odometry(const geometry_msgs::msg::Pose & pose)
+{
+  auto odometry_ptr = std::make_shared<nav_msgs::msg::Odometry>();
+  odometry_ptr->pose.pose = pose;
+  return odometry_ptr;
+}
+
 rclcpp::QoS create_transient_local_qos()
 {
   return rclcpp::QoS{1}.transient_local();

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -89,6 +89,18 @@ lanelet::ConstLanelets get_lanelets_from_ids(
   return lanelets;
 }
 
+lanelet::ConstLanelets get_lanelets_from_route(
+  const RouteHandler & route_handler, const LaneletRoute & route)
+{
+  lanelet::ConstLanelets lanelets;
+  for (const auto & segment : route.segments) {
+    const auto lane_id = segment.preferred_primitive.id;
+    const auto lanelet = route_handler.getLaneletsFromId(lane_id);
+    lanelets.push_back(lanelet);
+  }
+  return lanelets;
+}
+
 geometry_msgs::msg::Pose get_center_pose(
   const RouteHandler & route_handler, const size_t lanelet_id)
 {

--- a/planning/autoware_static_centerline_generator/src/utils.hpp
+++ b/planning/autoware_static_centerline_generator/src/utils.hpp
@@ -41,6 +41,9 @@ rclcpp::QoS create_transient_local_qos();
 lanelet::ConstLanelets get_lanelets_from_ids(
   const RouteHandler & route_handler, const std::vector<lanelet::Id> & lane_ids);
 
+lanelet::ConstLanelets get_lanelets_from_route(
+  const RouteHandler & route_handler, const LaneletRoute & route);
+
 geometry_msgs::msg::Pose get_center_pose(
   const RouteHandler & route_handler, const size_t lanelet_id);
 

--- a/planning/autoware_static_centerline_generator/src/utils.hpp
+++ b/planning/autoware_static_centerline_generator/src/utils.hpp
@@ -30,7 +30,7 @@ namespace autoware::static_centerline_generator
 {
 namespace utils
 {
-geometry_msgs::msg::Pose createPose(
+geometry_msgs::msg::Pose create_pose(
   const double px, const double py, const double pz, const double qx, const double qy,
   const double qz, const double qw);
 

--- a/planning/autoware_static_centerline_generator/src/utils.hpp
+++ b/planning/autoware_static_centerline_generator/src/utils.hpp
@@ -15,6 +15,7 @@
 #ifndef UTILS_HPP_
 #define UTILS_HPP_
 
+#include "autoware/behavior_path_planner_common/data_manager.hpp"
 #include "autoware/route_handler/route_handler.hpp"
 #include "type_alias.hpp"
 
@@ -29,6 +30,11 @@ namespace autoware::static_centerline_generator
 {
 namespace utils
 {
+geometry_msgs::msg::Pose createPose(
+  const double px, const double py, const double pz, const double qx, const double qy, const double qz, const double qw);
+
+nav_msgs::msg::Odometry::ConstSharedPtr convert_to_odometry(const geometry_msgs::msg::Pose & pose);
+
 rclcpp::QoS create_transient_local_qos();
 
 lanelet::ConstLanelets get_lanelets_from_ids(

--- a/planning/autoware_static_centerline_generator/src/utils.hpp
+++ b/planning/autoware_static_centerline_generator/src/utils.hpp
@@ -31,7 +31,8 @@ namespace autoware::static_centerline_generator
 namespace utils
 {
 geometry_msgs::msg::Pose createPose(
-  const double px, const double py, const double pz, const double qx, const double qy, const double qz, const double qw);
+  const double px, const double py, const double pz, const double qx, const double qy,
+  const double qz, const double qw);
 
 nav_msgs::msg::Odometry::ConstSharedPtr convert_to_odometry(const geometry_msgs::msg::Pose & pose);
 

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -42,8 +42,8 @@ def generate_test_description():
                 )
             },
             {"lanelet2_output_file_path": "/tmp/lanelet2_map.osm"},
-            {"start_lanelet_id": 215},
-            {"end_lanelet_id": 216},
+            {"start_lanelet_id": "215"},
+            {"end_lanelet_id": "216"},
             os.path.join(
                 get_package_share_directory("autoware_mission_planner_universe"),
                 "config",
@@ -60,6 +60,10 @@ def generate_test_description():
             os.path.join(
                 get_package_share_directory("autoware_behavior_velocity_planner"),
                 "config/behavior_velocity_planner.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("autoware_path_generator"),
+                "config/path_generator.param.yaml",
             ),
             os.path.join(
                 get_package_share_directory("autoware_path_smoother"),
@@ -96,7 +100,7 @@ def generate_test_description():
                 static_centerline_generator_node,
                 # Start test after 1s - gives time for the autoware_static_centerline_generator to finish initialization
                 launch.actions.TimerAction(
-                    period=1.0, actions=[launch_testing.actions.ReadyToTest()]
+                    period=10.0, actions=[launch_testing.actions.ReadyToTest()]
                 ),
             ]
         ),

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
@@ -53,7 +53,10 @@ def generate_test_description():
             ),
             DeclareLaunchArgument("rviz", default_value="false"),
             DeclareLaunchArgument("start_lanelet_id", default_value="215"),
+            DeclareLaunchArgument("start_pose", default_value="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]"),
             DeclareLaunchArgument("end_lanelet_id", default_value="216"),
+            DeclareLaunchArgument("end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"),
+            DeclareLaunchArgument("goal_method", default_value="fixed_goal_planner"),
             DeclareLaunchArgument(
                 "map_loader_param",
                 default_value=os.path.join(

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
@@ -53,9 +53,13 @@ def generate_test_description():
             ),
             DeclareLaunchArgument("rviz", default_value="false"),
             DeclareLaunchArgument("start_lanelet_id", default_value="215"),
-            DeclareLaunchArgument("start_pose", default_value="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]"),
+            DeclareLaunchArgument(
+                "start_pose", default_value="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]"
+            ),
             DeclareLaunchArgument("end_lanelet_id", default_value="216"),
-            DeclareLaunchArgument("end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"),
+            DeclareLaunchArgument(
+                "end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"
+            ),
             DeclareLaunchArgument("goal_method", default_value="fixed_goal_planner"),
             DeclareLaunchArgument(
                 "map_loader_param",

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_fixed_goal_planner.test.py
@@ -60,7 +60,7 @@ def generate_test_description():
             DeclareLaunchArgument(
                 "end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"
             ),
-            DeclareLaunchArgument("goal_method", default_value="fixed_goal_planner"),
+            DeclareLaunchArgument("goal_method", default_value="behavior_path_planner"),
             DeclareLaunchArgument(
                 "map_loader_param",
                 default_value=os.path.join(

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_path_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_path_generator.test.py
@@ -53,7 +53,10 @@ def generate_test_description():
             ),
             DeclareLaunchArgument("rviz", default_value="false"),
             DeclareLaunchArgument("start_lanelet_id", default_value="215"),
+            DeclareLaunchArgument("start_pose", default_value="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]"),
             DeclareLaunchArgument("end_lanelet_id", default_value="216"),
+            DeclareLaunchArgument("end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"),
+            DeclareLaunchArgument("goal_method", default_value="path_generator"),
             DeclareLaunchArgument(
                 "map_loader_param",
                 default_value=os.path.join(

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_path_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch_path_generator.test.py
@@ -53,9 +53,13 @@ def generate_test_description():
             ),
             DeclareLaunchArgument("rviz", default_value="false"),
             DeclareLaunchArgument("start_lanelet_id", default_value="215"),
-            DeclareLaunchArgument("start_pose", default_value="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]"),
+            DeclareLaunchArgument(
+                "start_pose", default_value="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]"
+            ),
             DeclareLaunchArgument("end_lanelet_id", default_value="216"),
-            DeclareLaunchArgument("end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"),
+            DeclareLaunchArgument(
+                "end_pose", default_value="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]"
+            ),
             DeclareLaunchArgument("goal_method", default_value="path_generator"),
             DeclareLaunchArgument(
                 "map_loader_param",


### PR DESCRIPTION
## Description

Enabled input of start and goal poses.
Used either `path_generator` or `behavior_path_planner` to allow smooth navigation to the goal pose.

## Related link

This PR is based on the assumption that the following path_generator modified PR has been built.

* https://github.com/autowarefoundation/autoware_core/pull/380


## How was this PR tested?

- path generator

```sh
ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml centerline_source:="optimization_trajectory_base" mode:="AUTO" lanelet2_input_file_path:="$HOME/tmp/lanelet2_map.osm" start_lanelet_id:=215 start_pose:="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]" end_lanelet_id:=216 end_pose:="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]" goal_method:="path_generator"
```

![image](https://github.com/user-attachments/assets/eb77b067-c818-425d-b0fe-48c47bb0658a)


- behavior path planner

```sh
ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml centerline_source:="optimization_trajectory_base" mode:="AUTO" lanelet2_input_file_path:="$HOME/tmp/lanelet2_map.osm" start_lanelet_id:=215 start_pose:="[89775.5, 43115.8, 6.0, 0.0, 0.0, 0.2876, 0.9575]" end_lanelet_id:=216 end_pose:="[89853.8, 43164.8, 6.2, 0.0, 0.0, 0.2876, 0.9575]" goal_method:="behavior_path_planner"
```

![image](https://github.com/user-attachments/assets/c4e27032-b559-44b1-a619-de818d6675a0)

- original function

```sh
ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml centerline_source:="optimization_trajectory_base" mode:="AUTO" lanelet2_input_file_path:="$HOME/tmp/lanelet2_map.osm" start_lanelet_id:=215 end_lanelet_id:=216
```

![image](https://github.com/user-attachments/assets/8fc0a73a-5d3b-48b2-a353-ae9caf8710e7)


## Notes for reviewers

None.

## Effects on system behavior

None.
