### PR TITLE
fix(parameter_estimatior): update package dependencies

### DIFF
--- a/vehicle/parameter_estimator/launch/parameter_estimator_with_simulation.launch.xml
+++ b/vehicle/parameter_estimator/launch/parameter_estimator_with_simulation.launch.xml
@@ -12,7 +12,7 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd"/>
 
   <!-- Vehicle -->
-  <include file="$(find-pkg-share vehicle_launch)/launch/vehicle.launch.xml">
+  <include file="$(find-pkg-share tier4_vehicle_launch)/launch/vehicle.launch.xml">
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
     <arg name="sensor_model" value="$(var sensor_model)"/>
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
@@ -20,7 +20,7 @@
   </include>
 
   <!-- Map -->
-  <include file="$(find-pkg-share map_launch)/launch/map.launch.xml">
+  <include file="$(find-pkg-share tier4_map_launch)/launch/map.launch.xml">
     <arg name="pointcloud_map_path" value="$(var map_path)/$(var pointcloud_map_file)"/>
     <arg name="pointcloud_map_metadata_path" value="$(var map_path)/pointcloud_map_metadata.yaml"/>
     <arg name="lanelet2_map_path" value="$(var map_path)/$(var lanelet2_map_file)"/>
@@ -35,10 +35,4 @@
   <!-- Rviz -->
   <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share time_delay_estimator)/config/time_delay_estimator_viz.rviz" if="$(var rviz)"/>
 
-  <!-- visualization -->
-  <include file="$(find-pkg-share dynamic_object_visualization)/launch/dynamic_object_visualizer.launch.xml">
-    <arg name="input" value="/perception/object_recognition/objects"/>
-    <arg name="with_feature" value="false"/>
-    <arg name="only_known_objects" value="true"/>
-  </include>
 </launch>

--- a/vehicle/parameter_estimator/launch/parameter_estimator_with_simulation.launch.xml
+++ b/vehicle/parameter_estimator/launch/parameter_estimator_with_simulation.launch.xml
@@ -34,5 +34,4 @@
 
   <!-- Rviz -->
   <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(find-pkg-share time_delay_estimator)/config/time_delay_estimator_viz.rviz" if="$(var rviz)"/>
-
 </launch>

--- a/vehicle/parameter_estimator/package.xml
+++ b/vehicle/parameter_estimator/package.xml
@@ -21,12 +21,11 @@
   <exec_depend>autoware_global_parameter_loader</exec_depend>
   <exec_depend>autoware_launch</exec_depend>
   <exec_depend>calibration_adapter</exec_depend>
-  <exec_depend>dynamic_object_visualization</exec_depend>
-  <exec_depend>map_launch</exec_depend>
+  <exec_depend>tier4_map_launch</exec_depend>
   <exec_depend>plotjuggler</exec_depend>
   <exec_depend>plotjuggler_ros</exec_depend>
   <exec_depend>time_delay_estimator</exec_depend>
-  <exec_depend>vehicle_launch</exec_depend>
+  <exec_depend>tier4_vehicle_launch</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/vehicle/parameter_estimator/package.xml
+++ b/vehicle/parameter_estimator/package.xml
@@ -21,11 +21,11 @@
   <exec_depend>autoware_global_parameter_loader</exec_depend>
   <exec_depend>autoware_launch</exec_depend>
   <exec_depend>calibration_adapter</exec_depend>
-  <exec_depend>tier4_map_launch</exec_depend>
   <exec_depend>plotjuggler</exec_depend>
   <exec_depend>plotjuggler_ros</exec_depend>
-  <exec_depend>time_delay_estimator</exec_depend>
+  <exec_depend>tier4_map_launch</exec_depend>
   <exec_depend>tier4_vehicle_launch</exec_depend>
+  <exec_depend>time_delay_estimator</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description

The following packages were modified in the PR, but their dependencies could not be resolved, so they were corrected.

* https://github.com/autowarefoundation/autoware_tools/pull/214

### Cheanges

- Updated vehicle_launch → tier4_vehicle_launch
- Updated map_launch → tier4_map_launch
- Removed dependency on the deleted dynamic_object_visualization package

## How was this PR tested?

rosdep install was successful and local build test successful.

```sh
$ rosdep install --from-paths src --ignore-src -y --rosdistro humble
#All required rosdeps installed successfully
```

## Notes for reviewers

None.

## Effects on system behavior

None.
