### PR TITLE
fix: to apply to a pose only tsv file

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
@@ -51,6 +51,21 @@ def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFra
     df_relative["angle.z"] = euler[:, 2]
     df_relative["angle.norm"] = np.linalg.norm(r.as_rotvec(), axis=1)
 
+    if "linear_velocity.x" not in df_prd.columns:
+        # If linear_velocity is not in the DataFrame, return the relative pose without it
+        return df_relative[
+            [
+                "timestamp",
+                *position_keys,
+                "position.norm",
+                *orientation_keys,
+                "angle.x",
+                "angle.y",
+                "angle.z",
+                "angle.norm",
+            ]
+        ]
+
     # Add linear velocity
     df_relative[linear_velocity_keys] = (
         df_prd[linear_velocity_keys].to_numpy() - df_ref[linear_velocity_keys].to_numpy()


### PR DESCRIPTION
## Description

Fixed the `calc_relative_pose.py` script so that it can be used  with a pose-only tsv file.

## How was this PR tested?

Applied to `localization/pose_twist_fusion_filter/pose`

```bash
ros2 run autoware_localization_evaluation_scripts compare_trajectories.py \
    /home/shintarosakoda/data/misc/20250617_130521_ndt/localization__pose_twist_fusion_filter__pose.tsv \
    /home/shintarosakoda/data/misc/20250617_130521_ndt/awsim__ground_truth__localization__kinematic_state.tsv
```

## Notes for reviewers

None.

## Effects on system behavior

None.
