### PR TITLE
fix(static_centerline_generator): do not embed a single point centerline

### DIFF
--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -53,7 +53,7 @@ The optimized centerline can be generated from the command line interface by des
 - `<goal-method>` (not mandatory, `path_generator` or `behavior_path_planner` only)
 
 ```sh
-ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> goal_pose:=<goal-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method>
+ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> end_pose:=<end-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method>
 ```
 
 **Note that `<goal-method>:=behavior_path_planner` is not currently supported.**

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -207,8 +207,10 @@ void update_centerline(
       traj_idx == new_centerline.size() - 1 ||
       centerline_lane_id != centerline_lane_ids.at(traj_idx + 1)) {
       const auto & centerline = centerline_map.at(centerline_lane_id);
-      lanelet_map_ptr->add(centerline);
-      lanelet_ref.setCenterline(centerline);
+      if (centerline.size() > 1) {
+        lanelet_map_ptr->add(centerline);
+        lanelet_ref.setCenterline(centerline);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

- Fixed so that a single point centerline is not generated.
- Fixed incorrect argument in readme.

## How was this PR tested?

Local test

```sh
ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=true lanelet2_input_file_path:=$HOME/map/one_centerline_test/lanelet2_map.osm start_lanelet_id:=203 start_pose:=[35970.342,56058.19,37.4566,0.0,0.0,-0.883,0.46924]  end_lanelet_id:=12544 end_pose:=[35928.0,55981.745,37.384,0.0,0.0,0.8729,0.48788] vehicle_model:=cargo_transport goal_method:=path_generator
```
- [TIER IV Internal map_link](https://tools.tier4.jp/vector_map_builder_ll2/?projectId=autoware_dev&areaMapId=1235&versionId=1235-20250611102924054472)

## Notes for reviewers

None.

## Effects on system behavior

None.
