### PR TITLE
refactor(driving_environment_analyzer): remove lane departure checker dependency

### DIFF
--- a/driving_environment_analyzer/package.xml
+++ b/driving_environment_analyzer/package.xml
@@ -16,7 +16,6 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_behavior_path_planner_common</depend>
-  <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>


### PR DESCRIPTION
## Description

Remove lane departure checker from package due to it is not used.


## How was this PR tested?

Build success

## Notes for reviewers

None.

## Effects on system behavior

None.
