### PR TITLE
feat(static_centerline): enabled input of lanelet_sequence

### DIFF
--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -51,9 +51,10 @@ The optimized centerline can be generated from the command line interface by des
 - `<end-pose>` (not mandatory)
 - `<vehicle-model>`
 - `<goal-method>` (not mandatory, `path_generator` or `behavior_path_planner` only)
+- `<lanelet-squence>` (not mandatory)
 
 ```sh
-ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> end_pose:=<end-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method>
+ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml run_backgrond:=false lanelet2_input_file_path:=<input-osm-path> lanelet2_output_file_path:=<output-osm-path> start_lanelet_id:=<start-lane-id> start_pose:=<start-pose> end_lanelet_id:=<end-lane-id> end_pose:=<end-pose> vehicle_model:=<vehicle-model> goal_method:=<goal-method> lanelet_squence:=<lanelet-squence>
 ```
 
 **Note that `<goal-method>:=behavior_path_planner` is not currently supported.**
@@ -65,6 +66,8 @@ By specifying `start-pose`, `goal-pose`, and `goal-method`, the centerline from 
 `<start-pose>`, `<goal-pose>` are entered like `[position.x, position.y, position.z, orientation.x, orientation.y, orientation.z, orientation.w]` with double type.
 In order to run smoothly to the goal pose, `goal-method` is used.
 Only `path_generator` or `behavior_path_planner` can be entered for `<goal_method>`.
+In `<lanelet-squence>`, you can specify the lanelet_ids for the static centerline to be embedded.
+The input route must be continuous and a drivable path.
 
 > [!WARNING]
 > If the start pose is off the center of the lane, it is necessary to manually embed a centerline that smoothly connects the start pose and the start lane in advance using VMB, etc.

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -15,6 +15,7 @@
   <arg name="end_lanelet_id" default="0"/>
   <arg name="end_pose" default="[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]"/>
   <arg name="goal_method" default="None"/>
+  <arg name="lanelet_sequence" default="[-1]"/>
 
   <!-- mandatory arguments when mode is GUI -->
   <arg name="bag_filename" default="bag.db3"/>
@@ -74,6 +75,7 @@
     <param name="end_lanelet_id" value="$(var end_lanelet_id)"/>
     <param name="end_pose" value="$(var end_pose)"/>
     <param name="goal_method" value="$(var goal_method)"/>
+    <param name="lanelet_sequence" value="$(var lanelet_sequence)"/>
     <!-- common param -->
     <param from="$(var common_param)"/>
     <param from="$(var nearest_search_param)"/>

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -278,36 +278,6 @@ std::vector<TrajectoryPoint> OptimizationTrajectoryBasedCenterline::optimize_tra
   return whole_optimized_traj_points;
 }
 
-std::shared_ptr<autoware_planning_msgs::msg::LaneletRoute>
-OptimizationTrajectoryBasedCenterline::create_route(
-  std::shared_ptr<RouteHandler> & route_handler_ptr, const geometry_msgs::msg::Pose & start_pose,
-  const geometry_msgs::msg::Pose & goal_pose) const
-{
-  // create route_ptr
-  auto route_ptr = std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
-
-  lanelet::ConstLanelets all_lanelets;
-  lanelet::ConstLanelets path_lanelets;
-  route_handler_ptr->planPathLaneletsBetweenCheckpoints(start_pose, goal_pose, &path_lanelets);
-
-  for (const auto & lane : path_lanelets) {
-    if (!all_lanelets.empty() && lane.id() == all_lanelets.back().id()) continue;
-    all_lanelets.push_back(lane);
-  }
-
-  route_handler_ptr->setRouteLanelets(all_lanelets);
-
-  std::vector<autoware_planning_msgs::msg::LaneletSegment> route_sections =
-    route_handler_ptr->createMapSegments(all_lanelets);
-
-  // set necessary data
-  route_ptr->header.frame_id = "map";
-  route_ptr->start_pose = start_pose;
-  route_ptr->goal_pose = goal_pose;
-  route_ptr->segments = route_sections;
-  return route_ptr;
-}
-
 void OptimizationTrajectoryBasedCenterline::init_path_generator_node(
   const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   const LaneletRoute & route) const


### PR DESCRIPTION
## Description

- Delete unused `create_route` function
- Added an argument for entering the `lanelet_sequence`
  - This prevents the unintended selection of lanelets as the starting point when beginning from overlapping lanelets.

## How was this PR tested?

## Notes for reviewers

The following start inputs match.

### Before and Not input `lanelet_sequence`

```sh
ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml centerline_source:='optimization_trajectory_base' mode:='AUTO' lanelet2_input_file_path:=/home/kazunorinakajima/lanelet2_map_original.osm vehicle_model:='cargo_transport' goal_method:='path_generator' start_lanelet_id:='5464' end_lanelet_id:='1907' end_pose:='[92846.48473626512, 59936.0518371911, 52.399499999999996, 0.0, 0.0, -0.8217839187574005, 0.5697992548887109]'
```

<img width="1760" height="1224" alt="image" src="https://github.com/user-attachments/assets/fffaaf47-1b3b-4cd3-9387-b8c2dffe8bc2" />

### After

```sh
ros2 launch autoware_static_centerline_generator static_centerline_generator.launch.xml centerline_source:='optimization_trajectory_base' mode:='AUTO' lanelet2_input_file_path:=/home/kazunorinakajima/lanelet2_map_original.osm vehicle_model:='cargo_transport' goal_method:='path_generator' start_lanelet_id:='5464' end_lanelet_id:='1907' end_pose:='[92846.48473626512, 59936.0518371911, 52.399499999999996, 0.0, 0.0, -0.8217839187574005, 0.5697992548887109]' lanelet_sequence:="[5464,5591,3584,1570,1676,1643,5056,1577,5205,1723,5275,5266,5298,1852,1939,5319,1907]"
```

<img width="1760" height="1224" alt="image" src="https://github.com/user-attachments/assets/2c1db3d3-3a4a-428e-ad4f-f8887e31c8e9" />

## Effects on system behavior

None.
