### PR TITLE
fix: show motion velocity planner output by default

### DIFF
--- a/planning/planning_debug_tools/scripts/trajectory_visualizer/config.yaml
+++ b/planning/planning_debug_tools/scripts/trajectory_visualizer/config.yaml
@@ -1,5 +1,6 @@
 initial_topics: # initial topics to plot and their type
   - [/planning/trajectory, Trajectory]
+  - [/planning/scenario_planning/lane_driving/trajectory, Trajectory]
   - [/planning/scenario_planning/lane_driving/motion_planning/path_optimizer/trajectory, Trajectory]
   - [/planning/scenario_planning/lane_driving/behavior_planning/path, Path]
   - [/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id, PathWithLaneId]


### PR DESCRIPTION
## Description

Show motion velocity planner output by default.

```patch
diff --git a/planning/planning_debug_tools/scripts/trajectory_visualizer/config.yaml b/planning/planning_debug_tools/scripts/trajectory_visualizer/config.yaml
index c987fa9..e26ed1c 100644
--- a/planning/planning_debug_tools/scripts/trajectory_visualizer/config.yaml
+++ b/planning/planning_debug_tools/scripts/trajectory_visualizer/config.yaml
@@ -1,5 +1,6 @@
 initial_topics: # initial topics to plot and their type
   - [/planning/scenario_planning/trajectory, Trajectory]
+  - [/planning/scenario_planning/lane_driving/trajectory, Trajectory]
   - [/planning/scenario_planning/lane_driving/motion_planning/path_optimizer/trajectory, Trajectory]
   - [/planning/scenario_planning/lane_driving/behavior_planning/path, Path]
   - [/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id, PathWithLaneId]
```

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
