### PR TITLE
fix: change to detailed library reference

### DIFF
--- a/planning/planning_debug_tools/scripts/trajectory_visualizer/trajectory_data.py
+++ b/planning/planning_debug_tools/scripts/trajectory_visualizer/trajectory_data.py
@@ -19,8 +19,8 @@ from autoware_planning_msgs.msg import TrajectoryPoint
 from nav_msgs.msg import Odometry
 import numpy as np
 from rclpy import time
-from shapely import LineString
-from shapely import Point
+from shapely.geometry import LineString
+from shapely.geometry import Point
 from tf_transformations import euler_from_quaternion
 
 


### PR DESCRIPTION
## Description
Original lib can not be opened:
```
from shapely import LineString
from shapely import Point
```
Use detailed lib instead:
```
from shapely.geometry import LineString
from shapely.geometry import Point
```
The modification has been tested.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
