### PR TITLE
fix(autoware_static_centerline_generator): fix the name of the executable in static_centerline_generator.launch.xml

### DIFF
--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -56,7 +56,7 @@
   </node>
 
   <!-- visualize map -->
-  <node pkg="autoware_lanelet2_map_visualizer" exec="lanelet2_map_visualization" name="lanelet2_map_visualization">
+  <node pkg="autoware_lanelet2_map_visualizer" exec="autoware_lanelet2_map_visualizer" name="lanelet2_map_visualization">
     <remap from="input/lanelet2_map" to="$(var lanelet2_map_topic)"/>
     <remap from="output/lanelet2_map_marker" to="$(var lanelet2_map_marker_topic)"/>
   </node>


### PR DESCRIPTION
## Description

This PR fixes the launch file of `autoware_static_centerline_generator` since the executable name of `autoware_lanelet2_map_visualizer` has been changed, and static_centerline_generator is not launch-able.
https://github.com/autowarefoundation/autoware_core/pull/477

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
