### PR TITLE
chore: update autoware_lanelet2_extension version from v0.8.0 to v0.9.0

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -29,7 +29,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.8.0
+    version: 0.9.0
   # universe
   universe/autoware.universe:
     type: git


### PR DESCRIPTION
## Description

Using `v0.8.0` of autoware_tools caused build failures in CI.
To resolve this, we upgraded to `v0.9.0`, which contains the relevant pull request.

- https://github.com/autowarefoundation/autoware_lanelet2_extension/compare/0.8.0...0.9.0
- Relation PR
  - * https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/75

## How was this PR tested?

ci check

## Notes for reviewers

None.

## Effects on system behavior

None.
