### PR TITLE
fix(rtc_manager_rviz_plugin): introduce RTC_MIN_START_DISTANCE for module activation logic

### DIFF
--- a/common/rtc_manager_rviz_plugin/CMakeLists.txt
+++ b/common/rtc_manager_rviz_plugin/CMakeLists.txt
@@ -20,6 +20,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/rtc_manager_panel.cpp
 )
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE -DRTC_MIN_START_DISTANCE=-2.0)
+
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   fmt::fmt

--- a/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_manager_panel.cpp
@@ -117,7 +117,7 @@ const CooperateStatus * RTCManagerPanel::find_activatable_module() const
 
   const CooperateStatus * front = nullptr;
   for (const auto & status : cooperate_statuses_ptr_->statuses) {
-    if (status.start_distance < 0) {
+    if (status.start_distance < RTC_MIN_START_DISTANCE) {
       continue;  // Skip already passed modules
     }
     if (status.auto_mode) {

--- a/common/rtc_manager_rviz_plugin/src/rtc_status_table_widget.cpp
+++ b/common/rtc_manager_rviz_plugin/src/rtc_status_table_widget.cpp
@@ -68,8 +68,8 @@ void RTCStatusTableWidget::update_statuses(const CooperateStatusArray::ConstShar
   // Sort statuses: non-negative start_distance first, then by distance ascending
   auto sorted_statuses = msg->statuses;
   std::sort(sorted_statuses.begin(), sorted_statuses.end(), [](const auto & a, const auto & b) {
-    const bool a_non_negative = a.start_distance >= 0;
-    const bool b_non_negative = b.start_distance >= 0;
+    const bool a_non_negative = a.start_distance >= RTC_MIN_START_DISTANCE;
+    const bool b_non_negative = b.start_distance >= RTC_MIN_START_DISTANCE;
     if (a_non_negative && b_non_negative) {
       return a.start_distance < b.start_distance;
     }
@@ -87,7 +87,7 @@ void RTCStatusTableWidget::update_statuses(const CooperateStatusArray::ConstShar
 void RTCStatusTableWidget::populate_row(int row, const CooperateStatus & status)
 {
   // Determine if this row should be dimmed (negative start_distance means already passed)
-  const bool is_dimmed = status.start_distance < 0;
+  const bool is_dimmed = status.start_distance < RTC_MIN_START_DISTANCE;
   const auto set_cell = [this, row, is_dimmed](Column column, const std::string & text) {
     auto * label = create_centered_label(text);
     if (is_dimmed) {


### PR DESCRIPTION
## Description

Currently, the rtc_manager_rviz_plugin button is only enabled for the front module if `start_distance > 0` is satisfied. However, start_distance may sometimes be lower than 0, e.g. -0.01, due to the stopping accuracy.
In this PR, I have introduced RTC_MIN_START_DISTANCE and set it to -2.0.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
