### PR TITLE
fix(rtc_manager_rviz_plugin): refine module activation logic in RTCManagerPanel

### DIFF
--- a/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
@@ -120,11 +120,14 @@ const CooperateStatus * RTCManagerPanel::find_activatable_module() const
     if (status.start_distance < 0) {
       continue;  // Skip already passed modules
     }
-    if (status.safe) {
-      continue;  // Skip auto mode modules (no manual activation needed)
-    }
-    if (status.command_status.type == Command::ACTIVATE) {
-      continue;  // Skip modules that are already activated
+    if (status.auto_mode) {
+      if (status.safe || status.command_status.type == Command::ACTIVATE) {
+        continue;
+      }
+    } else {
+      if (status.command_status.type == Command::ACTIVATE) {
+        continue;
+      }
     }
     if (!front || status.start_distance < front->start_distance) {
       front = &status;


### PR DESCRIPTION
## Description

Previously, the RTC manager panel failed to select an activatable module in manual mode. This PR resolves the issue.

<img width="5231" height="1815" alt="image" src="https://github.com/user-attachments/assets/9d0881bf-b235-444a-b201-b0ab22415c17" />

## How was this PR tested?

Tested on psim.

## Notes for reviewers

None.

## Effects on system behavior

None.
