### PR TITLE
fix(autoware_position_error_evaluator): add compile option to avoid depracated declarations

### DIFF
--- a/localization/autoware_position_error_evaluator/CMakeLists.txt
+++ b/localization/autoware_position_error_evaluator/CMakeLists.txt
@@ -12,6 +12,7 @@ add_definitions(-DQT_NO_KEYWORDS)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
   add_compile_options(-Wno-unused-parameter)
+  add_compile_options(-Wno-deprecated-declarations)
 endif()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
## Description

When we build `autoware_position_error_evaluator`, it fails due to deprecated declarations.

```
/workspace/src/tools/localization/autoware_position_error_evaluator/src/position_error_evaluator_tool.cpp: In member function ‘void autoware::position_error_evaluator::PositionErrorEvaluatorTool::onMap(const ConstSharedPtr&)’:
/workspace//src/tools/localization/autoware_position_error_evaluator/src/position_error_evaluator_tool.cpp:110:41: error: ‘void lanelet::utils::conversion::fromBinMsg(const LaneletMapBin&, lanelet::LaneletMapPtr)’ is deprecated: please use autoware::lanelet2_utils::from_autoware_map_msgs instead [-Werror=deprecated-declarations]
  110 |   lanelet::utils::conversion::fromBinMsg(*msg_ptr, lanelet_map_ptr_);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /workspace/src/tools/localization/autoware_position_error_evaluator/src/position_error_evaluator_tool.cpp:27:
/workspace/install/autoware_lanelet2_extension/include/autoware_lanelet2_extension/utility/message_conversion.hpp:49:6: note: declared here
   49 | void fromBinMsg(const autoware_map_msgs::msg::LaneletMapBin & msg, lanelet::LaneletMapPtr map);
      |      ^~~~~~~~~~
```

To avoid this problem, I add `-Wno-deprecated-declarations` as compile option.

## How was this PR tested?

Build on local environment.

## Notes for reviewers

None.

## Effects on system behavior

None.
