### PR TITLE
refert: pr #341 fix(autoware_static_centerline_generator): update initialization of path_generator

### DIFF
--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -282,17 +282,20 @@ void OptimizationTrajectoryBasedCenterline::init_path_generator_node(
   const geometry_msgs::msg::Pose current_pose, LaneletMapBin::ConstSharedPtr & map_bin_ptr,
   const LaneletRoute & route) const
 {
+  autoware::path_generator::PathGenerator::InputData path_generator_input;
+
   if (!path_generator_node_) {
     // initialize node, lanelet map and route
     path_generator_node_ =
       std::make_shared<autoware::path_generator::PathGenerator>(create_node_options());
 
     // NOTE: no need to register every time
-    autoware::path_generator::PathGenerator::RouteManagerData path_generator_route_manager;
-    path_generator_route_manager.lanelet_map_bin_ptr = map_bin_ptr;
-    path_generator_route_manager.route_ptr = std::make_shared<LaneletRoute>(route);
-    path_generator_node_->initialize_route_manager(path_generator_route_manager, current_pose);
+    path_generator_input.lanelet_map_bin_ptr = map_bin_ptr;
+    path_generator_input.route_ptr = std::make_shared<LaneletRoute>(route);
   }
+
+  path_generator_input.odometry_ptr = utils::convert_to_odometry(current_pose);
+  path_generator_node_->set_planner_data(path_generator_input);
 }
 
 std::shared_ptr<autoware::behavior_path_planner::PlannerData>


### PR DESCRIPTION
Reverts autowarefoundation/autoware_tools#341
we will revert this commit until we have a proper way to fix the test for autwoare_static_centerline_generator