### PR TITLE
feat: add acceleration evaluation

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -6,19 +6,25 @@ import json
 from multiprocessing import Pool
 from pathlib import Path
 
+import pandas as pd
+
 import compare_trajectories
 import extract_values_from_rosbag
-import pandas as pd
 import plot_diagnostics
+from utils.calc_acceleration_diff import calc_acceleration_diff
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("result_dir", type=Path)
     parser.add_argument("--parallel_num", type=int, default=1)
-    parser.add_argument("--topic_subject", type=str, default="/localization/kinematic_state")
     parser.add_argument(
-        "--topic_reference", type=str, default="/localization/pose_estimator/pose_with_covariance"
+        "--topic_subject", type=str, default="/localization/kinematic_state"
+    )
+    parser.add_argument(
+        "--topic_reference",
+        type=str,
+        default="/localization/pose_estimator/pose_with_covariance",
     )
     parser.add_argument("--save_dir_relative", type=str, default="")
     return parser.parse_args()
@@ -37,8 +43,12 @@ def process_directory(
     plot_diagnostics.main(rosbag_path=target_rosbag, save_dir=diagnostics_result_dir)
 
     # (2) Extract values from rosbag
-    save_name_subject = extract_values_from_rosbag.topic_name_to_save_name(topic_subject)
-    save_name_reference = extract_values_from_rosbag.topic_name_to_save_name(topic_reference)
+    save_name_subject = extract_values_from_rosbag.topic_name_to_save_name(
+        topic_subject
+    )
+    save_name_reference = extract_values_from_rosbag.topic_name_to_save_name(
+        topic_reference
+    )
     extract_values_from_rosbag.main(
         rosbag_path=target_rosbag,
         target_topics=[
@@ -78,14 +88,13 @@ def process_directory(
 
     # (6-1) relative pose
     relative_pose_tsv = (
-        save_dir / "compare_trajectories/localization__kinematic_state_result/relative_pose.tsv"
+        save_dir
+        / "compare_trajectories/localization__kinematic_state_result/relative_pose.tsv"
     )
     df = pd.read_csv(relative_pose_tsv, sep="\t")
-    mean_position_norm = df["position.norm"].mean()
-    mean_angle_norm = df["angle.norm"].mean()
-    mean_linear_velocity_norm = df["linear_velocity.norm"].mean()
-    mean_angular_velocity_norm = df["angular_velocity.norm"].mean()
 
+    # position
+    mean_position_norm = df["position.norm"].mean()
     THRESHOLD_MEAN_POSITION_NORM = 0.5
     if mean_position_norm > THRESHOLD_MEAN_POSITION_NORM:
         final_success = False
@@ -93,6 +102,8 @@ def process_directory(
     else:
         final_summary += f"{mean_position_norm=:.3f} [m]"
 
+    # angle
+    mean_angle_norm = df["angle.norm"].mean()
     THRESHOLD_MEAN_ANGLE_NORM = 0.5
     if mean_angle_norm > THRESHOLD_MEAN_ANGLE_NORM:
         final_success = False
@@ -100,19 +111,48 @@ def process_directory(
     else:
         final_summary += f"|{mean_angle_norm=:.3f} [deg]"
 
-    THRESHOLD_MEAN_LINEAR_VELOCITY_NORM = 0.05
-    if mean_linear_velocity_norm > THRESHOLD_MEAN_LINEAR_VELOCITY_NORM:
-        final_success = False
-        final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s] is too large."
-    else:
-        final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s]"
+    # linear velocity
+    if "linear_velocity.norm" in df.columns:
+        mean_linear_velocity_norm = df["linear_velocity.norm"].mean()
+        THRESHOLD_MEAN_LINEAR_VELOCITY_NORM = 0.05
+        if mean_linear_velocity_norm > THRESHOLD_MEAN_LINEAR_VELOCITY_NORM:
+            final_success = False
+            final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s] is too large."
+        else:
+            final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s]"
 
-    THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM = 0.05
-    if mean_angular_velocity_norm > THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM:
-        final_success = False
-        final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s] is too large."
-    else:
-        final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s]"
+    # angular velocity
+    if "angular_velocity.norm" in df.columns:
+        mean_angular_velocity_norm = df["angular_velocity.norm"].mean()
+        THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM = 0.05
+        if mean_angular_velocity_norm > THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM:
+            final_success = False
+            final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s] is too large."
+        else:
+            final_summary += f"|{mean_angular_velocity_norm=:.3f} [rad/s]"
+
+    # acceleration
+    df_ref = pd.read_csv(compare_result_dir / f"{save_name_reference}.tsv", sep="\t")
+    if "linear_velocity.x" in df_ref.columns:
+        THRESHOLD_MEAN_ACCELERATION_NORM = 0.5
+        acceleration_tsv = (
+            save_dir / "result_acceleration/localization__acceleration.tsv"
+        )
+        df_acceleration = pd.read_csv(acceleration_tsv, sep="\t")
+        df_result = calc_acceleration_diff(df_acceleration, df_ref)
+        df_result.to_csv(
+            save_dir / "result_acceleration/localization__acceleration_diff.tsv",
+            sep="\t",
+            index=False,
+        )
+        mean_acceleration_norm_diff = df_result["diff.norm"].mean()
+
+        # Check threshold
+        if mean_acceleration_norm_diff > THRESHOLD_MEAN_ACCELERATION_NORM:
+            final_success = False
+            final_summary += f"|{mean_acceleration_norm_diff=:.3f} [m/s²] is too large."
+        else:
+            final_summary += f"|{mean_acceleration_norm_diff=:.3f} [m/s²]"
 
     # (6-2) diagnostics
     target_tsv_list = [
@@ -125,7 +165,10 @@ def process_directory(
         localization_ekf_diagnostics_tsv = diagnostics_result_dir / f"{target_tsv}.tsv"
         df = pd.read_csv(localization_ekf_diagnostics_tsv, sep="\t")
         # filter out WARNs before activation
-        df = df[df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"]
+        df = df[
+            df["message"]
+            != "[WARN]process is not activated; [WARN]initial pose is not set"
+        ]
         not_ok_num = len(df[df["level"] != 0])
         if len(df) == 0:
             not_ok_percentage = 0
@@ -159,7 +202,9 @@ if __name__ == "__main__":
     topic_reference = args.topic_reference
     save_dir_relative = args.save_dir_relative
 
-    target_rosbags = list(result_dir.glob("**/*.db3")) + list(result_dir.glob("**/*.mcap"))
+    target_rosbags = list(result_dir.glob("**/*.db3")) + list(
+        result_dir.glob("**/*.mcap")
+    )
     directories = [path.parent.parent for path in target_rosbags]
     directories = list(set(directories))
     directories = [d for d in directories if not d.is_symlink()]
@@ -168,5 +213,8 @@ if __name__ == "__main__":
     with Pool(args.parallel_num) as pool:
         pool.starmap(
             process_directory,
-            [(d, topic_subject, topic_reference, save_dir_relative) for d in directories],
+            [
+                (d, topic_subject, topic_reference, save_dir_relative)
+                for d in directories
+            ],
         )

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
@@ -33,7 +33,7 @@ def calc_acceleration_diff(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.Dat
 
     # Calculate acceleration from reference velocity (numerical differentiation)
     df_ref_vel = df_ref_vel.sort_values("timestamp")
-    dt = (df_ref_vel["timestamp"].diff() / 1e9)  # Convert to seconds
+    dt = df_ref_vel["timestamp"].diff() / 1e9  # Convert to seconds
 
     # Protect against division by zero and very small time differences
     MIN_DT_THRESHOLD = 1e-6  # Minimum time difference threshold (1 microsecond)

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
@@ -1,0 +1,94 @@
+import pandas as pd
+import numpy as np
+from scipy.interpolate import interp1d
+
+
+def calc_acceleration_diff(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFrame:
+    """Calculate the difference in linear acceleration between two DataFrames.
+    df_prd has ["timestamp", "linear.x", "linear.y", "linear.z"] (acceleration)
+    df_ref has ["timestamp", "linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]
+    """
+
+    df_prd_acc = df_prd[["timestamp", "linear.x", "linear.y", "linear.z"]]
+    df_ref_vel = df_ref[
+        ["timestamp", "linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]
+    ]
+
+    # Calculate acceleration from reference velocity (numerical differentiation)
+    df_ref_vel = df_ref_vel.sort_values("timestamp")
+    dt = (df_ref_vel["timestamp"].diff() / 1e9).fillna(0)  # Convert to seconds
+    df_ref_acc = df_ref_vel.copy()
+    df_ref_acc["linear_velocity.x"] = df_ref_vel["linear_velocity.x"].diff() / dt
+    df_ref_acc["linear_velocity.y"] = df_ref_vel["linear_velocity.y"].diff() / dt
+    df_ref_acc["linear_velocity.z"] = df_ref_vel["linear_velocity.z"].diff() / dt
+    df_ref_acc = df_ref_acc.dropna()  # Remove first row with NaN
+
+    # Rename columns to match acceleration data
+    df_ref_acc = df_ref_acc.rename(
+        columns={
+            "linear_velocity.x": "linear.x",
+            "linear_velocity.y": "linear.y",
+            "linear_velocity.z": "linear.z",
+        }
+    )
+
+    # Interpolate reference acceleration to match timestamp of measured acceleration
+
+    # Remove duplicate timestamps and sort
+    df_ref_acc = df_ref_acc.drop_duplicates(subset=["timestamp"]).sort_values(
+        "timestamp"
+    )
+    df_prd_acc = df_prd_acc.drop_duplicates(subset=["timestamp"]).sort_values(
+        "timestamp"
+    )
+
+    min_timestamp = max(df_ref_acc["timestamp"].min(), df_prd_acc["timestamp"].min())
+    max_timestamp = min(df_ref_acc["timestamp"].max(), df_prd_acc["timestamp"].max())
+
+    df_ref_acc = df_ref_acc[
+        (min_timestamp <= df_ref_acc["timestamp"])
+        & (df_ref_acc["timestamp"] <= max_timestamp)
+    ]
+    df_prd_acc = df_prd_acc[
+        (min_timestamp <= df_prd_acc["timestamp"])
+        & (df_prd_acc["timestamp"] <= max_timestamp)
+    ]
+
+    # Create interpolation functions for each axis
+    assert len(df_ref_acc) > 1 and len(df_prd_acc) > 1
+
+    interp_x = interp1d(
+        df_ref_acc["timestamp"],
+        df_ref_acc["linear.x"],
+        kind="linear",
+        fill_value="extrapolate",
+    )
+    interp_y = interp1d(
+        df_ref_acc["timestamp"],
+        df_ref_acc["linear.y"],
+        kind="linear",
+        fill_value="extrapolate",
+    )
+    interp_z = interp1d(
+        df_ref_acc["timestamp"],
+        df_ref_acc["linear.z"],
+        kind="linear",
+        fill_value="extrapolate",
+    )
+
+    # Interpolate reference acceleration at measured timestamps
+    df_result = df_prd_acc.copy()
+    df_result["reference.linear.x"] = interp_x(df_result["timestamp"])
+    df_result["reference.linear.y"] = interp_y(df_result["timestamp"])
+    df_result["reference.linear.z"] = interp_z(df_result["timestamp"])
+
+    # Calculate differences between measured and reference acceleration
+    df_result["diff.x"] = df_prd_acc["linear.x"] - df_result["reference.linear.x"]
+    df_result["diff.y"] = df_prd_acc["linear.y"] - df_result["reference.linear.y"]
+    df_result["diff.z"] = df_prd_acc["linear.z"] - df_result["reference.linear.z"]
+    df_result["diff.norm"] = np.sqrt(
+        df_result["diff.x"] ** 2
+        + df_result["diff.y"] ** 2
+        + df_result["diff.z"] ** 2
+    )
+    return df_result

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
@@ -5,10 +5,10 @@ from scipy.interpolate import interp1d
 
 def calc_acceleration_diff(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFrame:
     """Calculate the difference in linear acceleration between two DataFrames.
+
     df_prd has ["timestamp", "linear.x", "linear.y", "linear.z"] (acceleration)
     df_ref has ["timestamp", "linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]
     """
-
     df_prd_acc = df_prd[["timestamp", "linear.x", "linear.y", "linear.z"]]
     df_ref_vel = df_ref[
         ["timestamp", "linear_velocity.x", "linear_velocity.y", "linear_velocity.z"]

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_acceleration_diff.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
 from scipy.interpolate import interp1d
 
 
@@ -35,23 +35,17 @@ def calc_acceleration_diff(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.Dat
     # Interpolate reference acceleration to match timestamp of measured acceleration
 
     # Remove duplicate timestamps and sort
-    df_ref_acc = df_ref_acc.drop_duplicates(subset=["timestamp"]).sort_values(
-        "timestamp"
-    )
-    df_prd_acc = df_prd_acc.drop_duplicates(subset=["timestamp"]).sort_values(
-        "timestamp"
-    )
+    df_ref_acc = df_ref_acc.drop_duplicates(subset=["timestamp"]).sort_values("timestamp")
+    df_prd_acc = df_prd_acc.drop_duplicates(subset=["timestamp"]).sort_values("timestamp")
 
     min_timestamp = max(df_ref_acc["timestamp"].min(), df_prd_acc["timestamp"].min())
     max_timestamp = min(df_ref_acc["timestamp"].max(), df_prd_acc["timestamp"].max())
 
     df_ref_acc = df_ref_acc[
-        (min_timestamp <= df_ref_acc["timestamp"])
-        & (df_ref_acc["timestamp"] <= max_timestamp)
+        (min_timestamp <= df_ref_acc["timestamp"]) & (df_ref_acc["timestamp"] <= max_timestamp)
     ]
     df_prd_acc = df_prd_acc[
-        (min_timestamp <= df_prd_acc["timestamp"])
-        & (df_prd_acc["timestamp"] <= max_timestamp)
+        (min_timestamp <= df_prd_acc["timestamp"]) & (df_prd_acc["timestamp"] <= max_timestamp)
     ]
 
     # Create interpolation functions for each axis
@@ -87,8 +81,6 @@ def calc_acceleration_diff(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.Dat
     df_result["diff.y"] = df_prd_acc["linear.y"] - df_result["reference.linear.y"]
     df_result["diff.z"] = df_prd_acc["linear.z"] - df_result["reference.linear.z"]
     df_result["diff.norm"] = np.sqrt(
-        df_result["diff.x"] ** 2
-        + df_result["diff.y"] ** 2
-        + df_result["diff.z"] ** 2
+        df_result["diff.x"] ** 2 + df_result["diff.y"] ** 2 + df_result["diff.z"] ** 2
     )
     return df_result

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
@@ -9,7 +9,6 @@ from scipy.spatial.transform import Rotation
 
 def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFrame:
     """Calculate the relative position and orientation of df_prd with respect to df_ref."""
-
     position_keys = ["position.x", "position.y", "position.z"]
     orientation_keys = [
         "orientation.x",

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
@@ -51,7 +51,7 @@ def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFra
     df_relative["angle.z"] = euler[:, 2]
     df_relative["angle.norm"] = np.linalg.norm(r.as_rotvec(), axis=1)
 
-    if "linear_velocity.x" not in df_prd.columns:
+    if "linear_velocity.x" not in df_prd.columns or "linear_velocity.x" not in df_ref.columns:
         # If linear_velocity is not in the DataFrame, return the relative pose without it
         return df_relative[
             [

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/calc_relative_pose.py
@@ -9,6 +9,7 @@ from scipy.spatial.transform import Rotation
 
 def calc_relative_pose(df_prd: pd.DataFrame, df_ref: pd.DataFrame) -> pd.DataFrame:
     """Calculate the relative position and orientation of df_prd with respect to df_ref."""
+
     position_keys = ["position.x", "position.y", "position.z"]
     orientation_keys = [
         "orientation.x",

--- a/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/utils/interpolate_pose.py
@@ -21,6 +21,8 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
     assert df_pose.iloc[0]["timestamp"] <= target_timestamp.iloc[0]
     assert target_timestamp.iloc[-1] <= df_pose.iloc[-1]["timestamp"]
 
+    has_velocity = "linear_velocity.x" in df_pose.columns
+
     position_keys = ["position.x", "position.y", "position.z"]
     orientation_keys = [
         "orientation.x",
@@ -48,9 +50,12 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         "timestamp": [],
         **{key: [] for key in position_keys},
         **{key: [] for key in orientation_keys},
-        **{key: [] for key in linear_velocity_keys},
-        **{key: [] for key in angular_velocity_keys},
     }
+    if has_velocity:
+        data_dict.update(
+            **{key: [] for key in linear_velocity_keys},
+            **{key: [] for key in angular_velocity_keys},
+        )
     while df_index < len(df_pose) - 1 and target_index < len(target_timestamp):
         curr_time = df_pose.iloc[df_index]["timestamp"]
         next_time = df_pose.iloc[df_index + 1]["timestamp"]
@@ -75,22 +80,6 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         slerp = Slerp([curr_time, next_time], Rotation.concatenate([curr_r, next_r]))
         target_orientation = slerp([target_time]).as_quat()[0]
 
-        curr_linear_velocity = df_pose.iloc[df_index][linear_velocity_keys]
-        next_linear_velocity = df_pose.iloc[df_index + 1][linear_velocity_keys]
-        target_linear_velocity = (
-            curr_linear_velocity * curr_weight + next_linear_velocity * next_weight
-        )
-
-        curr_angular_velocity = df_pose.iloc[df_index][angular_velocity_keys]
-        next_angular_velocity = df_pose.iloc[df_index + 1][angular_velocity_keys]
-        curr_r_ang_vel = Rotation.from_rotvec(curr_angular_velocity)
-        next_r_ang_vel = Rotation.from_rotvec(next_angular_velocity)
-        slerp_ang_vel = Slerp(
-            [curr_time, next_time],
-            Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel]),
-        )
-        target_angular_velocity = slerp_ang_vel([target_time]).as_rotvec()[0]
-
         data_dict["timestamp"].append(target_time)
         data_dict[position_keys[0]].append(target_position[0])
         data_dict[position_keys[1]].append(target_position[1])
@@ -99,11 +88,29 @@ def interpolate_pose(df_pose: pd.DataFrame, target_timestamp: pd.Series) -> pd.D
         data_dict[orientation_keys[1]].append(target_orientation[1])
         data_dict[orientation_keys[2]].append(target_orientation[2])
         data_dict[orientation_keys[3]].append(target_orientation[3])
-        data_dict[linear_velocity_keys[0]].append(target_linear_velocity[0])
-        data_dict[linear_velocity_keys[1]].append(target_linear_velocity[1])
-        data_dict[linear_velocity_keys[2]].append(target_linear_velocity[2])
-        data_dict[angular_velocity_keys[0]].append(target_angular_velocity[0])
-        data_dict[angular_velocity_keys[1]].append(target_angular_velocity[1])
-        data_dict[angular_velocity_keys[2]].append(target_angular_velocity[2])
+
+        if has_velocity:
+            curr_linear_velocity = df_pose.iloc[df_index][linear_velocity_keys]
+            next_linear_velocity = df_pose.iloc[df_index + 1][linear_velocity_keys]
+            target_linear_velocity = (
+                curr_linear_velocity * curr_weight + next_linear_velocity * next_weight
+            )
+
+            curr_angular_velocity = df_pose.iloc[df_index][angular_velocity_keys]
+            next_angular_velocity = df_pose.iloc[df_index + 1][angular_velocity_keys]
+            curr_r_ang_vel = Rotation.from_rotvec(curr_angular_velocity)
+            next_r_ang_vel = Rotation.from_rotvec(next_angular_velocity)
+            slerp_ang_vel = Slerp(
+                [curr_time, next_time],
+                Rotation.concatenate([curr_r_ang_vel, next_r_ang_vel]),
+            )
+            target_angular_velocity = slerp_ang_vel([target_time]).as_rotvec()[0]
+            data_dict[linear_velocity_keys[0]].append(target_linear_velocity[0])
+            data_dict[linear_velocity_keys[1]].append(target_linear_velocity[1])
+            data_dict[linear_velocity_keys[2]].append(target_linear_velocity[2])
+            data_dict[angular_velocity_keys[0]].append(target_angular_velocity[0])
+            data_dict[angular_velocity_keys[1]].append(target_angular_velocity[1])
+            data_dict[angular_velocity_keys[2]].append(target_angular_velocity[2])
+
         target_index += 1
     return pd.DataFrame(data_dict)


### PR DESCRIPTION
## Description

This PR adds acceleration evaluation functionality to the localization evaluation scripts. The main change is adding acceleration difference calculation between measured and reference trajectories, improving the robustness of localization evaluation by making velocity-related checks optional when data is not available.

## How was this PR tested?

```bash
source ~/autoware/install/setup.bash
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py \
    play_rate:=1.0 \
    storage:=mcap \
    scenario_path:=$HOME/driving_log_replayer_v2/localization.yaml
```

then, check

```bash
ls ~/driving_log_replayer_v2/out/latest/result_archive/result_acceleration/
localization__acceleration.tsv  localization__acceleration_diff.tsv
```

## Notes for reviewers

None.

## Effects on system behavior

None.
