### PR TITLE
fix(ci): pass app token to checkout for push auth

### DIFF
--- a/.github/workflows/bump-repo-versions-build-depends.yaml
+++ b/.github/workflows/bump-repo-versions-build-depends.yaml
@@ -9,14 +9,16 @@ jobs:
   create-version-update-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
       - name: Generate GitHub App token
         id: generate-token
         uses: tibdex/github-app-token@v2
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create PRs to update VCS repositories for autoware.repos
         uses: autowarefoundation/autoware-github-actions/create-prs-to-update-vcs-repositories@v1


### PR DESCRIPTION
- Fix `bump-repo-versions-build-depends` workflow failing to push branches
- Follow up from: https://github.com/autowarefoundation/autoware_tools/pull/363

## Why

`actions/checkout@v6` changed how it stores credentials: it now uses `includeIf.gitdir:` with an external config file instead of a direct local `http.extraheader`. The [`set-git-config`](https://github.com/autowarefoundation/autoware-github-actions/blob/main/set-git-config/action.yaml) action in `autoware-github-actions` only clears the old-style extraheader (`git config --local --unset-all http.https://github.com/.extraheader`), so the default `GITHUB_TOKEN` from checkout was still used for pushes instead of the app token. This caused `error: failed to push some refs` followed by a 422 when trying to create the PR.

The fix generates the app token before checkout and passes it directly, so the credentials file checkout@v6 creates already contains the correct token.

---

## Test plan

- [x] Dispatched workflow on this branch; push succeeded (branch `feat/update-autowarefoundation/autoware_lanelet2_extension/1.0.0` was created on the remote)
- [x] Confirmed the only remaining failure was `IndexError: No item found with id main` because the workflow was dispatched from a non-main ref, which won't occur under normal `schedule`/`workflow_dispatch` from `main`
- Failed run (before fix): https://github.com/autowarefoundation/autoware_tools/actions/runs/24265585800
- Fixed run (after fix): https://github.com/autowarefoundation/autoware_tools/actions/runs/24266101238