### PR TITLE
feat: remove plotjuggler_ros from dependencies

### DIFF
--- a/vehicle/parameter_estimator/package.xml
+++ b/vehicle/parameter_estimator/package.xml
@@ -19,7 +19,6 @@
   <depend>sensor_msgs</depend>
   <depend>tier4_calibration_msgs</depend>
   <exec_depend>plotjuggler</exec_depend>
-  <exec_depend>plotjuggler_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/vehicle/time_delay_estimator/package.xml
+++ b/vehicle/time_delay_estimator/package.xml
@@ -22,7 +22,6 @@
   <!--other depends-->
 
   <exec_depend>plotjuggler</exec_depend>
-  <exec_depend>plotjuggler_ros</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description
In [package release for Humble Hawksbill 2025-05-16](https://discourse.ros.org/t/new-packages-for-humble-hawksbill-2025-05-16/43801/1), ros-humble-plotjuggler-ros was removed.
In this PR, we are removing the dependency to plotjuggler_ros package, otherwise rosdep install will fail to find plotjuggler-ros.

## How was this PR tested?
I have made sure that rosdep install works fine.

## Notes for reviewers

None.

## Effects on system behavior

None.
