### PR TITLE
fix : perception_replayer_common.py と utils.py をCMakeLists.txtに追加

### DIFF
--- a/planning/planning_debug_tools/CMakeLists.txt
+++ b/planning/planning_debug_tools/CMakeLists.txt
@@ -53,6 +53,8 @@ install(PROGRAMS
   scripts/closest_velocity_checker.py
   scripts/perception_replayer/perception_reproducer.py
   scripts/perception_replayer/perception_replayer.py
+  scripts/perception_replayer/perception_replayer_common.py
+  scripts/perception_replayer/utils.py
   scripts/update_logger_level.sh
   DESTINATION lib/${PROJECT_NAME}
 )


### PR DESCRIPTION
## Description
CMakeLists.txt の install(PROGRAMS ...) に

scripts/perception_replayer/perception_replayer_common.py
scripts/perception_replayer/utils.py
を追加しました。
これにより、両スクリプトがパッケージインストール時に正しく配置されます。
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
