### PR TITLE
feat: add `summary.json`

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -127,7 +127,11 @@ def process_directory(
         # filter out WARNs before activation
         df = df[df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"]
         not_ok_num = len(df[df["level"] != 0])
-        not_ok_percentage = not_ok_num / len(df) * 100
+        if len(df) == 0:
+            not_ok_percentage = 0
+        else:
+            not_ok_num = len(df[df["level"] != 0])
+            not_ok_percentage = not_ok_num / len(df) * 100
         if not_ok_percentage > 1:
             final_success = False
             final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%] is too large."

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -84,6 +84,8 @@ def process_directory(
     df = pd.read_csv(relative_pose_tsv, sep="\t")
     mean_position_norm = df["position.norm"].mean()
     mean_angle_norm = df["angle.norm"].mean()
+    mean_linear_velocity_norm = df["linear_velocity.norm"].mean()
+    mean_angular_velocity_norm = df["angular_velocity.norm"].mean()
 
     THRESHOLD_MEAN_POSITION_NORM = 0.5
     if mean_position_norm > THRESHOLD_MEAN_POSITION_NORM:
@@ -98,6 +100,20 @@ def process_directory(
         final_summary += f"|{mean_angle_norm=:.3f} [deg] is too large."
     else:
         final_summary += f"|{mean_angle_norm=:.3f} [deg]"
+
+    THRESHOLD_MEAN_LINEAR_VELOCITY_NORM = 0.05
+    if mean_linear_velocity_norm > THRESHOLD_MEAN_LINEAR_VELOCITY_NORM:
+        final_success = False
+        final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s] is too large."
+    else:
+        final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s]"
+
+    THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM = 0.05
+    if mean_angular_velocity_norm > THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM:
+        final_success = False
+        final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s] is too large."
+    else:
+        final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s]"
 
     with open(save_dir / "summary.json", "w") as f:
         json.dump(

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -2,14 +2,14 @@
 """A script to analyze rosbags in parallel."""
 
 import argparse
+import json
 from multiprocessing import Pool
 from pathlib import Path
 
 import compare_trajectories
 import extract_values_from_rosbag
-import plot_diagnostics
 import pandas as pd
-import json
+import plot_diagnostics
 
 
 def parse_args() -> argparse.Namespace:
@@ -78,8 +78,7 @@ def process_directory(
 
     ## (6-1) relative pose
     relative_pose_tsv = (
-        save_dir
-        / "compare_trajectories/localization__kinematic_state_result/relative_pose.tsv"
+        save_dir / "compare_trajectories/localization__kinematic_state_result/relative_pose.tsv"
     )
     df = pd.read_csv(relative_pose_tsv, sep="\t")
     mean_position_norm = df["position.norm"].mean()
@@ -123,14 +122,10 @@ def process_directory(
         "ndt_scan_matcher__scan_matching_status",
     ]
     for target_tsv in target_tsv_list:
-        localization_ekf_diagnostics_tsv = (
-            diagnostics_result_dir / f"{target_tsv}.tsv"
-        )
+        localization_ekf_diagnostics_tsv = diagnostics_result_dir / f"{target_tsv}.tsv"
         df = pd.read_csv(localization_ekf_diagnostics_tsv, sep="\t")
         # filter out WARNs before activation
-        df = df[
-            df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"
-        ]
+        df = df[df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"]
         not_ok_num = len(df[df["level"] != 0])
         not_ok_percentage = not_ok_num / len(df) * 100
         if not_ok_percentage > 1:

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -76,7 +76,7 @@ def process_directory(
     final_success = True
     final_summary = ""
 
-    ## (6-1) relative pose
+    # (6-1) relative pose
     relative_pose_tsv = (
         save_dir / "compare_trajectories/localization__kinematic_state_result/relative_pose.tsv"
     )
@@ -114,7 +114,7 @@ def process_directory(
     else:
         final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s]"
 
-    ## (6-2) diagnostics
+    # (6-2) diagnostics
     target_tsv_list = [
         "localization__ekf_localizer",
         "localization__pose_instability_detector",

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
@@ -16,6 +16,8 @@ def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFra
         "orientation.z",
         "orientation.w",
     ]
+    linear_velocity_keys = ["linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]
+    angular_velocity_keys = ["angular_velocity.x", "angular_velocity.y", "angular_velocity.z"]
     assert len(df_prd) == len(df_ref)
 
     df_relative = df_prd.copy()
@@ -49,6 +51,19 @@ def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFra
     df_relative["angle.z"] = euler[:, 2]
     df_relative["angle.norm"] = np.linalg.norm(r.as_rotvec(), axis=1)
 
+    # Add linear velocity
+    df_relative[linear_velocity_keys] = df_prd[linear_velocity_keys].to_numpy() - df_ref[linear_velocity_keys].to_numpy()
+    df_relative["linear_velocity.norm"] = np.linalg.norm(
+        df_relative[linear_velocity_keys].values,
+        axis=1,
+    )
+    # Add angular velocity
+    df_relative[angular_velocity_keys] = df_prd[angular_velocity_keys].to_numpy() - df_ref[angular_velocity_keys].to_numpy()
+    df_relative["angular_velocity.norm"] = np.linalg.norm(
+        df_relative[angular_velocity_keys].values,
+        axis=1,
+    )
+
     # Arrange the order of columns
     return df_relative[
         [
@@ -60,5 +75,9 @@ def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFra
             "angle.y",
             "angle.z",
             "angle.norm",
+            *linear_velocity_keys,
+            "linear_velocity.norm",
+            *angular_velocity_keys,
+            "angular_velocity.norm",
         ]
     ]

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
@@ -52,13 +52,17 @@ def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFra
     df_relative["angle.norm"] = np.linalg.norm(r.as_rotvec(), axis=1)
 
     # Add linear velocity
-    df_relative[linear_velocity_keys] = df_prd[linear_velocity_keys].to_numpy() - df_ref[linear_velocity_keys].to_numpy()
+    df_relative[linear_velocity_keys] = (
+        df_prd[linear_velocity_keys].to_numpy() - df_ref[linear_velocity_keys].to_numpy()
+    )
     df_relative["linear_velocity.norm"] = np.linalg.norm(
         df_relative[linear_velocity_keys].values,
         axis=1,
     )
     # Add angular velocity
-    df_relative[angular_velocity_keys] = df_prd[angular_velocity_keys].to_numpy() - df_ref[angular_velocity_keys].to_numpy()
+    df_relative[angular_velocity_keys] = (
+        df_prd[angular_velocity_keys].to_numpy() - df_ref[angular_velocity_keys].to_numpy()
+    )
     df_relative["angular_velocity.norm"] = np.linalg.norm(
         df_relative[angular_velocity_keys].values,
         axis=1,

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
@@ -1,11 +1,13 @@
 """A script to interpolate poses to match the timestamp in target_timestamp."""
+# cspell:ignore rotvec
 
 import pandas as pd
-from scipy.spatial.transform import Rotation
-from scipy.spatial.transform import Slerp
+from scipy.spatial.transform import Rotation, Slerp
 
 
-def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.DataFrame:
+def interpolate_pose(
+    df_pose: pd.DataFrame, target_timestamp: pd.Series
+) -> pd.DataFrame:
     """Interpolate each pose in df_pose to match the timestamp in target_timestamp."""
     # check monotonicity
     assert df_pose["timestamp"].is_monotonic_increasing
@@ -26,8 +28,16 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         "orientation.z",
         "orientation.w",
     ]
-    linear_velocity_keys = ["linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]
-    angular_velocity_keys = ["angular_velocity.x", "angular_velocity.y", "angular_velocity.z"]
+    linear_velocity_keys = [
+        "linear_velocity.x",
+        "linear_velocity.y",
+        "linear_velocity.z",
+    ]
+    angular_velocity_keys = [
+        "angular_velocity.x",
+        "angular_velocity.y",
+        "angular_velocity.z",
+    ]
 
     df_pose = df_pose.reset_index(drop=True)
     target_timestamp = target_timestamp.reset_index(drop=True)
@@ -76,7 +86,8 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         curr_r_ang_vel = Rotation.from_rotvec(curr_angular_velocity)
         next_r_ang_vel = Rotation.from_rotvec(next_angular_velocity)
         slerp_ang_vel = Slerp(
-            [curr_time, next_time], Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel])
+            [curr_time, next_time],
+            Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel]),
         )
         target_angular_velocity = slerp_ang_vel([target_time]).as_rotvec()[0]
 

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
@@ -67,13 +67,17 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
 
         curr_linear_velocity = df_pose.iloc[df_index][linear_velocity_keys]
         next_linear_velocity = df_pose.iloc[df_index + 1][linear_velocity_keys]
-        target_linear_velocity = curr_linear_velocity * curr_weight + next_linear_velocity * next_weight
+        target_linear_velocity = (
+            curr_linear_velocity * curr_weight + next_linear_velocity * next_weight
+        )
 
         curr_angular_velocity = df_pose.iloc[df_index][angular_velocity_keys]
         next_angular_velocity = df_pose.iloc[df_index + 1][angular_velocity_keys]
         curr_r_ang_vel = Rotation.from_rotvec(curr_angular_velocity)
         next_r_ang_vel = Rotation.from_rotvec(next_angular_velocity)
-        slerp_ang_vel = Slerp([curr_time, next_time], Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel]))
+        slerp_ang_vel = Slerp(
+            [curr_time, next_time], Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel])
+        )
         target_angular_velocity = slerp_ang_vel([target_time]).as_rotvec()[0]
 
         data_dict["timestamp"].append(target_time)

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
@@ -26,6 +26,8 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         "orientation.z",
         "orientation.w",
     ]
+    linear_velocity_keys = ["linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]
+    angular_velocity_keys = ["angular_velocity.x", "angular_velocity.y", "angular_velocity.z"]
 
     df_pose = df_pose.reset_index(drop=True)
     target_timestamp = target_timestamp.reset_index(drop=True)
@@ -36,6 +38,8 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         "timestamp": [],
         **{key: [] for key in position_keys},
         **{key: [] for key in orientation_keys},
+        **{key: [] for key in linear_velocity_keys},
+        **{key: [] for key in angular_velocity_keys},
     }
     while df_index < len(df_pose) - 1 and target_index < len(target_timestamp):
         curr_time = df_pose.iloc[df_index]["timestamp"]
@@ -61,6 +65,17 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         slerp = Slerp([curr_time, next_time], Rotation.concatenate([curr_r, next_r]))
         target_orientation = slerp([target_time]).as_quat()[0]
 
+        curr_linear_velocity = df_pose.iloc[df_index][linear_velocity_keys]
+        next_linear_velocity = df_pose.iloc[df_index + 1][linear_velocity_keys]
+        target_linear_velocity = curr_linear_velocity * curr_weight + next_linear_velocity * next_weight
+
+        curr_angular_velocity = df_pose.iloc[df_index][angular_velocity_keys]
+        next_angular_velocity = df_pose.iloc[df_index + 1][angular_velocity_keys]
+        curr_r_ang_vel = Rotation.from_rotvec(curr_angular_velocity)
+        next_r_ang_vel = Rotation.from_rotvec(next_angular_velocity)
+        slerp_ang_vel = Slerp([curr_time, next_time], Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel]))
+        target_angular_velocity = slerp_ang_vel([target_time]).as_rotvec()[0]
+
         data_dict["timestamp"].append(target_time)
         data_dict[position_keys[0]].append(target_position[0])
         data_dict[position_keys[1]].append(target_position[1])
@@ -69,5 +84,11 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         data_dict[orientation_keys[1]].append(target_orientation[1])
         data_dict[orientation_keys[2]].append(target_orientation[2])
         data_dict[orientation_keys[3]].append(target_orientation[3])
+        data_dict[linear_velocity_keys[0]].append(target_linear_velocity[0])
+        data_dict[linear_velocity_keys[1]].append(target_linear_velocity[1])
+        data_dict[linear_velocity_keys[2]].append(target_linear_velocity[2])
+        data_dict[angular_velocity_keys[0]].append(target_angular_velocity[0])
+        data_dict[angular_velocity_keys[1]].append(target_angular_velocity[1])
+        data_dict[angular_velocity_keys[2]].append(target_angular_velocity[2])
         target_index += 1
     return pd.DataFrame(data_dict)

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
@@ -1,13 +1,13 @@
 """A script to interpolate poses to match the timestamp in target_timestamp."""
+
 # cspell:ignore rotvec
 
 import pandas as pd
-from scipy.spatial.transform import Rotation, Slerp
+from scipy.spatial.transform import Rotation
+from scipy.spatial.transform import Slerp
 
 
-def interpolate_pose(
-    df_pose: pd.DataFrame, target_timestamp: pd.Series
-) -> pd.DataFrame:
+def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.DataFrame:
     """Interpolate each pose in df_pose to match the timestamp in target_timestamp."""
     # check monotonicity
     assert df_pose["timestamp"].is_monotonic_increasing


### PR DESCRIPTION
## Description

Correspond to https://github.com/tier4/driving_log_replayer_v2/pull/165

This PR adds computation and output of a `summary.json` file capturing position, angle, linear velocity, and angular velocity metrics for localization evaluation.

- Extend interpolation to include linear and angular velocity
- Compute relative velocity norms alongside pose differences
- Generate `summary.json` with thresholds and pass/fail summary in the parallel analysis script

`summary.json` is used for [driving_log_replayer_v2](https://github.com/tier4/driving_log_replayer_v2).

`driving_log_replayer_v2` outputs a `result.jsonl` and the final line of that file is treated as the total result of the test case.

![dlr drawio](https://github.com/user-attachments/assets/5757e9dc-b6d7-4769-97d9-39b142e2b757)

Evaluator test -> [TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/40a651b0-d3f3-5222-8fbd-93682657b8a9?project_id=autoware_dev)

## How was this PR tested?

```bash
source ~/autoware/install/setup.bash
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py \
    play_rate:=1.0 \
    storage:=mcap \
    scenario_path:=$HOME/driving_log_replayer_v2/localization.yaml
```

and check

```bash
cat ~/driving_log_replayer_v2/out/latest/result_archive/summary.json
```

Result:

```bash
{
  "Result": {
    "Success": false,
    "Summary": "mean_position_norm=0.157 [m]|mean_angle_norm=0.031 [deg]|mean_linear_velocity_norm=0.003 [m/s]|mean_angular_velocity_norm=0.001 [rad/s]|localization__ekf_localizer 12.992 [%] is too large.|localization__pose_instability_detector 1.124 [%] is too large.|localization_error_monitor__ellipse_error_status 12.988 [%] is too large.|ndt_scan_matcher__scan_matching_status 57.276 [%] is too large."
  }
}
```

## Notes for reviewers

None.

## Effects on system behavior

None.
