### PR TITLE
fix(static_centerline_generator): set unit test timeout to 60s

### DIFF
--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -54,26 +54,26 @@ if(BUILD_TESTING)
   # default settings (centerline_source=optimization_trajectory_base, mode=AUTO)
   add_launch_test(
     test/test_static_centerline_generator_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   # 2. mode=AUTO
   # 2.1. goal_method=path_generator, centerline_source=optimization_trajectory_base
   #      various cases with start/end pose
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case1_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case2_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case3_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   add_launch_test(
     test/test_static_centerline_generator_path_generator_case4_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   # # 2.2. goal_method=behavior_path_planner, centerline_source=optimization_trajectory_base
   # # NOTE: Commented out since goal_method=behavior_path_planner is not supported.
@@ -85,7 +85,7 @@ if(BUILD_TESTING)
   # centerline_source=bag_ego_trajectory_base
   add_launch_test(
     test/test_static_centerline_generator_gui_launch.test.py
-    TIMEOUT "30"
+    TIMEOUT "60"
   )
   install(DIRECTORY
     test/data/


### PR DESCRIPTION
## Description

currently sometimes unit test fails due 30s timeout.
so increase value to 60s

https://github.com/autowarefoundation/autoware_universe/actions/runs/16672616115/job/47192430950?pr=11101

## How was this PR tested?

not tested 

## Notes for reviewers

None.

## Effects on system behavior

None.
