### PR TITLE
ci(build-and-test): fix ci issues

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,14 +29,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Free disk space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.2.0
-        with:
-          tool-cache: false
-          dotnet: false
-          swap-storage: false
-          large-packages: false
-
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,7 +21,7 @@ jobs:
           - -cuda
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware:latest-prebuilt
+            container: ghcr.io/autowarefoundation/autoware:universe-devel
             build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -29,7 +29,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.7.0
+    version: 0.8.0
   # universe
   universe/autoware.universe:
     type: git

--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -85,7 +85,7 @@ if(BUILD_TESTING)
   # centerline_source=bag_ego_trajectory_base
   add_launch_test(
     test/test_static_centerline_generator_gui_launch.test.py
-    TIMEOUT 60
+    TIMEOUT 120
   )
   install(DIRECTORY
     test/data/

--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -61,19 +61,19 @@ if(BUILD_TESTING)
   #      various cases with start/end pose
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case1_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "90"
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case2_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "90"
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case3_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "90"
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case4_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "90"
   )
   # # 2.2. goal_method=behavior_path_planner, centerline_source=optimization_trajectory_base
   # # NOTE: Commented out since goal_method=behavior_path_planner is not supported.
@@ -85,7 +85,7 @@ if(BUILD_TESTING)
   # centerline_source=bag_ego_trajectory_base
   add_launch_test(
     test/test_static_centerline_generator_gui_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   install(DIRECTORY
     test/data/

--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -54,38 +54,38 @@ if(BUILD_TESTING)
   # default settings (centerline_source=optimization_trajectory_base, mode=AUTO)
   add_launch_test(
     test/test_static_centerline_generator_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT 30
   )
   # 2. mode=AUTO
   # 2.1. goal_method=path_generator, centerline_source=optimization_trajectory_base
   #      various cases with start/end pose
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case1_launch.test.py
-    TIMEOUT "90"
+    TIMEOUT 90
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case2_launch.test.py
-    TIMEOUT "90"
+    TIMEOUT 90
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case3_launch.test.py
-    TIMEOUT "90"
+    TIMEOUT 90
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case4_launch.test.py
-    TIMEOUT "90"
+    TIMEOUT 90
   )
   # # 2.2. goal_method=behavior_path_planner, centerline_source=optimization_trajectory_base
   # # NOTE: Commented out since goal_method=behavior_path_planner is not supported.
   # add_launch_test(
   #   test/test_static_centerline_generator_behavior_path_planner_launch.test.py
-  #   TIMEOUT "30"
+  #   TIMEOUT 60
   # )
   # 3. mode=GUI
   # centerline_source=bag_ego_trajectory_base
   add_launch_test(
     test/test_static_centerline_generator_gui_launch.test.py
-    TIMEOUT "60"
+    TIMEOUT 60
   )
   install(DIRECTORY
     test/data/

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_gui_launch.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_gui_launch.test.py
@@ -66,7 +66,7 @@ class TestGuiOperation(TestBase):
         )
         self.pub_traj_end_idx.publish(create_Int32(150))
 
-        rclpy.spin_once(self.traj_sub_node, timeout_sec=10.0)
+        rclpy.spin_once(self.traj_sub_node, timeout_sec=30.0)
 
         # validate
         self.pub_validate = self.traj_sub_node.create_publisher(
@@ -82,7 +82,7 @@ class TestGuiOperation(TestBase):
         self.pub_save_map.publish(Empty())
 
         # subscribe the map_saved
-        rclpy.spin_once(self.map_saved_sub_node, timeout_sec=10.0)
+        rclpy.spin_once(self.map_saved_sub_node, timeout_sec=30.0)
 
         # check if the subscription is successful
         self.assertIsNotNone(self.centerline)

--- a/planning/autoware_static_centerline_generator/test/utils/test_utils.py
+++ b/planning/autoware_static_centerline_generator/test/utils/test_utils.py
@@ -86,7 +86,7 @@ class TestBase(unittest.TestCase):
             qos_profile,
         )
         print("spin_once for self.traj_sub_node")
-        rclpy.spin_once(self.traj_sub_node, timeout_sec=20.0)
+        rclpy.spin_once(self.traj_sub_node, timeout_sec=60.0)
 
         # subscribe the map_saved flag
         self.map_saved_sub_node.create_subscription(
@@ -96,7 +96,7 @@ class TestBase(unittest.TestCase):
             qos_profile,
         )
         print("spin_once for self.map_saved_sub_node")
-        rclpy.spin_once(self.map_saved_sub_node, timeout_sec=10.0)
+        rclpy.spin_once(self.map_saved_sub_node, timeout_sec=60.0)
 
         print("end setUp")
 


### PR DESCRIPTION
## Description

Fixes continuously failing https://github.com/autowarefoundation/autoware_tools/actions/workflows/build-and-test.yaml?query=branch%3Amain workflow.

<img width="1281" height="1268" alt="image" src="https://github.com/user-attachments/assets/8657131d-cda2-48e2-8b2c-089b2af6d40e" />

- https://github.com/autowarefoundation/autoware_tools/actions/runs/16639474474/job/47086953489

This jlumbroso/free-disk-space@v1.2.0 is not meant for running in containers. It is meant for workflows that run on github public runners without containers.

## How was this PR tested?

- https://github.com/autowarefoundation/autoware_tools/actions/runs/16657382337 ❌
  - It seems the container name was old too. Updated it with https://github.com/autowarefoundation/autoware_tools/pull/283/commits/af6d9aaf714a578ace913cd8ffd0032edafb180e
- https://github.com/autowarefoundation/autoware_tools/actions/runs/16657441513 ❌
  - Failed due to version mismatch of autoware_lanelet2_extension from current autoware_core. Updating from 0.7.0 to 0.8.0 with https://github.com/autowarefoundation/autoware_tools/pull/283/commits/7be143540060e83e798c83cf32101fe295238081
- https://github.com/autowarefoundation/autoware_tools/actions/runs/16657648834 ❌
  - autoware_static_centerline_generator test failed. Normally tracked by https://github.com/autowarefoundation/autoware_tools/issues/281#issuecomment-3140607422 issue and https://github.com/autowarefoundation/autoware_tools/pull/282 would increase its timeout. But I decided to incorporate that to this PR to see if this will succeed.
- https://github.com/autowarefoundation/autoware_tools/actions/runs/16658220834 ❌
  - Failed again, this time in 38 seconds but it got interrupted.
  - https://github.com/ros2/launch/blob/1abf55ef6d3874ab5a4656e9ac0ea5d057c3c541/launch_testing_ament_cmake/cmake/add_launch_test.cmake#L111 requires integers but we pass it the numbers as strings. It still got them correctly. But I still turned them to integer in the cmakelists file to be on the correct side.
  - I found some more timeouts, maybe they are the source of early shutdown. Trying with https://github.com/autowarefoundation/autoware_tools/pull/283/commits/ee8e866ad8f31671a4c2b9cce8d19791a3323686 now.
- https://github.com/autowarefoundation/autoware_tools/actions/runs/16659179281 ❌
  - This time, Test 8 has passed in multiple attempts! 🎊
  - But Test 10 has some issues, increasing its timeouts too with https://github.com/autowarefoundation/autoware_tools/pull/283/commits/b39afd49ea9d295544af51b6c00ca90192faf94f.
- https://github.com/autowarefoundation/autoware_tools/actions/runs/16659862659 ✅
  - Finally all tests pass with increased timeouts 🎇

## Notes for reviewers

None.

## Effects on system behavior

None.
