### PR TITLE
feat(autoware_lanelet2_extension): replace ported autoware_lanelet2_extension in autoware_tools

### DIFF
--- a/driving_environment_analyzer/src/utils.cpp
+++ b/driving_environment_analyzer/src/utils.cpp
@@ -22,6 +22,8 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <magic_enum.hpp>
 
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/primitives/LaneletSequence.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 
 #include <algorithm>
@@ -106,7 +108,7 @@ double getLaneWidth(const lanelet::ConstLanelet & lane)
 
 double getRouteLength(const lanelet::ConstLanelets & lanes)
 {
-  return lanelet::utils::getLaneletLength3d(lanes);
+  return lanelet::geometry::length3d(lanelet::LaneletSequence(lanes));
 }
 
 double getMaxCurvature(const lanelet::ConstLanelets & lanes)
@@ -227,7 +229,7 @@ double getRouteLengthWithSameDirectionLane(
 
   for (const auto & lane : lanes) {
     if (existSameDirectionLane(lane, route_handler)) {
-      value += lanelet::utils::getLaneletLength3d(lane);
+      value += lanelet::geometry::length3d(lane);
     }
   }
 
@@ -241,7 +243,7 @@ double getRouteLengthWithOppositeDirectionLane(
 
   for (const auto & lane : lanes) {
     if (existOppositeDirectionLane(lane, route_handler)) {
-      value += lanelet::utils::getLaneletLength3d(lane);
+      value += lanelet::geometry::length3d(lane);
     }
   }
 
@@ -262,7 +264,7 @@ double getRouteLengthWithNoAdjacentLane(
       continue;
     }
 
-    value += lanelet::utils::getLaneletLength3d(lane);
+    value += lanelet::geometry::length3d(lane);
   }
 
   return value;


### PR DESCRIPTION
## Description
Several functions from `autoware_lanelet2_extension` are ported to `autoware_lanelet_utils`. Those functions will be deprecated in `autoware_lanelet2_extension` (https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/81).
This PR will replace all the usages of ported function in `autoware_tools`.
Target functions
- [ ] ~~getClosestSegment~~
- [ ] ~~getLaneletAngle~~
- [ ] ~~getClosestCenterPose~~
- [ ] ~~getClosestLaneletWithConstrains~~
- [ ] ~~getLaneletLength2d~~
- [x] getLaneletLength3d
- [ ] ~~getConflictingLanelets~~

<img width="1434" height="250" alt="Screenshot from 2025-11-27 14-32-08" src="https://github.com/user-attachments/assets/6b62a7b7-43b1-4e2c-86cb-10908149d408" />


The strikethrough functions don't exist in `autoware_tools`.


## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
