### PR TITLE
ci: add workflow to automatically update versions in build_depends.repos

### DIFF
--- a/.github/workflows/bump-repo-versions-build-depends.yaml
+++ b/.github/workflows/bump-repo-versions-build-depends.yaml
@@ -1,0 +1,31 @@
+name: bump-repo-versions-build-depends
+
+on:
+  schedule:
+    - cron: 0 0,6,12,18 * * *
+  workflow_dispatch:
+
+jobs:
+  create-version-update-pr:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Create PRs to update VCS repositories for autoware.repos
+        uses: autowarefoundation/autoware-github-actions/create-prs-to-update-vcs-repositories@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repo_name: ${{ github.repository }}
+          parent_dir: .
+          targets: major minor patch
+          base_branch: main
+          new_branch_prefix: feat/update-
+          autoware_repos_file_name: build_depends.repos
+          verbosity: 1

--- a/.github/workflows/bump-repo-versions-build-depends.yaml
+++ b/.github/workflows/bump-repo-versions-build-depends.yaml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   create-version-update-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate GitHub App token
         id: generate-token


### PR DESCRIPTION
## Description
This adds workflow to automatically update versions in build_depends.repos.

## Relevant PR
https://github.com/autowarefoundation/autoware_tools/pull/362

## How was this PR tested?
Tested in my fork:
- action: https://github.com/mitsudome-r/autoware_tools/actions/runs/22698169682/job/65809145499
- created PR: https://github.com/mitsudome-r/autoware_tools/pull/13

## Notes for reviewers

None.

## Effects on system behavior

None.
