### PR TITLE
fix(autoware_static_centerline_generator): fix test dependency

### DIFF
--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -41,8 +41,8 @@
   <depend>tier4_map_msgs</depend>
 
   <exec_depend>autoware_launch</exec_depend>
-  <exec_depend>libqt5-widgets</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
+  <exec_depend>libqt5-widgets</exec_depend>
   <exec_depend>python3-flask-cors</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -41,6 +41,8 @@
   <depend>tier4_map_msgs</depend>
 
   <exec_depend>autoware_launch</exec_depend>
+  <exec_depend>libqt5-widgets</exec_depend>
+  <exec_depend>libqt5-core</exec_depend>
   <exec_depend>python3-flask-cors</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
@@ -53,6 +55,8 @@
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_map_tf_generator</test_depend>
   <test_depend>autoware_sample_vehicle_description</test_depend>
+  <test_depend>libqt5-core</test_depend>
+  <test_depend>libqt5-widgets</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Description
This PR fixes dependency for autoware_static_centerline_generator.
The package uses Qt5 for execution, but it does not have the library as dependency.

This is causing a failure in build-and-test-differential-above in Autoware Core.
https://github.com/autowarefoundation/autoware_core/actions/runs/16671444714/job/47188492044?pr=593
<img width="1439" height="211" alt="image" src="https://github.com/user-attachments/assets/ea207f39-6fb5-4b6d-88fd-00247c646a67" />

## How was this PR tested?
The test passes in CI. 

## Notes for reviewers

None.

## Effects on system behavior

None.
