### PR TITLE
fix: change the criteria for localization 

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -161,7 +161,6 @@ def process_directory(
         if len(df) == 0:
             not_ok_percentage = 0
         else:
-            not_ok_num = len(df[df["level"] != 0])
             not_ok_percentage = not_ok_num / len(df) * 100
         if not_ok_percentage > 5:
             final_success = False

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -152,10 +152,11 @@ def process_directory(
         "ndt_scan_matcher__scan_matching_status",
     ]
     for target_tsv in target_tsv_list:
-        localization_ekf_diagnostics_tsv = diagnostics_result_dir / f"{target_tsv}.tsv"
-        df = pd.read_csv(localization_ekf_diagnostics_tsv, sep="\t")
+        diagnostics_tsv = diagnostics_result_dir / f"{target_tsv}.tsv"
+        df = pd.read_csv(diagnostics_tsv, sep="\t")
         # filter out WARNs before activation
         df = df[df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"]
+        df = df[df["message"] != "Node is not activated."]
         not_ok_num = len(df[df["level"] != 0])
         if len(df) == 0:
             not_ok_percentage = 0

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -163,7 +163,7 @@ def process_directory(
         else:
             not_ok_num = len(df[df["level"] != 0])
             not_ok_percentage = not_ok_num / len(df) * 100
-        if not_ok_percentage > 1:
+        if not_ok_percentage > 5:
             final_success = False
             final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%] is too large."
         else:


### PR DESCRIPTION
## Description

This PR updates the localization evaluation criteria by changing the input file variable names, filtering logic, and the threshold logic for determining localization success.

- Renamed the diagnostics file variable for clarity.
- Added an extra condition to filter out "Node is not activated." messages.
- Updated the failure threshold from 1% to 5%.

## How was this PR tested?

```bash
source ~/autoware/install/setup.bash
ros2 launch driving_log_replayer_v2 driving_log_replayer_v2.launch.py \
    play_rate:=1.0 \
    scenario_path:=$HOME/driving_log_replayer_v2/localization.yaml
```


## Notes for reviewers

None.

## Effects on system behavior

None.
