### PR TITLE
feat(autoware_localization_evaluation_scripts): detect rise/fall flags of localization diagnostics

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/CMakeLists.txt
+++ b/localization/autoware_localization_evaluation_scripts/CMakeLists.txt
@@ -8,6 +8,7 @@ install(PROGRAMS
     scripts/analyze_rosbags_parallel.py
     scripts/compare_trajectories.py
     scripts/extract_values_from_rosbag.py
+    scripts/diagnostics_flag_check.py
     scripts/plot_diagnostics.py
     DESTINATION lib/${PROJECT_NAME}
 )

--- a/localization/autoware_localization_evaluation_scripts/README.md
+++ b/localization/autoware_localization_evaluation_scripts/README.md
@@ -117,6 +117,37 @@ $HOME/driving_log_replayer_v2/out/latest/pose_tsv/localization__kinematic_state_
 0 directories, 4 files
 ```
 
+## diagnostics_flag_check.py
+
+```bash
+ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
+   <path_to_scenario_file> <directory_to_diagnostics_result>
+```
+
+[Example]
+
+```bash
+$ ros2 run autoware_localization_evaluation_scripts compare_trajectories.py \
+    ./scenario.yml \
+    $HOME/driving_log_replayer_v2/out/latest/result_archive/diagnostics_result
+```
+
+This command checks whether a diagnostics have risen/fallen at a specific timing.
+The diagnostics flag to observe should be defined in the input scenario file in the format like below.
+
+```yaml
+Evaluation:
+  Conditions:
+    DiagnosticsFlagCheck:
+      pose_is_passed_delay_gate:
+        flag: rise
+        at_sec: 113
+        at_nanosec: 750000000
+```
+
+Currently this script is still in development and the number of observable diagnostics will increase.
+Read the actual `diagnostics_flag_check.py` file to know what can be observed and the definition of rise and fall for each diagnostics.
+
 ## analyze_rosbags_parallel.py
 
 ```bash

--- a/localization/autoware_localization_evaluation_scripts/README.md
+++ b/localization/autoware_localization_evaluation_scripts/README.md
@@ -120,14 +120,14 @@ $HOME/driving_log_replayer_v2/out/latest/pose_tsv/localization__kinematic_state_
 ## diagnostics_flag_check.py
 
 ```bash
-ros2 run autoware_localization_evaluation_scripts analyze_rosbags_parallel.py \
+ros2 run autoware_localization_evaluation_scripts diagnostics_flag_check.py \
    <path_to_scenario_file> <directory_to_diagnostics_result>
 ```
 
 [Example]
 
 ```bash
-$ ros2 run autoware_localization_evaluation_scripts compare_trajectories.py \
+$ ros2 run autoware_localization_evaluation_scripts diagnostics_flag_check.py \
     ./scenario.yml \
     $HOME/driving_log_replayer_v2/out/latest/result_archive/diagnostics_result
 ```

--- a/localization/autoware_localization_evaluation_scripts/README.md
+++ b/localization/autoware_localization_evaluation_scripts/README.md
@@ -145,6 +145,8 @@ Evaluation:
         at_nanosec: 750000000
 ```
 
+This example means that the diagnostics `pose_is_passed_delay_gate` should rise at 113.75 sec in the rosbag time. To be more specific, the flag should rise within a time window of ±0.2 seconds around the target time.
+
 Currently this script is still in development and the number of observable diagnostics will increase.
 Read the actual `diagnostics_flag_check.py` file to know what can be observed and the definition of rise and fall for each diagnostics.
 

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -63,17 +63,6 @@ def load_overall_criteria_mask(yaml_path: Path) -> OverallCriteriaMask:
     return OverallCriteriaMask(**{**OverallCriteriaMask().__dict__, **filtered_mask})
 
 
-def load_diagnostics_flag_check(yaml_path: Path):
-    try:
-        with open(yaml_path, "r") as f:
-            data = yaml.safe_load(f)
-        conditions = data["Evaluation"]["Conditions"]
-    except Exception:
-        return None
-
-    return conditions.get("DiagnosticsFlagCheck", None)
-
-
 def process_directory(
     directory: Path,
     topic_subject: str,
@@ -88,7 +77,6 @@ def process_directory(
     diagnostics_result_dir = save_dir / "diagnostics_result"
 
     criteria_mask = load_overall_criteria_mask(scenario_file)
-    diagnostics_flag_condition = load_diagnostics_flag_check(scenario_file)
 
     # (1) Plot diagnostics
     plot_diagnostics.main(rosbag_path=target_rosbag, save_dir=diagnostics_result_dir)
@@ -228,10 +216,8 @@ def process_directory(
                 final_summary += f"|{target_tsv} {not_ok_percentage:.3f} [%]"
 
     # (7) extract diag rise/fall
-    if diagnostics_flag_condition is not None:
-        diag_flag_check = diagnostics_flag_check.main(
-            diagnostics_flag_condition, diagnostics_result_dir
-        )
+    if scenario_file is not None:
+        diag_flag_check = diagnostics_flag_check.main(scenario_file, diagnostics_result_dir)
         for key, check in diag_flag_check.items():
             if check is False:
                 final_success = False

--- a/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/analyze_rosbags_parallel.py
@@ -3,6 +3,7 @@
 
 import argparse
 from dataclasses import dataclass
+from dataclasses import fields
 import json
 from multiprocessing import Pool
 from pathlib import Path
@@ -51,7 +52,15 @@ def load_overall_criteria_mask(yaml_path: Path) -> OverallCriteriaMask:
 
     # If mask exists -> merge with defaults, else return defaults
     mask = conditions.get("OverallCriteriaMask", {})
-    return OverallCriteriaMask(**{**OverallCriteriaMask().__dict__, **mask})
+    valid_fields = {f.name for f in fields(OverallCriteriaMask)}
+    invalid_fields = [k for k in mask if k not in valid_fields]
+
+    if invalid_fields:
+        print(f"[WARN] Ignoring invalid OverallCriteriaMask fields: {invalid_fields}")
+
+    filtered_mask = {k: v for k, v in mask.items() if k in valid_fields}
+
+    return OverallCriteriaMask(**{**OverallCriteriaMask().__dict__, **filtered_mask})
 
 
 def load_diagnostics_flag_check(yaml_path: Path):

--- a/localization/autoware_localization_evaluation_scripts/scripts/diagnostics_flag_check.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/diagnostics_flag_check.py
@@ -177,8 +177,8 @@ def main(scenario_file: Path, diagnostics_result_dir: Path) -> Dict[str, bool]:
 
         flag = criteria.get("flag", "").strip().lower()
         at_sec = int(float(criteria.get("at_sec", 0)))
-        at_nsec = int(float(criteria.get("at_nanosec", 0)))
-        target_time = int(at_sec * 1_000_000_000 + at_nsec)
+        at_nanosec = int(float(criteria.get("at_nanosec", 0)))
+        target_time = int(at_sec * 1_000_000_000 + at_nanosec)
 
         if key == "pose_no_update_count":
             tsv_path = diagnostics_result_dir / "localization__ekf_localizer.tsv"


### PR DESCRIPTION
## Description

This PR adds a new evaluation script `diagnostics_flag_check.py` to detect the rise or fall of the localization diagnostics.
Currently this script only detects the rise/fall of `pose_is_passed_delay_gate` and `pose_no_update_count` (from ekf_localizer).

The condition can be read from the scenario file if it has a condition block like this.

```yaml
Evaluation:
  Conditions:
    DiagnosticsFlagCheck:
      pose_is_passed_delay_gate:
        flag: rise
        at_sec: 113
        at_nanosec: 750000000
```

This example means that the diagnostics `pose_is_passed_delay_gate` should rise at 113.75 sec in the rosbag time. To be more specific, the flag should rise within a time window of ±0.2 seconds around the target time.

## How was this PR tested?

Tested that it works as expected with driving_log_replayer scenario.

[INTERNAL_LINK(Evaluation Result)](https://evaluation.tier4.jp/evaluation/reports/51df55fa-f2b8-5178-800a-44d96ce6b7e8/tests/9deb0b45-ca2b-5fb7-a916-6da660701d43/78714f4a-b3cc-5a27-bf84-dfd748cc345c?project_id=autoware_dev)

## Notes for reviewers

This PR should be merged with this PR.

https://github.com/tier4/driving_log_replayer_v2/pull/205

## Effects on system behavior

If a scenario file is given, the analyze_rosbags_parallel.py will also run diagnostics_flag_check.py
