### PR TITLE
feat: enable pcd divider to generate a metadat file

### DIFF
--- a/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_divider.hpp
+++ b/map/autoware_pointcloud_divider/include/autoware/pointcloud_divider/pcd_divider.hpp
@@ -120,7 +120,7 @@ public:
     return std::pair<double, double>(grid_size_x_, grid_size_y_);
   }
 
-  void run();
+  void run(bool meta_gen = false);
   void run(const std::vector<std::string> & pcd_names);
 
 private:
@@ -159,7 +159,7 @@ private:
 
   std::string makeFileName(const GridInfo<2> & grid) const;
 
-  PclCloudPtr loadPCD(const std::string & pcd_name);
+  PclCloudPtr loadPCD(const std::string & pcd_name, bool load_all = false);
   void savePCD(const std::string & pcd_name, const pcl::PointCloud<PointT> & cloud);
   void dividePointCloud(const PclCloudPtr & cloud_ptr);
   void paramInitialize();
@@ -171,6 +171,8 @@ private:
   void mergeAndDownsample();
   void mergeAndDownsample(
     const std::string & dir_path, std::list<std::string> & pcd_list, size_t total_point_num);
+
+  void meta_generator(const std::vector<std::string> & pcd_names);
 };
 
 }  // namespace autoware::pointcloud_divider

--- a/map/autoware_pointcloud_divider/launch/pointcloud_divider.launch.xml
+++ b/map/autoware_pointcloud_divider/launch/pointcloud_divider.launch.xml
@@ -8,6 +8,7 @@
   <arg name="output_pcd_dir" description="The path to the folder containing the output PCD files and metadata files"/>
   <arg name="prefix" default="" description="The prefix for output PCD files"/>
   <arg name="point_type" default="point_xyzi" description="The type of map points"/>
+  <arg name="metadata_generate" default="false" description="Generate a metadata file without segmentation the PCDs"/>
 
   <group>
     <node pkg="autoware_pointcloud_divider" exec="autoware_pointcloud_divider_node" name="pointcloud_divider" output="screen">
@@ -20,6 +21,7 @@
       <param name="output_pcd_dir" value="$(var output_pcd_dir)"/>
       <param name="prefix" value="$(var prefix)"/>
       <param name="point_type" value="$(var point_type)"/>
+      <param name="metadata_generate" value="$(var metadata_generate)"/>
     </node>
   </group>
 </launch>

--- a/map/autoware_pointcloud_divider/schema/pointcloud_divider.schema.json
+++ b/map/autoware_pointcloud_divider/schema/pointcloud_divider.schema.json
@@ -45,6 +45,11 @@
           "type": "string",
           "description": "Type of the point when processing PCD files. Could be point_xyz or point_xyzi",
           "default": "point_xyzi"
+        },
+        "metadata_generate": {
+          "type": "boolean",
+          "description": "If true only generate a metadata file. Otherwise perform PCD segmentation.",
+          "default": "false"
         }
       },
       "required": ["grid_size_x", "grid_size_y", "input_pcd_or_dir", "output_pcd_dir", "prefix"],

--- a/map/autoware_pointcloud_divider/src/pcd_divider.cpp
+++ b/map/autoware_pointcloud_divider/src/pcd_divider.cpp
@@ -52,6 +52,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -101,13 +102,19 @@ std::vector<std::string> PCDDivider<PointT>::discoverPCDs(const std::string & in
 }
 
 template <class PointT>
-void PCDDivider<PointT>::run()
+void PCDDivider<PointT>::run(bool meta_gen)
 {
   // Discover PCD files
   auto pcd_list = discoverPCDs(input_pcd_or_dir_);
 
   // Process pcd files
-  run(pcd_list);
+  if (meta_gen) {
+    // Only generate a metadata file
+    meta_generator(pcd_list);
+  } else {
+    // Do the segmentation
+    run(pcd_list);
+  }
 }
 
 template <class PointT>
@@ -164,7 +171,8 @@ void PCDDivider<PointT>::checkOutputDirectoryValidity()
 }
 
 template <class PointT>
-typename pcl::PointCloud<PointT>::Ptr PCDDivider<PointT>::loadPCD(const std::string & pcd_name)
+typename pcl::PointCloud<PointT>::Ptr PCDDivider<PointT>::loadPCD(
+  const std::string & pcd_name, bool load_all)
 {
   if (pcd_name != reader_.get_path()) {
     reader_.setInput(pcd_name);
@@ -172,7 +180,39 @@ typename pcl::PointCloud<PointT>::Ptr PCDDivider<PointT>::loadPCD(const std::str
 
   PclCloudPtr cloud_ptr(new PclCloudType);
 
-  reader_.readABlock(*cloud_ptr);
+  if (load_all) {
+    size_t total_point_num = reader_.point_num();
+    size_t copy_loc = 0;
+
+    PclCloudType tmp_cloud;
+
+    cloud_ptr->resize(total_point_num);
+
+    int seg_count = 0;
+
+    while (reader_.good() && rclcpp::ok()) {
+      RCLCPP_INFO(logger_, "Copy segment %d", seg_count++);
+      size_t read_size = reader_.readABlock(tmp_cloud);
+
+      RCLCPP_INFO(
+        logger_,
+        "Read size (bytes/points) = %lu/%lu, tmp size = %lu, cloud size = %lu, total pnum = %lu",
+        read_size, read_size / sizeof(PointT), tmp_cloud.size(), cloud_ptr->size(),
+        total_point_num);
+
+      if (read_size > 0) {
+        if (!std::memcpy(
+              cloud_ptr->data() + copy_loc, tmp_cloud.data(), tmp_cloud.size() * sizeof(PointT))) {
+          RCLCPP_ERROR(logger_, "Error: Failed to copy points from tmp buffer to cloud");
+          exit(EXIT_FAILURE);
+        }
+      }
+
+      copy_loc += tmp_cloud.size();
+    }
+  } else {
+    reader_.readABlock(*cloud_ptr);
+  }
 
   return cloud_ptr;
 }
@@ -200,12 +240,12 @@ void PCDDivider<PointT>::dividePointCloud(const PclCloudPtr & cloud_ptr)
       exit(EXIT_SUCCESS);
     }
 
-    auto tmp = pointToGrid2(p, grid_size_x_, grid_size_y_);
-    auto it = grid_to_cloud_.find(tmp);
+    auto grid_key = pointToGrid2(p, grid_size_x_, grid_size_y_);
+    auto it = grid_to_cloud_.find(grid_key);
 
     // If the grid has not existed yet, create a new one
     if (it == grid_to_cloud_.end()) {
-      auto & new_grid = grid_to_cloud_[tmp];
+      auto & new_grid = grid_to_cloud_[grid_key];
 
       std::get<0>(new_grid).reserve(max_block_size_);
 
@@ -227,11 +267,11 @@ void PCDDivider<PointT>::dividePointCloud(const PclCloudPtr & cloud_ptr)
         // Otherwise, update the seg_by_size_ if the change of size is significant
         if (cloud.size() - prev_size >= 10000) {
           prev_size = cloud.size();
-          auto seg_to_size_it = seg_to_size_itr_map_.find(tmp);
+          auto seg_to_size_it = seg_to_size_itr_map_.find(grid_key);
 
           if (seg_to_size_it == seg_to_size_itr_map_.end()) {
             auto size_it = seg_by_size_.insert(std::make_pair(prev_size, it));
-            seg_to_size_itr_map_[tmp] = size_it;
+            seg_to_size_itr_map_[grid_key] = size_it;
           } else {
             seg_by_size_.erase(seg_to_size_it->second);
             auto new_size_it = seg_by_size_.insert(std::make_pair(prev_size, it));
@@ -473,6 +513,44 @@ void PCDDivider<PointT>::saveGridInfoToYAML(const std::string & yaml_file_path)
   }
 
   yaml_file.close();
+}
+
+template <class PointT>
+void PCDDivider<PointT>::meta_generator(const std::vector<std::string> & pcd_list)
+{
+  std::string yaml_file_path = output_dir_ + "/pointcloud_map_metadata.yaml";
+  std::unordered_set<GridInfo<2>> segment_set;
+
+  for (auto & pcd_name : pcd_list) {
+    RCLCPP_INFO(logger_, "pcd_name = %s", pcd_name.c_str());
+    do {
+      auto cloud_ptr = loadPCD(pcd_name);
+
+      for (auto & p : *cloud_ptr) {
+        if (!rclcpp::ok()) {
+          exit(0);
+        }
+
+        auto seg_key = pointToGrid2(p, grid_size_x_, grid_size_y_);
+
+        if (segment_set.find(seg_key) == segment_set.end()) {
+          segment_set.insert(seg_key);
+        }
+      }
+    } while (reader_.good() && rclcpp::ok());
+  }
+
+  std::ofstream output_metadata(yaml_file_path);
+
+  output_metadata << "x_resolution: " << grid_size_x_ << std::endl;
+  output_metadata << "y_resolution: " << grid_size_y_ << std::endl;
+
+  for (auto & it : segment_set) {
+    output_metadata << file_prefix_ << "_" << it.ix << "_" << it.iy << ".pcd: [" << it.ix << ", "
+                    << it.iy << "]" << std::endl;
+  }
+
+  RCLCPP_INFO(logger_, "A metadata file is saved at %s", yaml_file_path.c_str());
 }
 
 template class PCDDivider<pcl::PointXYZ>;

--- a/map/autoware_pointcloud_divider/src/pointcloud_divider_node.cpp
+++ b/map/autoware_pointcloud_divider/src/pointcloud_divider_node.cpp
@@ -35,6 +35,7 @@ PointCloudDivider::PointCloudDivider(const rclcpp::NodeOptions & node_options)
   std::string output_pcd_dir = declare_parameter<std::string>("output_pcd_dir");
   std::string file_prefix = declare_parameter<std::string>("prefix");
   std::string point_type = declare_parameter<std::string>("point_type");
+  bool meta_gen = declare_parameter<bool>("metadata_generate", false);
   // Enter a new line and clear it
   // This is to get rid of the prefix of RCLCPP_INFO
   std::string line_breaker(102, ' ');
@@ -73,7 +74,7 @@ PointCloudDivider::PointCloudDivider(const rclcpp::NodeOptions & node_options)
     pcd_divider_exe.setOutputDir(output_pcd_dir);
     pcd_divider_exe.setPrefix(file_prefix);
 
-    pcd_divider_exe.run();
+    pcd_divider_exe.run(meta_gen);
   } else if (point_type == "point_xyzi") {
     autoware::pointcloud_divider::PCDDivider<pcl::PointXYZI> pcd_divider_exe(get_logger());
 
@@ -84,7 +85,7 @@ PointCloudDivider::PointCloudDivider(const rclcpp::NodeOptions & node_options)
     pcd_divider_exe.setOutputDir(output_pcd_dir);
     pcd_divider_exe.setPrefix(file_prefix);
 
-    pcd_divider_exe.run();
+    pcd_divider_exe.run(meta_gen);
   }
 
   rclcpp::shutdown();


### PR DESCRIPTION
## Description
- Enable the point cloud divider to generate a metadata file of map segments, instead of actually dividing the PCD map. This is helpful when we work with tiny segmentation resolution without needing the actual PCD files. In such cases, dividing the PCD map is super slow, but generating a metadata file is very fast.

## How was this PR tested?
- I tested this on the large Odaiba rinkai map, trying to divide the map to tiny 2.0x2.0m segments.
- Run this command 
```ros2 launch autoware_pointcloud_divider pointcloud_divider.launch.xml input_pcd_or_dir:=<map_path> output_pcd_dir:=<output_folder> grid_size_x:=2.0 grid_size_y:=2.0 metadata_generate:=true```
- A metadata file was generated at the <output_folder>

## Notes for reviewers

None.

## Effects on system behavior

None.
