### PR TITLE
feat(autoware_localization_evaluation_scripts): create masks for each criterion

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/README.md
+++ b/localization/autoware_localization_evaluation_scripts/README.md
@@ -2,7 +2,7 @@
 
 This package contains some scripts for evaluating the localization of Autoware.
 
-Ths scripts are used for the result rosbags of localization, particularly the result_bag from `driving_log_replayer_v2`.
+The scripts are used for the result rosbags of localization, particularly the result_bag from `driving_log_replayer_v2`.
 
 <https://tier4.github.io/driving_log_replayer_v2/quick_start/setup/>
 
@@ -134,4 +134,41 @@ $ ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py 
     --topic_reference "/localization/pose_estimator/pose_with_covariance"
 ```
 
-This command performs the above three analyses on the subdirectories of the target directory.
+This command performs the above three analysis on the subdirectories of the target directory and outputs the results regarding the following criteria.
+You can see the results in a JSON file named `summary.json`.
+
+| Criterion                      | Description                                                                                      | Success Condition/Threshold |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ | --------------------------- |
+| mean_relative_position         | The mean difference of position calcualated through `compare_trajectories.py`                    | < 0.5 [m]                   |
+| mean_relative_angle            | The mean difference of angle calcualated through `compare_trajectories.py`                       | < 0.5 [deg]                 |
+| mean_relative_linear_velocity  | The mean difference of linear velocity calcualated through `compare_trajectories.py`             | < 0.05 [m/s]                |
+| mean_relative_angular_velocity | The mean difference of angular velocity calcualated through `compare_trajectories.py`            | < 0.05 [rad/s]              |
+| mean_relative_accelaration     | The mean difference of linear acceleration calcualated through `compare_trajectories.py`         | < 0.5 [m/s^2]               |
+| diagnostics_not_ok_rate        | Check whether diagnostics collect by `plot_diagnostics.py` has low percentages of non-ok status. | < 5.0 [%]                   |
+
+`analyze_rosbags_parallel.py` has an optional argument `--scenario_file` to pass a scenario file (formatted by Driving Log Replayer) to the script.
+If the scenario file has a condition named `OverallCriteriaMask` like below, the script `analyze_rosbags_parallel.py` will skip the criterion if it is set to `false`.
+The `OverallCriteriaMask` block must be under `Evaluation -> Conditions`. **Note that the scenario file is not required** and the script will automatically set the mask to `true` if no scenario file is given OR there is no `OverallCriteriaMask` in the scenario file.
+
+```yaml
+Evaluation:
+  Conditions:
+    OverallCriteriaMask:
+      mean_relative_position: false
+      mean_relative_angle: false
+      mean_relative_linear_velocity: true
+      mean_relative_angular_velocity: true
+      mean_relative_accelaration: false
+      diagnostics_not_ok_rate: false
+```
+
+[Example]
+
+```bash
+$ ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
+    $HOME/driving_log_replayer_v2/out/ \
+    --parallel_num 2 \
+    --topic_subject "/localization/kinematic_state" \
+    --topic_reference "/localization/pose_estimator/pose_with_covariance"
+    --scenario_file /path/to/scenario.yml
+```

--- a/localization/autoware_localization_evaluation_scripts/README.md
+++ b/localization/autoware_localization_evaluation_scripts/README.md
@@ -169,6 +169,6 @@ $ ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py 
     $HOME/driving_log_replayer_v2/out/ \
     --parallel_num 2 \
     --topic_subject "/localization/kinematic_state" \
-    --topic_reference "/localization/pose_estimator/pose_with_covariance"
+    --topic_reference "/localization/pose_estimator/pose_with_covariance" \
     --scenario_file /path/to/scenario.yml
 ```

--- a/localization/autoware_localization_evaluation_scripts/README.md
+++ b/localization/autoware_localization_evaluation_scripts/README.md
@@ -139,11 +139,11 @@ You can see the results in a JSON file named `summary.json`.
 
 | Criterion                      | Description                                                                                      | Success Condition/Threshold |
 | ------------------------------ | ------------------------------------------------------------------------------------------------ | --------------------------- |
-| mean_relative_position         | The mean difference of position calcualated through `compare_trajectories.py`                    | < 0.5 [m]                   |
-| mean_relative_angle            | The mean difference of angle calcualated through `compare_trajectories.py`                       | < 0.5 [deg]                 |
-| mean_relative_linear_velocity  | The mean difference of linear velocity calcualated through `compare_trajectories.py`             | < 0.05 [m/s]                |
-| mean_relative_angular_velocity | The mean difference of angular velocity calcualated through `compare_trajectories.py`            | < 0.05 [rad/s]              |
-| mean_relative_accelaration     | The mean difference of linear acceleration calcualated through `compare_trajectories.py`         | < 0.5 [m/s^2]               |
+| mean_relative_position         | The mean difference of position calculated through `compare_trajectories.py`                     | < 0.5 [m]                   |
+| mean_relative_angle            | The mean difference of angle calculated through `compare_trajectories.py`                        | < 0.5 [deg]                 |
+| mean_relative_linear_velocity  | The mean difference of linear velocity calculated through `compare_trajectories.py`              | < 0.05 [m/s]                |
+| mean_relative_angular_velocity | The mean difference of angular velocity calculated through `compare_trajectories.py`             | < 0.05 [rad/s]              |
+| mean_relative_acceleration     | The mean difference of linear acceleration calculated through `compare_trajectories.py`          | < 0.5 [m/s^2]               |
 | diagnostics_not_ok_rate        | Check whether diagnostics collect by `plot_diagnostics.py` has low percentages of non-ok status. | < 5.0 [%]                   |
 
 `analyze_rosbags_parallel.py` has an optional argument `--scenario_file` to pass a scenario file (formatted by Driving Log Replayer) to the script.
@@ -158,7 +158,7 @@ Evaluation:
       mean_relative_angle: false
       mean_relative_linear_velocity: true
       mean_relative_angular_velocity: true
-      mean_relative_accelaration: false
+      mean_relative_acceleration: false
       diagnostics_not_ok_rate: false
 ```
 

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -46,13 +46,10 @@ def load_overall_criteria_mask(yaml_path: Path) -> OverallCriteriaMask:
             data = yaml.safe_load(f)
         conditions = data["Evaluation"]["Conditions"]
     except Exception:
-        print("Cannot load scenario file")
         return OverallCriteriaMask()
 
     # If mask exists -> merge with defaults, else return defaults
     mask = conditions.get("OverallCriteriaMask", {})
-    if mask is {}:
-        print("mask is empty")
     return OverallCriteriaMask(**{**OverallCriteriaMask().__dict__, **mask})
 
 
@@ -133,7 +130,6 @@ def process_directory(
 
     # position
     if criteria_mask.mean_relative_position:
-        print("PPPOSITION")
         mean_position_norm = df["position.norm"].mean()
         THRESHOLD_MEAN_POSITION_NORM = 0.5
         if mean_position_norm > THRESHOLD_MEAN_POSITION_NORM:

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -2,6 +2,7 @@
 """A script to analyze rosbags in parallel."""
 
 import argparse
+from dataclasses import dataclass
 import json
 from multiprocessing import Pool
 from pathlib import Path
@@ -11,6 +12,17 @@ import extract_values_from_rosbag
 import pandas as pd
 import plot_diagnostics
 from utils.calc_acceleration_diff import calc_acceleration_diff
+import yaml
+
+
+@dataclass
+class OverallCriteriaMask:
+    mean_relative_position: bool = True
+    mean_relative_angle: bool = True
+    mean_relative_linear_velocity: bool = True
+    mean_relative_angular_velocity: bool = True
+    mean_relative_accelaration: bool = True
+    diagnostics_not_ok_rate: bool = True
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,17 +36,51 @@ def parse_args() -> argparse.Namespace:
         default="/localization/pose_estimator/pose_with_covariance",
     )
     parser.add_argument("--save_dir_relative", type=str, default="")
+    parser.add_argument("--scenario_file", type=Path, default=None)
     return parser.parse_args()
 
 
+def load_overall_criteria_mask(yaml_path: Path) -> OverallCriteriaMask:
+    try:
+        with open(yaml_path, "r") as f:
+            data = yaml.safe_load(f)
+        conditions = data["Evaluation"]["Conditions"]
+    except Exception:
+        print("Cannot load scenario file")
+        return OverallCriteriaMask()
+
+    # If mask exists -> merge with defaults, else return defaults
+    mask = conditions.get("OverallCriteriaMask", {})
+    if mask is {}:
+        print("mask is empty")
+    return OverallCriteriaMask(**{**OverallCriteriaMask().__dict__, **mask})
+
+
+def load_diagnostics_flag_check(yaml_path: Path):
+    try:
+        with open(yaml_path, "r") as f:
+            data = yaml.safe_load(f)
+        conditions = data["Evaluation"]["Conditions"]
+    except Exception:
+        return None
+
+    return conditions.get("DiagnosticsFlagCheck", None)
+
+
 def process_directory(
-    directory: Path, topic_subject: str, topic_reference: str, save_dir_relative: str
+    directory: Path,
+    topic_subject: str,
+    topic_reference: str,
+    save_dir_relative: str,
+    scenario_file: Path,
 ) -> None:
     target_rosbag = directory / "result_bag"
     save_dir = directory if save_dir_relative == "" else directory / save_dir_relative
     compare_result_dir = save_dir / "compare_trajectories"
     compare_result_dir.mkdir(parents=True, exist_ok=True)
     diagnostics_result_dir = save_dir / "diagnostics_result"
+
+    criteria_mask = load_overall_criteria_mask(scenario_file)
 
     # (1) Plot diagnostics
     plot_diagnostics.main(rosbag_path=target_rosbag, save_dir=diagnostics_result_dir)
@@ -86,25 +132,28 @@ def process_directory(
     df = pd.read_csv(relative_pose_tsv, sep="\t")
 
     # position
-    mean_position_norm = df["position.norm"].mean()
-    THRESHOLD_MEAN_POSITION_NORM = 0.5
-    if mean_position_norm > THRESHOLD_MEAN_POSITION_NORM:
-        final_success = False
-        final_summary += f"{mean_position_norm=:.3f} [m] is too large."
-    else:
-        final_summary += f"{mean_position_norm=:.3f} [m]"
+    if criteria_mask.mean_relative_position:
+        print("PPPOSITION")
+        mean_position_norm = df["position.norm"].mean()
+        THRESHOLD_MEAN_POSITION_NORM = 0.5
+        if mean_position_norm > THRESHOLD_MEAN_POSITION_NORM:
+            final_success = False
+            final_summary += f"{mean_position_norm=:.3f} [m] is too large."
+        else:
+            final_summary += f"{mean_position_norm=:.3f} [m]"
 
     # angle
-    mean_angle_norm = df["angle.norm"].mean()
-    THRESHOLD_MEAN_ANGLE_NORM = 0.5
-    if mean_angle_norm > THRESHOLD_MEAN_ANGLE_NORM:
-        final_success = False
-        final_summary += f"|{mean_angle_norm=:.3f} [deg] is too large."
-    else:
-        final_summary += f"|{mean_angle_norm=:.3f} [deg]"
+    if criteria_mask.mean_relative_angle:
+        mean_angle_norm = df["angle.norm"].mean()
+        THRESHOLD_MEAN_ANGLE_NORM = 0.5
+        if mean_angle_norm > THRESHOLD_MEAN_ANGLE_NORM:
+            final_success = False
+            final_summary += f"|{mean_angle_norm=:.3f} [deg] is too large."
+        else:
+            final_summary += f"|{mean_angle_norm=:.3f} [deg]"
 
     # linear velocity
-    if "linear_velocity.norm" in df.columns:
+    if "linear_velocity.norm" in df.columns and criteria_mask.mean_relative_linear_velocity:
         mean_linear_velocity_norm = df["linear_velocity.norm"].mean()
         THRESHOLD_MEAN_LINEAR_VELOCITY_NORM = 0.05
         if mean_linear_velocity_norm > THRESHOLD_MEAN_LINEAR_VELOCITY_NORM:
@@ -114,7 +163,7 @@ def process_directory(
             final_summary += f"|{mean_linear_velocity_norm=:.3f} [m/s]"
 
     # angular velocity
-    if "angular_velocity.norm" in df.columns:
+    if "angular_velocity.norm" in df.columns and criteria_mask.mean_relative_angular_velocity:
         mean_angular_velocity_norm = df["angular_velocity.norm"].mean()
         THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM = 0.05
         if mean_angular_velocity_norm > THRESHOLD_MEAN_ANGULAR_VELOCITY_NORM:
@@ -125,7 +174,7 @@ def process_directory(
 
     # acceleration
     df_ref = pd.read_csv(compare_result_dir / f"{save_name_reference}.tsv", sep="\t")
-    if "linear_velocity.x" in df_ref.columns:
+    if "linear_velocity.x" in df_ref.columns and criteria_mask.mean_relative_accelaration:
         THRESHOLD_MEAN_ACCELERATION_NORM = 0.5
         acceleration_tsv = save_dir / "result_acceleration/localization__acceleration.tsv"
         df_acceleration = pd.read_csv(acceleration_tsv, sep="\t")
@@ -151,22 +200,25 @@ def process_directory(
         "localization_error_monitor__ellipse_error_status",
         "ndt_scan_matcher__scan_matching_status",
     ]
-    for target_tsv in target_tsv_list:
-        diagnostics_tsv = diagnostics_result_dir / f"{target_tsv}.tsv"
-        df = pd.read_csv(diagnostics_tsv, sep="\t")
-        # filter out WARNs before activation
-        df = df[df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"]
-        df = df[df["message"] != "Node is not activated."]
-        not_ok_num = len(df[df["level"] != 0])
-        if len(df) == 0:
-            not_ok_percentage = 0
-        else:
-            not_ok_percentage = not_ok_num / len(df) * 100
-        if not_ok_percentage > 5:
-            final_success = False
-            final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%] is too large."
-        else:
-            final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%]"
+    if criteria_mask.diagnostics_not_ok_rate:
+        for target_tsv in target_tsv_list:
+            diagnostics_tsv = diagnostics_result_dir / f"{target_tsv}.tsv"
+            df = pd.read_csv(diagnostics_tsv, sep="\t")
+            # filter out WARNs before activation
+            df = df[
+                df["message"] != "[WARN]process is not activated; [WARN]initial pose is not set"
+            ]
+            df = df[df["message"] != "Node is not activated."]
+            not_ok_num = len(df[df["level"] != 0])
+            if len(df) == 0:
+                not_ok_percentage = 0
+            else:
+                not_ok_percentage = not_ok_num / len(df) * 100
+            if not_ok_percentage > 5:
+                final_success = False
+                final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%] is too large."
+            else:
+                final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%]"
 
     with open(save_dir / "summary.json", "w") as f:
         json.dump(
@@ -188,6 +240,7 @@ if __name__ == "__main__":
     topic_subject = args.topic_subject
     topic_reference = args.topic_reference
     save_dir_relative = args.save_dir_relative
+    scenario_file = args.scenario_file
 
     target_rosbags = list(result_dir.glob("**/*.db3")) + list(result_dir.glob("**/*.mcap"))
     directories = [path.parent.parent for path in target_rosbags]
@@ -198,5 +251,8 @@ if __name__ == "__main__":
     with Pool(args.parallel_num) as pool:
         pool.starmap(
             process_directory,
-            [(d, topic_subject, topic_reference, save_dir_relative) for d in directories],
+            [
+                (d, topic_subject, topic_reference, save_dir_relative, scenario_file)
+                for d in directories
+            ],
         )

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -21,7 +21,7 @@ class OverallCriteriaMask:
     mean_relative_angle: bool = True
     mean_relative_linear_velocity: bool = True
     mean_relative_angular_velocity: bool = True
-    mean_relative_accelaration: bool = True
+    mean_relative_acceleration: bool = True
     diagnostics_not_ok_rate: bool = True
 
 
@@ -170,7 +170,7 @@ def process_directory(
 
     # acceleration
     df_ref = pd.read_csv(compare_result_dir / f"{save_name_reference}.tsv", sep="\t")
-    if "linear_velocity.x" in df_ref.columns and criteria_mask.mean_relative_accelaration:
+    if "linear_velocity.x" in df_ref.columns and criteria_mask.mean_relative_acceleration:
         THRESHOLD_MEAN_ACCELERATION_NORM = 0.5
         acceleration_tsv = save_dir / "result_acceleration/localization__acceleration.tsv"
         df_acceleration = pd.read_csv(acceleration_tsv, sep="\t")


### PR DESCRIPTION
## Description

Currently, autoware_localization_evaluation_scripts can only provide the success/failure result by taking the AND condition of all criteria.This PR enables autoware_localization_evaluation_scripts to toggle whether to use the criterion or not for the final summary.

The mask is expected to be provided from the scenario file by adding a condition like the following.
Note that passing a scenario file is optional and the script will manage the masks as true if no scenario file is given OR there is no `OverallCriteriaMask` condition in the scenario file. So after this PR is merged, the existing evaluation through driving_log_replayer doesn't change at all.

Read the modified `README.md` for further information.

```yaml
Evaluation:
  Conditions:
    OverallCriteriaMask:
      mean_relative_position: false
      mean_relative_angle: false
      mean_relative_linear_velocity: true
      mean_relative_angular_velocity: true
      mean_relative_acceleration: false
      diagnostics_not_ok_rate: false
```

## How was this PR tested?

Tested by the following procedure.

1. Get a random scenario file and its evaluation result and from the driving_log_replayer.
2. Add a `OverallCriteriaMask` block to the scenario file above, OR you can just save this as a new yaml file and treat it as a scenario file which will work only for testing this PR.
3. Build `autoware_localization_evaluation_scripts` if you haven't.
4. Execute the following

```bash
ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
/path/to/driving_log_replayer/result \
--save_dir_relative result_archive \
--topic_reference /localization/reference_kinematic_state \
--scenario_file scenario.yml
```

## Notes for reviewers

None.

## Effects on system behavior

Skip criterion if it is set as `false` in the scenario file.