### PR TITLE
fix(autoware_localization_evaluation_scripts): fix diagnostics flag check expection handling

### DIFF
--- a/localization/autoware_localization_evaluation_scripts/scripts/diagnostics_flag_check.py
+++ b/localization/autoware_localization_evaluation_scripts/scripts/diagnostics_flag_check.py
@@ -168,7 +168,7 @@ def main(scenario_file: Path, diagnostics_result_dir: Path) -> Dict[str, bool]:
     diagnostics_flag_condition = load_diagnostics_flag_check(scenario_file)
 
     if not diagnostics_flag_condition:
-        print("No DiagnosticsCriteria found, exiting.")
+        print("No DiagnosticsFlagCheck found, exiting.")
         return {}
 
     results = {key: False for key in diagnostics_flag_condition}


### PR DESCRIPTION
## Description

Fix error handling when there is no `DiagnosticFlagCheck` key in the scenario file.

## How was this PR tested?

In the current main
```
ros2 run autoware_localization_evaluation_scripts diagnostics_flag_check.py path/to/scenario.yml path/to/diagnostics_result/
```
will be like this when the scenario file doesn't contain `DiagnosticsFlagCheck` in the scenario file.
```
Traceback (most recent call last):
  File "/home/........./autoware_localization_evaluation_scripts/lib/autoware_localization_evaluation_scripts/diagnostics_flag_check.py", line 170, in main
    results = {key: False for key in diagnostics_flag_condition}
TypeError: 'NoneType' object is not iterable
[ros2run]: Process exited with failure 1
```

With this fix, it will be
```
No DiagnosticsFlagCheck found, exiting.
```

## Notes for reviewers

None.

## Effects on system behavior

None.
