### PR TITLE
ci(build-and-test-diff): use self hosted runners

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -30,7 +30,7 @@ jobs:
           - container-suffix: ""
             runner: ubuntu-22.04
           - container-suffix: -cuda
-            runner: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
+            runner: [self-hosted, Linux, X64]
 
     steps:
       - name: Set PR fetch depth


### PR DESCRIPTION
## Description

- See: https://github.com/autowarefoundation/autoware_universe/pull/10677

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
