### PR TITLE
fix(autoware_static_centerline_generator): update initialization of path_generator

### DIFF
--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -285,7 +285,7 @@ void OptimizationTrajectoryBasedCenterline::init_path_generator_node(
   if (!path_generator_node_) {
     // initialize node, lanelet map and route
     path_generator_node_ =
-    std::make_shared<autoware::path_generator::PathGenerator>(create_node_options());
+      std::make_shared<autoware::path_generator::PathGenerator>(create_node_options());
 
     // NOTE: no need to register every time
     autoware::path_generator::PathGenerator::RouteManagerData path_generator_route_manager;


### PR DESCRIPTION
## Description
There was a change in initialization function for path_generator_node from this PR https://github.com/autowarefoundation/autoware_core/pull/725.

This PR updates the code in autoware_static_centerline_generator to use the new function

## How was this PR tested?

(ADDED by @sasakisasaki ) Reviewer @sasakisasaki tested as follows.

```
$ cd autoware    # latest
$ mkdir src
$ vcs import src < repositories/autoware.repos && vcs import src < repositories/autoware-nightly.repos && vcs import src < repositories/tools.repos && vcs import src < repositories/tools-nightly.repos 
$ colcon build --base-paths ./src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_static_centerline_generator

Here build failed with the following error:
'''
^[[01m^[[K/home/junyasasaki/autoware/src/tools/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp:^[[m^[[K In member function ‘^[[01m^[[Kvoid autoware::static_centerline_generator::OptimizationTrajectoryBasedCenterline::init_path_generator_node(geometry_msgs::msg::Pose, autoware_map_msgs::msg::LaneletMapBin_<std::allocator<void> >::ConstSharedPtr&, const LaneletRoute&) const^[[m^[[K’:
^[[01m^[[K/home/junyasasaki/autoware/src/tools/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp:293:26:^[[m^[[K ^[[01;31m^[[Kerror: ^[[m^[[K‘^[[01m^[[Kstruct autoware::path_generator::PathGenerator::InputData^[[m^[[K’ has no member named ‘^[[01m^[[Klanelet_map_bin_ptr^[[m^[[K’
  293 |     path_generator_input.^[[01;31m^[[Klanelet_map_bin_ptr^[[m^[[K = map_bin_ptr;
      |                          ^[[01;31m^[[K^~~~~~~~~~~~~~~~~~~^[[m^[[K
^[[01m^[[K/home/junyasasaki/autoware/src/tools/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp:294:26:^[[m^[[K ^[[01;31m^[[Kerror: ^[[m^[[K‘^[[01m^[[Kstruct autoware::path_generator::PathGenerator::InputData^[[m^[[K’ has no member named ‘^[[01m^[[Kroute_ptr^[[m^[[K’
  294 |     path_generator_input.^[[01;31m^[[Kroute_ptr^[[m^[[K = std::make_shared<LaneletRoute>(route);
      |                          ^[[01;31m^[[K^~~~~~~~~^[[m^[[K
^[[01m^[[K/home/junyasasaki/autoware/src/tools/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp:298:25:^[[m^[[K ^[[01;31m^[[Kerror: ^[[m^[[K‘^[[01m^[[Kusing element_type = class autoware::path_generator::PathGenerator^[[m^[[K’ {aka ‘^[[01m^[[Kclass autoware::path_generator::PathGenerator^[[m^[[K’} has no member named ‘^[[01m^[[Kset_planner_data^[[m^[[K’; did you mean ‘^[[01m^[[Kautoware::path_generator::PlannerData autoware::path_generator::PathGenerator::planner_data_^[[m^[[K’? (not accessible from this context)
  298 |   path_generator_node_->^[[01;31m^[[Kset_planner_data^[[m^[[K(path_generator_input);
      |                         ^[[01;31m^[[K^~~~~~~~~~~~~~~~^[[m^[[K
In file included from ^[[01m^[[K/home/junyasasaki/autoware/src/tools/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.hpp:21^[[m^[[K,
                 from ^[[01m^[[K/home/junyasasaki/autoware/src/tools/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp:15^[[m^[[K:
^[[01m^[[K/home/junyasasaki/autoware/install/autoware_path_generator/include/autoware/path_generator/node.hpp:98:15:^[[m^[[K ^[[01;36m^[[Knote: ^[[m^[[Kdeclared private here
   98 |   PlannerData ^[[01;36m^[[Kplanner_data_^[[m^[[K;
      |               ^[[01;36m^[[K^~~~~~~~~~~~~^[[m^[[K
gmake[2]: *** [CMakeFiles/main.dir/build.make:104: CMakeFiles/main.dir/src/centerline_source/optimization_trajectory_based_centerline.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:593: CMakeFiles/main.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
'''

Then:
$ history
$ cd src/tools/
$ git remote add mitsudome https://github.com/mitsudome-r/autoware_tools.git
$ git fetch --all
$ git checkout fix-static-centerline-generator 
$ cd ../../
$ colcon build --base-paths ./src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_static_centerline_generator

Build succeeded.

```

## Notes for reviewers

None.

## Effects on system behavior

None.
