### PR TITLE
feat(planning_data_analyzer): parallelize open-loop evaluation with  multiple EPDMS horizons

### DIFF
--- a/planning/autoware_planning_data_analyzer/CMakeLists.txt
+++ b/planning/autoware_planning_data_analyzer/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_planning_data_analyzer)
 
 find_package(autoware_cmake REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -29,7 +28,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/utils/path_utils.cpp
   src/autoware_planning_data_analyzer_node.cpp
 )
-ament_target_dependencies(${PROJECT_NAME} tf2_geometry_msgs)
 
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::planning_data_analyzer::AutowarePlanningDataAnalyzerNode"

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -9,48 +9,6 @@ This package provides offline evaluation tools for trajectory planning performan
 1. **Open Loop**: Evaluate prediction accuracy against ground truth trajectories
 2. **OR Scene**: Evaluate override regression scenarios (LIVE vs HISTORICAL)
 
-## Open-Loop Evaluation
-
-Open-loop evaluation computes both trajectory error metrics and planning-quality subscores.
-
-### Trajectory Error Metrics
-
-For each evaluated trajectory, the following are computed:
-
-- ADE
-- FDE
-- AHE
-- FHE
-- lateral deviation
-- longitudinal deviation
-- TTC trace
-- per-horizon metrics (full, and configured horizons such as 1.0s, 2.0s, 4.0s, 8.0s)
-
-### Plnnaing Quality Score (EPDMS)
-
-To show multi-facet (comfort, progress, safety) quality of generated trajectory, EPDMS (Extended Predictive Driver Model Score) is computed based on the multiple subscores.
-
-Two variant topics are exported:
-
-- synthetic_epdms_raw
-- synthetic_epdms_human_filtered
-
-### EPDMS's Subscores
-
-EPDMS is obtained from combining the following subscores:
-
-- history_comfort
-- extended_comfort
-- time_to_collision_within_bound
-- lane_keeping
-- ego_progress
-- drivable_area_compliance
-- no_at_fault_collision
-- driving_direction_compliance
-- traffic_light_compliance
-
-These subscores are exported both as per-trajectory outputs and as aggregate statistics.
-
 ## Quick Start
 
 ### Open Loop Evaluation
@@ -114,10 +72,12 @@ Located in `scripts/` directory:
 - **Visualization**: `generate_or_visualization.py`
 - **Comparison**: `compare_live_historical.py`
 
+See `scripts/README.md` for detailed documentation.
+
 ---
 
 ## For More Information
 
-- Offline evaluation scripts: [scripts/](scripts/)
-- Configuration: [config/planning_data_analyzer.param.yaml](config/planning_data_analyzer.param.yaml)
+- Offline evaluation scripts: [scripts/README.md](scripts/README.md)
+- Configuration: [config/offline_evaluation.param.yaml](config/offline_evaluation.param.yaml)
 - Launch files: [launch/](launch/)

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -51,6 +51,8 @@
       # ADE/FDE are reported at these horizons plus "full" (entire trajectory).
       # Trajectories shorter than a horizon are excluded from that horizon with 0.1s tolerance.
       evaluation_horizons: [1.0, 2.0, 4.0, 8.0]
+      # Additional synthetic EPDMS variants computed on truncated trajectories.
+      epdms_horizons: [2.0, 3.0, 4.0]
       extended_comfort:
         max_acceleration_rms: 0.7  # Maximum RMS acceleration discrepancy between consecutive plans [m/s^2]
         max_jerk_rms: 0.5  # Maximum RMS jerk discrepancy between consecutive plans [m/s^3]

--- a/planning/autoware_planning_data_analyzer/package.xml
+++ b/planning/autoware_planning_data_analyzer/package.xml
@@ -37,7 +37,6 @@
   <depend>rclcpp</depend>
   <depend>rosbag2_cpp</depend>
   <depend>std_srvs</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -59,8 +59,6 @@
 
 namespace autoware::planning_data_analyzer
 {
-
-using autoware::route_handler::RouteHandler;
 using autoware_utils::create_marker_color;
 using autoware_utils_rclcpp::get_or_declare_parameter;
 
@@ -84,7 +82,7 @@ std::filesystem::path resolve_bag_uri(const std::string & input_bag_path)
 AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   const rclcpp::NodeOptions & node_options)
 : Node("autoware_planning_data_analyzer", node_options),
-  route_handler_{std::make_shared<RouteHandler>()}
+  route_handler_{std::make_shared<autoware::route_handler::RouteHandler>()}
 {
   try {
     vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
@@ -96,11 +94,10 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
       e.what());
     vehicle_info_ = autoware::vehicle_info_utils::VehicleInfo{};
   }
-  setup_evaluation_bag_writer();
-
   // Open bag file
   bag_path_ =
     resolve_bag_uri(get_or_declare_parameter<std::string>(*this, "input_bag_path")).string();
+  setup_evaluation_bag_writer();
   try {
     bag_reader_.open(bag_path_);
   } catch (const std::exception & e) {
@@ -152,6 +149,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
     get_or_declare_parameter<double>(*this, "open_loop.lane_keep.max_lateral_deviation");
   lane_keeping_params_.max_continuous_violation_time =
     get_or_declare_parameter<double>(*this, "open_loop.lane_keep.max_continuous_violation_time");
+  epdms_horizons_ =
+    get_or_declare_parameter<std::vector<double>>(*this, "open_loop.epdms_horizons");
   objects_topic_name_ = get_or_declare_parameter<std::string>(*this, "objects_topic");
   traffic_signals_topic_name_ =
     get_or_declare_parameter<std::string>(*this, "traffic_signals_topic");
@@ -209,7 +208,12 @@ void AutowarePlanningDataAnalyzerNode::setup_evaluation_bag_writer()
     const auto temp_root = std::filesystem::temp_directory_path() / "planning_data_analyzer";
     utils::ensure_directory_writable(temp_root, get_logger());
 
-    evaluation_metrics_bag_path_ = temp_root / "evaluation_metrics_tmp.mcap";
+    std::ostringstream run_dir_name;
+    run_dir_name << "run_" << std::chrono::steady_clock::now().time_since_epoch().count();
+    evaluation_temp_root_ = temp_root / run_dir_name.str();
+    utils::ensure_directory_writable(evaluation_temp_root_, get_logger());
+
+    evaluation_metrics_bag_path_ = evaluation_temp_root_ / "evaluation_merged_tmp.mcap";
     if (std::filesystem::exists(evaluation_metrics_bag_path_)) {
       std::filesystem::remove_all(evaluation_metrics_bag_path_);
     }
@@ -310,7 +314,9 @@ void AutowarePlanningDataAnalyzerNode::replace_input_bag_with_merged_evaluation(
   }
 
   const std::filesystem::path input_bag_path(bag_path_);
-  const std::filesystem::path temp_root = evaluation_metrics_bag_path_.parent_path();
+  const std::filesystem::path temp_root = evaluation_temp_root_.empty()
+                                            ? evaluation_metrics_bag_path_.parent_path()
+                                            : evaluation_temp_root_;
   const std::filesystem::path merged_bag_parent = temp_root / "merged";
   const std::filesystem::path backup_bag_parent = temp_root / "backup";
   const std::filesystem::path merged_bag_path = merged_bag_parent / input_bag_path.filename();
@@ -368,10 +374,11 @@ void AutowarePlanningDataAnalyzerNode::replace_input_bag_with_merged_evaluation(
     if (std::filesystem::exists(backup_bag_parent)) {
       std::filesystem::remove_all(backup_bag_parent);
     }
-    if (std::filesystem::exists(evaluation_metrics_bag_path_)) {
-      std::filesystem::remove_all(evaluation_metrics_bag_path_);
-    }
     throw;
+  }
+
+  if (!temp_root.empty() && std::filesystem::exists(temp_root)) {
+    std::filesystem::remove_all(temp_root);
   }
 }
 
@@ -505,6 +512,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       evaluator.set_json_output_dir(output_dir_path.string());
       evaluator.set_metric_variant(open_loop_metric_variant);
       evaluator.set_evaluation_horizons(evaluation_horizons);
+      evaluator.set_epdms_horizons(epdms_horizons_);
       evaluator.set_extended_comfort_parameters(extended_comfort_parameters_);
       auto times =
         evaluator.run_evaluation_from_bag(bag_path_, evaluation_bag_writer_.get(), topic_names);

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -45,7 +45,6 @@
 namespace autoware::planning_data_analyzer
 {
 
-using autoware::route_handler::RouteHandler;
 using autoware_planning_msgs::msg::Trajectory;
 
 class AutowarePlanningDataAnalyzerNode : public rclcpp::Node
@@ -68,7 +67,7 @@ private:
   void write_map_and_route_markers_to_bag(const rclcpp::Time & reference_time);
   void create_route_markers(visualization_msgs::msg::MarkerArray & marker_array) const;
 
-  std::shared_ptr<RouteHandler> route_handler_;
+  std::shared_ptr<autoware::route_handler::RouteHandler> route_handler_;
   visualization_msgs::msg::MarkerArray::ConstSharedPtr map_marker_;
 
   mutable std::mutex mutex_;
@@ -91,6 +90,7 @@ private:
   metrics::HistoryComfortParameters history_comfort_params_;
   metrics::ExtendedComfortParameters extended_comfort_parameters_;
   metrics::LaneKeepingParameters lane_keeping_params_;
+  std::vector<double> epdms_horizons_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
   std::string objects_topic_name_;
   std::string traffic_signals_topic_name_;
@@ -101,6 +101,7 @@ private:
   EvaluationMode evaluation_mode_;
   std::string bag_path_;
   std::filesystem::path evaluation_metrics_bag_path_;
+  std::filesystem::path evaluation_temp_root_;
 
   rclcpp::TimerBase::SharedPtr map_check_timer_;
 

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -40,8 +40,6 @@
 namespace autoware::planning_data_analyzer
 {
 
-using autoware::route_handler::RouteHandler;
-
 // Forward declarations
 struct SynchronizedData;
 struct TopicNames;
@@ -56,7 +54,8 @@ class BaseEvaluator
 {
 public:
   explicit BaseEvaluator(
-    rclcpp::Logger logger, std::shared_ptr<RouteHandler> route_handler = nullptr)
+    rclcpp::Logger logger,
+    std::shared_ptr<autoware::route_handler::RouteHandler> route_handler = nullptr)
   : logger_(logger), route_handler_(std::move(route_handler))
   {
   }
@@ -119,7 +118,11 @@ protected:
       const auto topic_info = rosbag2_storage::TopicMetadata{
         0, topic_name, topic_type, rmw_get_serialization_format(), {}, ""};
 #endif
-      bag_writer.create_topic(topic_info);
+      try {
+        bag_writer.create_topic(topic_info);
+      } catch (const std::exception &) {
+        // Topic may already exist when writing analyzer outputs directly into a copied bag.
+      }
     }
   }
 
@@ -208,7 +211,7 @@ protected:
     const rclcpp::Time & normalized_timestamp) const;
 
   rclcpp::Logger logger_;
-  std::shared_ptr<RouteHandler> route_handler_;
+  std::shared_ptr<autoware::route_handler::RouteHandler> route_handler_;
   std::string json_output_dir_;
 
   // For normalized timestamp calculation

--- a/planning/autoware_planning_data_analyzer/src/metrics/deviation_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/deviation_metrics.cpp
@@ -14,9 +14,9 @@
 
 #include "deviation_metrics.hpp"
 
-#include "metric_utils.hpp"
-
 #include <autoware_utils_geometry/geometry.hpp>
+
+#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>
@@ -66,8 +66,7 @@ std::pair<double, double> calculate_errors_in_vehicle_frame(
   const geometry_msgs::msg::Pose & ground_truth_pose)
 {
   // Get yaw angle from ground truth
-  const double gt_yaw =
-    autoware::planning_data_analyzer::metrics::get_yaw(ground_truth_pose.orientation);
+  const double gt_yaw = tf2::getYaw(ground_truth_pose.orientation);
 
   // Position difference in global coordinate frame
   const double dx_global = trajectory_pose.position.x - ground_truth_pose.position.x;

--- a/planning/autoware_planning_data_analyzer/src/metrics/driving_direction_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/driving_direction_compliance.cpp
@@ -36,11 +36,12 @@ DrivingDirectionComplianceResult calculate_driving_direction_compliance(
   result.reason = "available";
   result.score = 1.0;
 
-  std::vector<double> filtered_progress;
-  filtered_progress.reserve(evaluation_points.size());
-  for (const auto & point : evaluation_points) {
-    filtered_progress.push_back(
-      point.in_oncoming_traffic && !point.is_intersection ? std::max(0.0, point.progress_m) : 0.0);
+  std::vector<double> filtered_progress(evaluation_points.size(), 0.0);
+  for (size_t i = 0; i < evaluation_points.size(); ++i) {
+    const auto & point = evaluation_points.at(i);
+    if (point.in_oncoming_traffic && !point.is_intersection) {
+      filtered_progress[i] = std::max(0.0, point.progress_m);
+    }
   }
 
   for (size_t i = 0; i < evaluation_points.size(); ++i) {

--- a/planning/autoware_planning_data_analyzer/src/metrics/ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/ego_progress.cpp
@@ -29,13 +29,12 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 namespace
 {
 
 std::optional<double> calculate_raw_progress_m(
-  const Trajectory & trajectory, const std::shared_ptr<RouteHandler> & route_handler)
+  const Trajectory & trajectory,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   if (trajectory.points.size() < 2U) {
     return std::nullopt;
@@ -121,7 +120,7 @@ std::optional<size_t> find_selected_candidate_index(
 EgoProgressResult calculate_ego_progress(
   const std::shared_ptr<Trajectory> & selected_trajectory,
   const std::shared_ptr<CandidateTrajectories> & candidate_trajectories,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   EgoProgressResult result;
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/ego_progress.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/ego_progress.hpp
@@ -25,8 +25,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 struct EgoProgressResult
 {
   double score{0.0};
@@ -39,7 +37,7 @@ struct EgoProgressResult
 EgoProgressResult calculate_ego_progress(
   const std::shared_ptr<Trajectory> & selected_trajectory,
   const std::shared_ptr<CandidateTrajectories> & candidate_trajectories,
-  const std::shared_ptr<RouteHandler> & route_handler);
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms_aggregation.cpp
@@ -32,16 +32,6 @@ double apply_human_filter(
   return applied ? 1.0 : agent_value;
 }
 
-void populate_human_filter_metric(
-  HumanFilterMetrics::Metric & metric, const double agent_value, const bool agent_available,
-  const double human_value, const bool human_available)
-{
-  metric.human_reference = human_value;
-  metric.human_reference_available = human_available;
-  metric.filtered = apply_human_filter(
-    agent_value, agent_available, human_value, human_available, metric.filter_applied);
-}
-
 }  // namespace
 
 HumanFilterMetrics calculate_human_filter_metrics(
@@ -49,49 +39,74 @@ HumanFilterMetrics calculate_human_filter_metrics(
 {
   HumanFilterMetrics result;
 
-  populate_human_filter_metric(
-    result.history_comfort, agent_metrics.history_comfort, agent_metrics.history_comfort_available,
-    human_metrics.history_comfort, human_metrics.history_comfort_available);
+  result.human_history_comfort = human_metrics.history_comfort;
+  result.human_history_comfort_available = human_metrics.history_comfort_available;
+  result.filtered_history_comfort = apply_human_filter(
+    agent_metrics.history_comfort, agent_metrics.history_comfort_available,
+    human_metrics.history_comfort, human_metrics.history_comfort_available,
+    result.history_comfort_filter_applied);
 
-  populate_human_filter_metric(
-    result.extended_comfort, agent_metrics.extended_comfort,
-    agent_metrics.extended_comfort_available, human_metrics.extended_comfort,
-    human_metrics.extended_comfort_available);
+  result.human_extended_comfort = human_metrics.extended_comfort;
+  result.human_extended_comfort_available = human_metrics.extended_comfort_available;
+  result.filtered_extended_comfort = apply_human_filter(
+    agent_metrics.extended_comfort, agent_metrics.extended_comfort_available,
+    human_metrics.extended_comfort, human_metrics.extended_comfort_available,
+    result.extended_comfort_filter_applied);
 
-  populate_human_filter_metric(
-    result.ego_progress, agent_metrics.ego_progress, agent_metrics.ego_progress_available,
-    human_metrics.ego_progress, human_metrics.ego_progress_available);
+  result.human_ego_progress = human_metrics.ego_progress;
+  result.human_ego_progress_available = human_metrics.ego_progress_available;
+  result.filtered_ego_progress = apply_human_filter(
+    agent_metrics.ego_progress, agent_metrics.ego_progress_available, human_metrics.ego_progress,
+    human_metrics.ego_progress_available, result.ego_progress_filter_applied);
 
-  populate_human_filter_metric(
-    result.time_to_collision_within_bound, agent_metrics.time_to_collision_within_bound,
+  result.human_time_to_collision_within_bound = human_metrics.time_to_collision_within_bound;
+  result.human_time_to_collision_within_bound_available =
+    human_metrics.time_to_collision_within_bound_available;
+  result.filtered_time_to_collision_within_bound = apply_human_filter(
+    agent_metrics.time_to_collision_within_bound,
     agent_metrics.time_to_collision_within_bound_available,
     human_metrics.time_to_collision_within_bound,
-    human_metrics.time_to_collision_within_bound_available);
+    human_metrics.time_to_collision_within_bound_available,
+    result.time_to_collision_within_bound_filter_applied);
 
-  populate_human_filter_metric(
-    result.lane_keeping, agent_metrics.lane_keeping, agent_metrics.lane_keeping_available,
-    human_metrics.lane_keeping, human_metrics.lane_keeping_available);
+  result.human_lane_keeping = human_metrics.lane_keeping;
+  result.human_lane_keeping_available = human_metrics.lane_keeping_available;
+  result.filtered_lane_keeping = apply_human_filter(
+    agent_metrics.lane_keeping, agent_metrics.lane_keeping_available, human_metrics.lane_keeping,
+    human_metrics.lane_keeping_available, result.lane_keeping_filter_applied);
 
-  populate_human_filter_metric(
-    result.drivable_area_compliance, agent_metrics.drivable_area_compliance,
-    agent_metrics.drivable_area_compliance_available, human_metrics.drivable_area_compliance,
-    human_metrics.drivable_area_compliance_available);
+  result.human_drivable_area_compliance = human_metrics.drivable_area_compliance;
+  result.human_drivable_area_compliance_available =
+    human_metrics.drivable_area_compliance_available;
+  result.filtered_drivable_area_compliance = apply_human_filter(
+    agent_metrics.drivable_area_compliance, agent_metrics.drivable_area_compliance_available,
+    human_metrics.drivable_area_compliance, human_metrics.drivable_area_compliance_available,
+    result.drivable_area_compliance_filter_applied);
 
-  populate_human_filter_metric(
-    result.no_at_fault_collision, agent_metrics.no_at_fault_collision,
-    agent_metrics.no_at_fault_collision_available, human_metrics.no_at_fault_collision,
-    human_metrics.no_at_fault_collision_available);
+  result.human_no_at_fault_collision = human_metrics.no_at_fault_collision;
+  result.human_no_at_fault_collision_available = human_metrics.no_at_fault_collision_available;
+  result.filtered_no_at_fault_collision = apply_human_filter(
+    agent_metrics.no_at_fault_collision, agent_metrics.no_at_fault_collision_available,
+    human_metrics.no_at_fault_collision, human_metrics.no_at_fault_collision_available,
+    result.no_at_fault_collision_filter_applied);
 
-  populate_human_filter_metric(
-    result.driving_direction_compliance, agent_metrics.driving_direction_compliance,
+  result.human_driving_direction_compliance = human_metrics.driving_direction_compliance;
+  result.human_driving_direction_compliance_available =
+    human_metrics.driving_direction_compliance_available;
+  result.filtered_driving_direction_compliance = apply_human_filter(
+    agent_metrics.driving_direction_compliance,
     agent_metrics.driving_direction_compliance_available,
     human_metrics.driving_direction_compliance,
-    human_metrics.driving_direction_compliance_available);
+    human_metrics.driving_direction_compliance_available,
+    result.driving_direction_compliance_filter_applied);
 
-  populate_human_filter_metric(
-    result.traffic_light_compliance, agent_metrics.traffic_light_compliance,
-    agent_metrics.traffic_light_compliance_available, human_metrics.traffic_light_compliance,
-    human_metrics.traffic_light_compliance_available);
+  result.human_traffic_light_compliance = human_metrics.traffic_light_compliance;
+  result.human_traffic_light_compliance_available =
+    human_metrics.traffic_light_compliance_available;
+  result.filtered_traffic_light_compliance = apply_human_filter(
+    agent_metrics.traffic_light_compliance, agent_metrics.traffic_light_compliance_available,
+    human_metrics.traffic_light_compliance, human_metrics.traffic_light_compliance_available,
+    result.traffic_light_compliance_filter_applied);
 
   return result;
 }
@@ -111,17 +126,17 @@ SyntheticEpdmsMetrics calculate_synthetic_epdms(
                                       agent_metrics.lane_keeping_available &&
                                       agent_metrics.history_comfort_available &&
                                       agent_metrics.extended_comfort_available;
-  result.raw.available = raw_multiplicative_available && raw_weighted_available;
-  if (result.raw.available) {
-    result.raw.multiplicative_metrics_prod =
+  result.raw_available = raw_multiplicative_available && raw_weighted_available;
+  if (result.raw_available) {
+    result.raw_multiplicative_metrics_prod =
       agent_metrics.no_at_fault_collision * agent_metrics.drivable_area_compliance *
       agent_metrics.driving_direction_compliance * agent_metrics.traffic_light_compliance;
-    result.raw.weighted_metrics =
+    result.raw_weighted_metrics =
       (5.0 * agent_metrics.ego_progress + 5.0 * agent_metrics.time_to_collision_within_bound +
        2.0 * agent_metrics.lane_keeping + 2.0 * agent_metrics.history_comfort +
        2.0 * agent_metrics.extended_comfort) /
       kSyntheticWeightedDenominator;
-    result.raw.epdms = result.raw.multiplicative_metrics_prod * result.raw.weighted_metrics;
+    result.raw_epdms = result.raw_multiplicative_metrics_prod * result.raw_weighted_metrics;
   }
 
   const bool human_filtered_multiplicative_available =
@@ -134,25 +149,25 @@ SyntheticEpdmsMetrics calculate_synthetic_epdms(
     agent_metrics.time_to_collision_within_bound_available &&
     agent_metrics.lane_keeping_available && agent_metrics.history_comfort_available &&
     agent_metrics.extended_comfort_available;
-  result.human_filtered.available =
+  result.human_filtered_available =
     human_filtered_multiplicative_available && human_filtered_weighted_available;
-  if (result.human_filtered.available) {
-    result.human_filtered.multiplicative_metrics_prod =
-      human_filter_metrics.no_at_fault_collision.filtered *
-      human_filter_metrics.drivable_area_compliance.filtered *
-      human_filter_metrics.driving_direction_compliance.filtered *
-      human_filter_metrics.traffic_light_compliance.filtered;
+  if (result.human_filtered_available) {
+    result.human_filtered_multiplicative_metrics_prod =
+      human_filter_metrics.filtered_no_at_fault_collision *
+      human_filter_metrics.filtered_drivable_area_compliance *
+      human_filter_metrics.filtered_driving_direction_compliance *
+      human_filter_metrics.filtered_traffic_light_compliance;
     const double filtered_ego_progress =
-      human_filter_metrics.ego_progress.filter_applied ? 1.0 : agent_metrics.ego_progress;
-    result.human_filtered.weighted_metrics =
+      human_filter_metrics.ego_progress_filter_applied ? 1.0 : agent_metrics.ego_progress;
+    result.human_filtered_weighted_metrics =
       (5.0 * filtered_ego_progress +
-       5.0 * human_filter_metrics.time_to_collision_within_bound.filtered +
-       2.0 * human_filter_metrics.lane_keeping.filtered +
-       2.0 * human_filter_metrics.history_comfort.filtered +
-       2.0 * human_filter_metrics.extended_comfort.filtered) /
+       5.0 * human_filter_metrics.filtered_time_to_collision_within_bound +
+       2.0 * human_filter_metrics.filtered_lane_keeping +
+       2.0 * human_filter_metrics.filtered_history_comfort +
+       2.0 * human_filter_metrics.filtered_extended_comfort) /
       kSyntheticWeightedDenominator;
-    result.human_filtered.epdms =
-      result.human_filtered.multiplicative_metrics_prod * result.human_filtered.weighted_metrics;
+    result.human_filtered_epdms =
+      result.human_filtered_multiplicative_metrics_prod * result.human_filtered_weighted_metrics;
   }
 
   return result;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms_aggregation.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms_aggregation.hpp
@@ -52,37 +52,63 @@ struct EpdmsMetricSnapshot
 
 struct HumanFilterMetrics
 {
-  struct Metric
-  {
-    double human_reference{0.0};
-    bool human_reference_available{false};
-    double filtered{0.0};
-    bool filter_applied{false};
-  };
+  double human_history_comfort{0.0};
+  bool human_history_comfort_available{false};
+  double filtered_history_comfort{0.0};
+  bool history_comfort_filter_applied{false};
 
-  Metric history_comfort;
-  Metric extended_comfort;
-  Metric ego_progress;
-  Metric time_to_collision_within_bound;
-  Metric lane_keeping;
-  Metric drivable_area_compliance;
-  Metric no_at_fault_collision;
-  Metric driving_direction_compliance;
-  Metric traffic_light_compliance;
+  double human_extended_comfort{0.0};
+  bool human_extended_comfort_available{false};
+  double filtered_extended_comfort{0.0};
+  bool extended_comfort_filter_applied{false};
+
+  double human_ego_progress{0.0};
+  bool human_ego_progress_available{false};
+  double filtered_ego_progress{0.0};
+  bool ego_progress_filter_applied{false};
+
+  double human_time_to_collision_within_bound{0.0};
+  bool human_time_to_collision_within_bound_available{false};
+  double filtered_time_to_collision_within_bound{0.0};
+  bool time_to_collision_within_bound_filter_applied{false};
+
+  double human_lane_keeping{0.0};
+  bool human_lane_keeping_available{false};
+  double filtered_lane_keeping{0.0};
+  bool lane_keeping_filter_applied{false};
+
+  double human_drivable_area_compliance{0.0};
+  bool human_drivable_area_compliance_available{false};
+  double filtered_drivable_area_compliance{0.0};
+  bool drivable_area_compliance_filter_applied{false};
+
+  double human_no_at_fault_collision{0.0};
+  bool human_no_at_fault_collision_available{false};
+  double filtered_no_at_fault_collision{0.0};
+  bool no_at_fault_collision_filter_applied{false};
+
+  double human_driving_direction_compliance{0.0};
+  bool human_driving_direction_compliance_available{false};
+  double filtered_driving_direction_compliance{0.0};
+  bool driving_direction_compliance_filter_applied{false};
+
+  double human_traffic_light_compliance{0.0};
+  bool human_traffic_light_compliance_available{false};
+  double filtered_traffic_light_compliance{0.0};
+  bool traffic_light_compliance_filter_applied{false};
 };
 
 struct SyntheticEpdmsMetrics
 {
-  struct Stage
-  {
-    bool available{false};
-    double multiplicative_metrics_prod{0.0};
-    double weighted_metrics{0.0};
-    double epdms{0.0};
-  };
+  bool raw_available{false};
+  double raw_multiplicative_metrics_prod{0.0};
+  double raw_weighted_metrics{0.0};
+  double raw_epdms{0.0};
 
-  Stage raw;
-  Stage human_filtered;
+  bool human_filtered_available{false};
+  double human_filtered_multiplicative_metrics_prod{0.0};
+  double human_filtered_weighted_metrics{0.0};
+  double human_filtered_epdms{0.0};
 };
 
 HumanFilterMetrics calculate_human_filter_metrics(

--- a/planning/autoware_planning_data_analyzer/src/metrics/extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/extended_comfort.cpp
@@ -14,9 +14,9 @@
 
 #include "extended_comfort.hpp"
 
-#include "metric_utils.hpp"
-
 #include <autoware_utils_math/normalization.hpp>
+
+#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>
@@ -82,8 +82,8 @@ DynamicSignals calculate_dynamic_signals(
       std::hypot(next_point.longitudinal_velocity_mps, next_point.lateral_velocity_mps);
     signals.accelerations.at(i) = (next_speed - speed) / dt;
 
-    const double yaw = get_yaw(point.pose.orientation);
-    const double next_yaw = get_yaw(next_point.pose.orientation);
+    const double yaw = tf2::getYaw(point.pose.orientation);
+    const double next_yaw = tf2::getYaw(next_point.pose.orientation);
     const double delta_yaw = autoware_utils_math::normalize_radian(next_yaw - yaw);
     signals.yaw_rates.at(i) = delta_yaw / dt;
   }

--- a/planning/autoware_planning_data_analyzer/src/metrics/history_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/history_comfort.cpp
@@ -14,9 +14,11 @@
 
 #include "history_comfort.hpp"
 
-#include "metric_utils.hpp"
-
 #include <autoware_utils_math/normalization.hpp>
+
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>
@@ -83,8 +85,8 @@ void calculate_history_comfort_metrics(
       history_comfort_params.finite_difference_epsilon);
 
     const double yaw_delta = autoware_utils_math::normalize_radian(
-      get_yaw(trajectory.points[i + 1].pose.orientation) -
-      get_yaw(trajectory.points[i].pose.orientation));
+      tf2::getYaw(trajectory.points[i + 1].pose.orientation) -
+      tf2::getYaw(trajectory.points[i].pose.orientation));
     metrics.yaw_rates[i] = yaw_delta / time_resolution;
     metrics.longitudinal_accelerations[i] = (trajectory.points[i + 1].longitudinal_velocity_mps -
                                              trajectory.points[i].longitudinal_velocity_mps) /

--- a/planning/autoware_planning_data_analyzer/src/metrics/metric_utils.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/metric_utils.cpp
@@ -28,8 +28,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 namespace
 {
 
@@ -51,7 +49,7 @@ bool is_vehicle_info_valid(const autoware::vehicle_info_utils::VehicleInfo & veh
 
 double get_yaw(const geometry_msgs::msg::Quaternion & orientation)
 {
-  return tf2::getYaw(tf2::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w));
+  return tf2::getYaw(orientation);
 }
 
 autoware_utils_geometry::Polygon2d create_pose_footprint(
@@ -67,7 +65,8 @@ autoware_utils_geometry::Polygon2d create_pose_footprint(
 }
 
 std::optional<lanelet::ConstLanelet> find_reference_lanelet(
-  const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler)
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   if (!route_handler || !route_handler->isHandlerReady()) {
     return std::nullopt;
@@ -89,7 +88,7 @@ std::optional<lanelet::ConstLanelet> find_reference_lanelet(
 
 lanelet::ConstLanelets collect_route_relevant_lanelets(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   lanelet::ConstLanelets route_lanelets;
   if (!route_handler || !route_handler->isHandlerReady()) {
@@ -119,7 +118,8 @@ autoware_utils_geometry::LineString2d to_linestring2d(const lanelet::ConstLineSt
 }
 
 bool is_pose_in_intersection(
-  const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler)
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   const auto lanelet = find_reference_lanelet(pose, route_handler);
   return lanelet.has_value() &&

--- a/planning/autoware_planning_data_analyzer/src/metrics/metric_utils.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/metric_utils.hpp
@@ -32,8 +32,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 bool is_vehicle_info_valid(const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
 
 double get_yaw(const geometry_msgs::msg::Quaternion & orientation);
@@ -43,16 +41,18 @@ autoware_utils_geometry::Polygon2d create_pose_footprint(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
 
 std::optional<lanelet::ConstLanelet> find_reference_lanelet(
-  const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler);
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler);
 
 lanelet::ConstLanelets collect_route_relevant_lanelets(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::shared_ptr<RouteHandler> & route_handler);
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler);
 
 autoware_utils_geometry::LineString2d to_linestring2d(const lanelet::ConstLineString3d & line);
 
 bool is_pose_in_intersection(
-  const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler);
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler);
 
 double forward_offset_in_ego_frame(
   const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & object_pose);

--- a/planning/autoware_planning_data_analyzer/src/metrics/no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/no_at_fault_collision.cpp
@@ -35,8 +35,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 namespace
 {
 
@@ -163,7 +161,7 @@ bool footprint_intersects_lanelet(
 
 std::optional<EgoAreaFlags> compute_ego_area_flags(
   const geometry_msgs::msg::Pose & pose, const Polygon2d & ego_polygon,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   if (!route_handler) {
     return std::nullopt;
@@ -202,7 +200,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<PredictedObjects> & objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   NoAtFaultCollisionResult result;
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/no_at_fault_collision.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/no_at_fault_collision.hpp
@@ -27,8 +27,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 struct NoAtFaultCollisionResult
 {
   double score{0.0};
@@ -41,7 +39,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<PredictedObjects> & objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr);
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/traffic_light_compliance.cpp
@@ -35,8 +35,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 namespace
 {
 
@@ -68,7 +66,7 @@ bool footprint_intersects_stop_line(
 TrafficLightComplianceResult calculate_traffic_light_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<TrafficLightGroupArray> & traffic_signals,
-  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
   TrafficLightComplianceResult result;

--- a/planning/autoware_planning_data_analyzer/src/metrics/traffic_light_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/traffic_light_compliance.hpp
@@ -26,8 +26,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 struct TrafficLightComplianceResult
 {
   double score{0.0};
@@ -38,7 +36,7 @@ struct TrafficLightComplianceResult
 TrafficLightComplianceResult calculate_traffic_light_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<TrafficLightGroupArray> & traffic_signals,
-  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -40,8 +40,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 namespace
 {
 
@@ -55,7 +53,7 @@ tf2::Vector3 get_velocity_in_world_coordinate(
   const autoware_planning_msgs::msg::TrajectoryPoint & point)
 {
   const auto & pose = point.pose;
-  const double yaw = get_yaw(pose.orientation);
+  const double yaw = tf2::getYaw(pose.orientation);
   const double cos_yaw = std::cos(yaw);
   const double sin_yaw = std::sin(yaw);
 
@@ -181,7 +179,7 @@ double calculate_time_to_collision(
     const double v = segment_length / dt;
 
     // Transform velocity from world frame to vehicle frame
-    const double yaw = get_yaw(obj_point.pose.orientation);
+    const double yaw = tf2::getYaw(obj_point.pose.orientation);
     const double c = std::cos(yaw);
     const double s = std::sin(yaw);
     const double vx_w = dir_w.x() * v;
@@ -199,7 +197,8 @@ double calculate_time_to_collision(
 }
 
 bool is_pose_in_route_lane(
-  const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler)
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   if (!route_handler || !route_handler->isHandlerReady()) {
     return false;
@@ -223,7 +222,7 @@ bool is_pose_in_route_lane(
 
 TrajectoryPointMetrics calculate_trajectory_point_metrics(
   const std::shared_ptr<SynchronizedData> & sync_data,
-  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
   const HistoryComfortParameters & history_comfort_params,
   const LaneKeepingParameters & lane_keeping_params,
   const DrivingDirectionComplianceParameters & driving_direction_params,

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
@@ -31,8 +31,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 struct HistoryComfortParameters
 {
   double finite_difference_epsilon{1.0e-3};
@@ -90,7 +88,7 @@ struct TrajectoryPointMetrics
  */
 TrajectoryPointMetrics calculate_trajectory_point_metrics(
   const std::shared_ptr<SynchronizedData> & sync_data,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler = nullptr,
   const HistoryComfortParameters & history_comfort_params = HistoryComfortParameters{},
   const LaneKeepingParameters & lane_keeping_params = LaneKeepingParameters{},
   const DrivingDirectionComplianceParameters & driving_direction_params =

--- a/planning/autoware_planning_data_analyzer/src/metrics/ttc_within_bound.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/ttc_within_bound.cpp
@@ -33,8 +33,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 namespace
 {
 
@@ -107,7 +105,7 @@ TTCWithinBoundResult calculate_ttc_within_bound(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<PredictedObjects> & objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
 {
   TTCWithinBoundResult result;
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/ttc_within_bound.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/ttc_within_bound.hpp
@@ -27,8 +27,6 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-using autoware::route_handler::RouteHandler;
-
 struct TTCWithinBoundResult
 {
   double score{0.0};
@@ -41,7 +39,7 @@ TTCWithinBoundResult calculate_ttc_within_bound(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<PredictedObjects> & objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr);
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -14,10 +14,17 @@
 
 #include "open_loop_evaluator.hpp"
 
+#include "metrics/drivable_area_compliance.hpp"
 #include "metrics/epdms_aggregation.hpp"
+#include "metrics/history_comfort.hpp"
 #include "metrics/metric_utils.hpp"
+#include "metrics/no_at_fault_collision.hpp"
+#include "metrics/traffic_light_compliance.hpp"
 #include "metrics/trajectory_metrics.hpp"
+#include "metrics/ttc_within_bound.hpp"
 
+#include <autoware/lanelet2_utils/geometry.hpp>
+#include <autoware/lanelet2_utils/intersection.hpp>
 #include <autoware/motion_utils/trajectory/conversion.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
@@ -36,17 +43,22 @@
 #include <tf2/utils.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
+#include <cstdlib>
+#include <exception>
 #include <iomanip>
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <numeric>
 #include <optional>
 #include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -56,15 +68,7 @@ namespace autoware::planning_data_analyzer
 namespace
 {
 
-std::shared_ptr<SynchronizedData> clone_with_trajectory(
-  const std::shared_ptr<SynchronizedData> & original,
-  const autoware_planning_msgs::msg::Trajectory & trajectory)
-{
-  auto cloned = std::make_shared<SynchronizedData>(*original);
-  cloned->trajectory = std::make_shared<autoware_planning_msgs::msg::Trajectory>(trajectory);
-  cloned->candidate_trajectories.reset();
-  return cloned;
-}
+using SyntheticEpdmsByHorizon = std::map<std::string, metrics::SyntheticEpdmsMetrics>;
 
 metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetrics & metrics)
 {
@@ -91,9 +95,446 @@ metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetric
   return snapshot;
 }
 
-double get_yaw_from_msg(const geometry_msgs::msg::Quaternion & orientation)
+std::string format_epdms_horizon_label(const double horizon_s)
 {
-  return metrics::get_yaw(orientation);
+  std::ostringstream oss;
+  const double rounded = std::round(horizon_s);
+  if (std::abs(horizon_s - rounded) < 1.0e-6) {
+    oss << static_cast<int>(rounded);
+  } else {
+    oss << std::fixed << std::setprecision(1) << horizon_s;
+  }
+  oss << "s";
+  return oss.str();
+}
+
+std::optional<Trajectory> truncate_trajectory_to_horizon(
+  const Trajectory & trajectory, const double horizon_s)
+{
+  if (horizon_s <= 0.0 || trajectory.points.empty()) {
+    return std::nullopt;
+  }
+
+  Trajectory truncated = trajectory;
+  truncated.points.clear();
+  for (const auto & point : trajectory.points) {
+    const double t = rclcpp::Duration(point.time_from_start).seconds();
+    if (t <= horizon_s + 1.0e-6) {
+      truncated.points.push_back(point);
+    } else {
+      break;
+    }
+  }
+
+  if (truncated.points.empty()) {
+    return std::nullopt;
+  }
+
+  return truncated;
+}
+
+std::shared_ptr<CandidateTrajectories> truncate_candidate_trajectories_to_horizon(
+  const std::shared_ptr<CandidateTrajectories> & candidate_trajectories, const double horizon_s)
+{
+  if (!candidate_trajectories) {
+    return nullptr;
+  }
+
+  auto truncated = std::make_shared<CandidateTrajectories>(*candidate_trajectories);
+  for (auto & candidate : truncated->candidate_trajectories) {
+    std::vector<autoware_planning_msgs::msg::TrajectoryPoint> truncated_points;
+    for (const auto & point : candidate.points) {
+      const double t = rclcpp::Duration(point.time_from_start).seconds();
+      if (t <= horizon_s + 1.0e-6) {
+        truncated_points.push_back(point);
+      } else {
+        break;
+      }
+    }
+    candidate.points = std::move(truncated_points);
+  }
+
+  return truncated;
+}
+
+metrics::EpdmsMetricSnapshot calculate_human_reference_snapshot(
+  const OpenLoopEvaluator::EvaluationData & eval_data,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const metrics::HistoryComfortParameters & history_comfort_params,
+  const metrics::LaneKeepingParameters & lane_keeping_params,
+  const metrics::DrivingDirectionComplianceParameters & driving_direction_params,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+
+metrics::EpdmsMetricSnapshot build_epdms_snapshot(
+  const metrics::TrajectoryPointMetrics & trajectory_metrics,
+  const metrics::EgoProgressResult & ego_progress_result,
+  const metrics::ExtendedComfortResult & extended_comfort_result)
+{
+  metrics::EpdmsMetricSnapshot snapshot;
+  snapshot.history_comfort = trajectory_metrics.history_comfort;
+  snapshot.history_comfort_available = true;
+  snapshot.extended_comfort = extended_comfort_result.score;
+  snapshot.extended_comfort_available = extended_comfort_result.available;
+  snapshot.ego_progress = ego_progress_result.score;
+  snapshot.ego_progress_available = ego_progress_result.available;
+  snapshot.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
+  snapshot.time_to_collision_within_bound_available =
+    trajectory_metrics.time_to_collision_within_bound_available;
+  snapshot.lane_keeping = trajectory_metrics.lane_keeping;
+  snapshot.lane_keeping_available = trajectory_metrics.lane_keeping_available;
+  snapshot.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
+  snapshot.drivable_area_compliance_available =
+    trajectory_metrics.drivable_area_compliance_available;
+  snapshot.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
+  snapshot.no_at_fault_collision_available = trajectory_metrics.no_at_fault_collision_available;
+  snapshot.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
+  snapshot.driving_direction_compliance_available =
+    trajectory_metrics.driving_direction_compliance_available;
+  snapshot.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
+  snapshot.traffic_light_compliance_available =
+    trajectory_metrics.traffic_light_compliance_available;
+  return snapshot;
+}
+
+std::pair<metrics::HumanFilterMetrics, metrics::SyntheticEpdmsMetrics>
+calculate_horizon_synthetic_epdms(
+  const OpenLoopEvaluator::EvaluationData & eval_data,
+  const OpenLoopEvaluator::EvaluationData * previous_eval_data, const double horizon_s,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const metrics::HistoryComfortParameters & history_comfort_params,
+  const metrics::LaneKeepingParameters & lane_keeping_params,
+  const metrics::DrivingDirectionComplianceParameters & driving_direction_params,
+  const metrics::ExtendedComfortParameters & extended_comfort_parameters,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+{
+  const auto truncated_prediction =
+    eval_data.synchronized_data && eval_data.synchronized_data->trajectory
+      ? truncate_trajectory_to_horizon(*eval_data.synchronized_data->trajectory, horizon_s)
+      : std::nullopt;
+  const auto truncated_gt =
+    truncate_trajectory_to_horizon(eval_data.ground_truth_trajectory, horizon_s);
+
+  if (!truncated_prediction.has_value() || !truncated_gt.has_value()) {
+    return {};
+  }
+
+  auto truncated_sync = std::make_shared<SynchronizedData>(*eval_data.synchronized_data);
+  truncated_sync->trajectory = std::make_shared<Trajectory>(truncated_prediction.value());
+  truncated_sync->candidate_trajectories = truncate_candidate_trajectories_to_horizon(
+    eval_data.synchronized_data->candidate_trajectories, horizon_s);
+
+  const auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
+    truncated_sync, route_handler, history_comfort_params, lane_keeping_params,
+    driving_direction_params, vehicle_info);
+  const auto ego_progress = metrics::calculate_ego_progress(
+    truncated_sync->trajectory, truncated_sync->candidate_trajectories, route_handler);
+
+  metrics::ExtendedComfortResult extended_comfort_result{
+    0.0, false, "unavailable_no_previous_trajectory"};
+  metrics::ExtendedComfortResult human_extended_comfort_result{
+    0.0, false, "unavailable_no_previous_trajectory"};
+  if (
+    previous_eval_data && previous_eval_data->synchronized_data &&
+    previous_eval_data->synchronized_data->trajectory) {
+    const auto truncated_previous_prediction =
+      truncate_trajectory_to_horizon(*previous_eval_data->synchronized_data->trajectory, horizon_s);
+    const auto truncated_previous_gt =
+      truncate_trajectory_to_horizon(previous_eval_data->ground_truth_trajectory, horizon_s);
+    if (truncated_previous_prediction.has_value()) {
+      extended_comfort_result = metrics::calculate_extended_comfort(
+        truncated_previous_prediction.value(), truncated_prediction.value(),
+        extended_comfort_parameters);
+    }
+    if (truncated_previous_gt.has_value()) {
+      human_extended_comfort_result = metrics::calculate_extended_comfort(
+        truncated_previous_gt.value(), truncated_gt.value(), extended_comfort_parameters);
+    }
+  }
+
+  auto human_eval_data = eval_data;
+  human_eval_data.synchronized_data = truncated_sync;
+  human_eval_data.ground_truth_trajectory = truncated_gt.value();
+  auto human_snapshot = calculate_human_reference_snapshot(
+    human_eval_data, route_handler, history_comfort_params, lane_keeping_params,
+    driving_direction_params, vehicle_info);
+  human_snapshot.extended_comfort = human_extended_comfort_result.score;
+  human_snapshot.extended_comfort_available = human_extended_comfort_result.available;
+
+  const auto agent_snapshot =
+    build_epdms_snapshot(trajectory_metrics, ego_progress, extended_comfort_result);
+  const auto human_filter_metrics =
+    metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
+  const auto synthetic_epdms =
+    metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics);
+  return std::make_pair(human_filter_metrics, synthetic_epdms);
+}
+
+std::size_t resolve_parallel_worker_count(const std::size_t work_item_count)
+{
+  if (work_item_count <= 1U) {
+    return 1U;
+  }
+
+  constexpr std::size_t kMinWorkPerWorker = 8U;
+  const auto auto_hw_threads = std::max(
+    1U, std::thread::hardware_concurrency() > 1U ? std::thread::hardware_concurrency() - 1U : 1U);
+
+  std::size_t requested_threads = 0U;
+  if (const char * env = std::getenv("AUTOWARE_PLANNING_DATA_ANALYZER_NUM_THREADS")) {
+    try {
+      requested_threads = static_cast<std::size_t>(std::stoul(env));
+    } catch (const std::exception &) {
+      requested_threads = 0U;
+    }
+  }
+
+  const auto capped_for_workload = std::max<std::size_t>(1U, work_item_count / kMinWorkPerWorker);
+  const auto auto_threads = std::min<std::size_t>(auto_hw_threads, capped_for_workload);
+  if (requested_threads == 0U) {
+    return std::max<std::size_t>(1U, auto_threads);
+  }
+  return std::max<std::size_t>(1U, std::min<std::size_t>(requested_threads, work_item_count));
+}
+
+bool is_pose_in_route_lane_for_human_snapshot(
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
+{
+  if (!route_handler || !route_handler->isHandlerReady()) {
+    return false;
+  }
+
+  lanelet::ConstLanelet closest_lanelet;
+  if (route_handler->getClosestLaneletWithinRoute(pose, &closest_lanelet)) {
+    return true;
+  }
+
+  for (const auto & lanelet : route_handler->getRoadLaneletsAtPose(pose)) {
+    if (route_handler->isRouteLanelet(lanelet)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+struct CachedRoutePoseClassification
+{
+  std::optional<lanelet::ConstLanelet> reference_lanelet;
+  bool in_intersection{false};
+  bool in_route_lane{false};
+};
+
+std::vector<CachedRoutePoseClassification> build_route_pose_cache(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler)
+{
+  std::vector<CachedRoutePoseClassification> cache;
+  cache.reserve(trajectory.points.size());
+
+  for (const auto & point : trajectory.points) {
+    CachedRoutePoseClassification entry;
+    entry.reference_lanelet = metrics::find_reference_lanelet(point.pose, route_handler);
+    if (entry.reference_lanelet.has_value()) {
+      entry.in_intersection = autoware::experimental::lanelet2_utils::is_intersection_lanelet(
+        entry.reference_lanelet.value());
+    }
+    entry.in_route_lane = is_pose_in_route_lane_for_human_snapshot(point.pose, route_handler);
+    cache.push_back(std::move(entry));
+  }
+
+  return cache;
+}
+
+metrics::EpdmsMetricSnapshot calculate_human_reference_snapshot(
+  const OpenLoopEvaluator::EvaluationData & eval_data,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const metrics::HistoryComfortParameters & history_comfort_params,
+  const metrics::LaneKeepingParameters & lane_keeping_params,
+  const metrics::DrivingDirectionComplianceParameters & driving_direction_params,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+{
+  metrics::EpdmsMetricSnapshot snapshot;
+  const auto & trajectory = eval_data.ground_truth_trajectory;
+  const auto & sync_data = eval_data.synchronized_data;
+
+  metrics::TrajectoryPointMetrics history_metrics;
+  metrics::calculate_history_comfort_metrics(trajectory, history_comfort_params, history_metrics);
+  snapshot.history_comfort = history_metrics.history_comfort;
+  snapshot.history_comfort_available = true;
+
+  const auto ttc_within_bound = metrics::calculate_ttc_within_bound(
+    trajectory, sync_data->objects, vehicle_info, route_handler);
+  snapshot.time_to_collision_within_bound = ttc_within_bound.score;
+  snapshot.time_to_collision_within_bound_available = ttc_within_bound.available;
+
+  const auto no_at_fault_collision = metrics::calculate_no_at_fault_collision(
+    trajectory, sync_data->objects, vehicle_info, route_handler);
+  snapshot.no_at_fault_collision = no_at_fault_collision.score;
+  snapshot.no_at_fault_collision_available = no_at_fault_collision.available;
+
+  snapshot.ego_progress = 1.0;
+  snapshot.ego_progress_available = false;
+
+  if (!route_handler) {
+    return snapshot;
+  }
+  if (!route_handler->isHandlerReady()) {
+    return snapshot;
+  }
+
+  const auto route_pose_cache = build_route_pose_cache(trajectory, route_handler);
+
+  std::vector<metrics::DrivingDirectionEvaluationPoint> driving_direction_evaluation_points;
+  driving_direction_evaluation_points.reserve(trajectory.points.size());
+  for (std::size_t i = 0; i < trajectory.points.size(); ++i) {
+    double progress_m = 0.0;
+    if (i > 0U) {
+      progress_m = autoware_utils_geometry::calc_distance2d(
+        trajectory.points.at(i - 1U).pose.position, trajectory.points.at(i).pose.position);
+    }
+
+    driving_direction_evaluation_points.push_back(
+      metrics::DrivingDirectionEvaluationPoint{
+        rclcpp::Duration(trajectory.points.at(i).time_from_start).seconds(), progress_m,
+        !route_pose_cache.at(i).in_route_lane, route_pose_cache.at(i).in_intersection});
+  }
+
+  const auto driving_direction_compliance = metrics::calculate_driving_direction_compliance(
+    driving_direction_evaluation_points, driving_direction_params);
+  snapshot.driving_direction_compliance = driving_direction_compliance.score;
+  snapshot.driving_direction_compliance_available = driving_direction_compliance.available;
+
+  std::vector<metrics::LaneKeepingEvaluationPoint> lane_keeping_evaluation_points;
+  lane_keeping_evaluation_points.reserve(trajectory.points.size());
+  for (std::size_t i = 0; i < trajectory.points.size(); ++i) {
+    const auto & cached_pose = route_pose_cache.at(i);
+    const auto & point = trajectory.points.at(i);
+    if (!cached_pose.reference_lanelet.has_value()) {
+      lane_keeping_evaluation_points.push_back(
+        metrics::LaneKeepingEvaluationPoint{
+          point.time_from_start, std::numeric_limits<double>::quiet_NaN(), false});
+      continue;
+    }
+
+    const double lateral_deviation =
+      autoware::experimental::lanelet2_utils::get_lateral_distance_to_centerline(
+        cached_pose.reference_lanelet.value(), point.pose);
+    lane_keeping_evaluation_points.push_back(
+      metrics::LaneKeepingEvaluationPoint{
+        point.time_from_start, lateral_deviation, cached_pose.in_intersection});
+  }
+
+  const auto has_finite_lane_keeping_sample = std::any_of(
+    lane_keeping_evaluation_points.begin(), lane_keeping_evaluation_points.end(),
+    [](const auto & evaluation_point) {
+      return std::isfinite(evaluation_point.lateral_deviation);
+    });
+  if (has_finite_lane_keeping_sample) {
+    snapshot.lane_keeping =
+      metrics::calculate_lane_keeping_score(lane_keeping_evaluation_points, lane_keeping_params);
+    snapshot.lane_keeping_available = true;
+  }
+
+  const auto drivable_lanelets =
+    metrics::collect_route_relevant_lanelets(trajectory, route_handler);
+  const auto drivable_area_compliance =
+    metrics::calculate_drivable_area_compliance(trajectory, drivable_lanelets, vehicle_info);
+  snapshot.drivable_area_compliance = drivable_area_compliance.score;
+  snapshot.drivable_area_compliance_available = drivable_area_compliance.available;
+
+  const auto traffic_light_compliance = metrics::calculate_traffic_light_compliance(
+    trajectory, sync_data->traffic_signals, route_handler, vehicle_info);
+  snapshot.traffic_light_compliance = traffic_light_compliance.score;
+  snapshot.traffic_light_compliance_available = traffic_light_compliance.available;
+
+  return snapshot;
+}
+
+std::vector<int64_t> build_gt_absolute_time_cache(
+  const autoware_planning_msgs::msg::Trajectory & gt_trajectory)
+{
+  std::vector<int64_t> gt_abs_times;
+  gt_abs_times.reserve(gt_trajectory.points.size());
+  const auto gt_start = rclcpp::Time(gt_trajectory.header.stamp).nanoseconds();
+  for (const auto & pt : gt_trajectory.points) {
+    gt_abs_times.push_back(gt_start + rclcpp::Duration(pt.time_from_start).nanoseconds());
+  }
+  return gt_abs_times;
+}
+
+std::optional<geometry_msgs::msg::Pose> interpolate_ground_truth_from_cached_trajectory_times(
+  const rclcpp::Time & target_time, const autoware_planning_msgs::msg::Trajectory & gt_trajectory,
+  const std::vector<int64_t> & gt_abs_times, const double gt_sync_tolerance_ms)
+{
+  if (gt_trajectory.points.empty() || gt_abs_times.empty()) {
+    return std::nullopt;
+  }
+
+  const auto target_ns = target_time.nanoseconds();
+  const auto front_ns = gt_abs_times.front();
+  const auto back_ns = gt_abs_times.back();
+  const auto tolerance_ns = static_cast<int64_t>(std::llround(gt_sync_tolerance_ms * 1e6));
+  if (target_ns < front_ns) {
+    if (front_ns - target_ns <= tolerance_ns) {
+      return gt_trajectory.points.front().pose;
+    }
+    return std::nullopt;
+  }
+  if (target_ns > back_ns) {
+    if (target_ns - back_ns <= tolerance_ns) {
+      return gt_trajectory.points.back().pose;
+    }
+    return std::nullopt;
+  }
+
+  if (target_ns == front_ns) {
+    return gt_trajectory.points.front().pose;
+  }
+  if (target_ns == back_ns) {
+    return gt_trajectory.points.back().pose;
+  }
+
+  size_t lower_idx = 0;
+  size_t upper_idx = gt_abs_times.size() - 1;
+  while (upper_idx - lower_idx > 1) {
+    const size_t mid = lower_idx + (upper_idx - lower_idx) / 2;
+    if (gt_abs_times[mid] <= target_ns) {
+      lower_idx = mid;
+    } else {
+      upper_idx = mid;
+    }
+  }
+
+  const auto lower_ns = gt_abs_times[lower_idx];
+  const auto upper_ns = gt_abs_times[upper_idx];
+  const auto lower_dist_ns = target_ns - lower_ns;
+  const auto upper_dist_ns = upper_ns - target_ns;
+  if (std::min(lower_dist_ns, upper_dist_ns) > tolerance_ns) {
+    return std::nullopt;
+  }
+
+  const double dt_total = static_cast<double>(upper_ns - lower_ns) / 1e9;
+  const double dt_target = static_cast<double>(target_ns - lower_ns) / 1e9;
+  const double ratio = dt_total > 0.0 ? dt_target / dt_total : 0.0;
+
+  const auto & p1 = gt_trajectory.points[lower_idx].pose;
+  const auto & p2 = gt_trajectory.points[upper_idx].pose;
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = p1.position.x + ratio * (p2.position.x - p1.position.x);
+  pose.position.y = p1.position.y + ratio * (p2.position.y - p1.position.y);
+  pose.position.z = p1.position.z + ratio * (p2.position.z - p1.position.z);
+
+  const double yaw1 = tf2::getYaw(p1.orientation);
+  const double yaw2 = tf2::getYaw(p2.orientation);
+  double yaw_diff = yaw2 - yaw1;
+  while (yaw_diff > M_PI) yaw_diff -= 2 * M_PI;
+  while (yaw_diff < -M_PI) yaw_diff += 2 * M_PI;
+  const double yaw_interp = yaw1 + ratio * yaw_diff;
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw_interp);
+  pose.orientation = tf2::toMsg(q);
+  return pose;
 }
 
 }  // namespace
@@ -197,6 +638,7 @@ void OpenLoopEvaluator::evaluate(
   trajectory_point_metrics_list_.clear();
   human_filter_metrics_list_.clear();
   synthetic_epdms_metrics_list_.clear();
+  synthetic_epdms_horizon_metrics_list_.clear();
   // Reset normalized timestamp tracking for new evaluation
   first_bag_timestamp_set_ = false;
 
@@ -219,126 +661,261 @@ void OpenLoopEvaluator::evaluate(
     return;
   }
 
-  // Evaluate each trajectory with its ground truth
-  for (std::size_t i = 0; i < evaluation_data_list.size(); ++i) {
-    const auto & eval_data = evaluation_data_list.at(i);
-    // Calculate trajectory point metrics
-    auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
-      eval_data.synchronized_data, route_handler_, history_comfort_params_, lane_keeping_params_,
-      driving_direction_params_, vehicle_info_);
-    // Evaluate trajectory
-    auto metrics = evaluate_trajectory(eval_data);
-    metrics.history_comfort = trajectory_metrics.history_comfort;
-    if (i == 0U) {
-      metrics.extended_comfort = 0.0;
-      metrics.extended_comfort_available = false;
-      metrics.extended_comfort_reason = "unavailable_no_previous_trajectory";
-    } else {
-      const auto & previous_eval_data = evaluation_data_list.at(i - 1U);
-      const auto & previous_trajectory = previous_eval_data.synchronized_data->trajectory;
-      const auto & current_trajectory = eval_data.synchronized_data->trajectory;
-      if (!previous_trajectory || !current_trajectory) {
-        metrics.extended_comfort = 0.0;
-        metrics.extended_comfort_available = false;
-        metrics.extended_comfort_reason = "unavailable_missing_trajectory";
-      } else {
-        const auto extended_comfort_result = metrics::calculate_extended_comfort(
-          *previous_trajectory, *current_trajectory, extended_comfort_parameters_);
-        metrics.extended_comfort = extended_comfort_result.score;
-        metrics.extended_comfort_available = extended_comfort_result.available;
-        metrics.extended_comfort_reason = extended_comfort_result.reason;
+  struct ParallelEvaluationResult
+  {
+    OpenLoopTrajectoryMetrics metrics;
+    metrics::TrajectoryPointMetrics trajectory_metrics;
+    metrics::EpdmsMetricSnapshot human_snapshot;
+    metrics::HumanFilterMetrics human_filter_metrics;
+    metrics::SyntheticEpdmsMetrics synthetic_epdms;
+    SyntheticEpdmsByHorizon synthetic_epdms_by_horizon;
+  };
+
+  std::vector<ParallelEvaluationResult> parallel_results(evaluation_data_list.size());
+  const auto worker_count = resolve_parallel_worker_count(evaluation_data_list.size());
+  constexpr std::size_t kProgressLogInterval = 1000U;
+  const auto log_parallel_progress = [this](
+                                       const char * phase_name, const std::size_t processed,
+                                       const std::size_t total) {
+    RCLCPP_DEBUG(logger_, "%s progress: %zu/%zu trajectory samples", phase_name, processed, total);
+  };
+  RCLCPP_INFO(
+    logger_, "Evaluating %zu open-loop trajectories using %zu worker thread(s)",
+    evaluation_data_list.size(), worker_count);
+  RCLCPP_INFO(logger_, "Parallel phase 1 started: base trajectory metrics");
+
+  std::atomic<std::size_t> next_index{0U};
+  std::atomic<std::size_t> phase1_processed{0U};
+  std::atomic<bool> stop_requested{false};
+  std::exception_ptr worker_exception;
+  std::mutex worker_exception_mutex;
+
+  auto worker = [&]() {
+    while (true) {
+      if (stop_requested.load()) {
+        return;
+      }
+
+      const auto i = next_index.fetch_add(1U);
+      if (i >= evaluation_data_list.size()) {
+        return;
+      }
+
+      try {
+        const auto & eval_data = evaluation_data_list.at(i);
+        auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
+          eval_data.synchronized_data, route_handler_, history_comfort_params_,
+          lane_keeping_params_, driving_direction_params_, vehicle_info_);
+        auto metrics = evaluate_trajectory(eval_data);
+        metrics.history_comfort = trajectory_metrics.history_comfort;
+        metrics.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
+        metrics.time_to_collision_within_bound_available =
+          trajectory_metrics.time_to_collision_within_bound_available;
+        metrics.time_to_collision_within_bound_reason =
+          trajectory_metrics.time_to_collision_within_bound_reason;
+        metrics.time_to_collision_infraction_time_s =
+          trajectory_metrics.time_to_collision_infraction_time_s;
+        metrics.lane_keeping = trajectory_metrics.lane_keeping;
+        metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
+        metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
+        const auto ego_progress = metrics::calculate_ego_progress(
+          eval_data.synchronized_data ? eval_data.synchronized_data->trajectory : nullptr,
+          eval_data.synchronized_data ? eval_data.synchronized_data->candidate_trajectories
+                                      : nullptr,
+          route_handler_);
+        metrics.ego_progress = ego_progress.score;
+        metrics.ego_progress_available = ego_progress.available;
+        metrics.ego_progress_reason = ego_progress.reason;
+        metrics.ego_progress_raw_m = ego_progress.raw_progress_m;
+        metrics.ego_progress_best_raw_m = ego_progress.best_raw_progress_m;
+        metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
+        metrics.drivable_area_compliance_available =
+          trajectory_metrics.drivable_area_compliance_available;
+        metrics.drivable_area_compliance_reason =
+          trajectory_metrics.drivable_area_compliance_reason;
+        metrics.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
+        metrics.no_at_fault_collision_available =
+          trajectory_metrics.no_at_fault_collision_available;
+        metrics.no_at_fault_collision_reason = trajectory_metrics.no_at_fault_collision_reason;
+        metrics.time_to_at_fault_collision_s = trajectory_metrics.time_to_at_fault_collision_s;
+        metrics.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
+        metrics.driving_direction_compliance_available =
+          trajectory_metrics.driving_direction_compliance_available;
+        metrics.driving_direction_compliance_reason =
+          trajectory_metrics.driving_direction_compliance_reason;
+        metrics.max_oncoming_progress_m = trajectory_metrics.max_oncoming_progress_m;
+        metrics.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
+        metrics.traffic_light_compliance_available =
+          trajectory_metrics.traffic_light_compliance_available;
+        metrics.traffic_light_compliance_reason =
+          trajectory_metrics.traffic_light_compliance_reason;
+
+        auto human_snapshot = calculate_human_reference_snapshot(
+          eval_data, route_handler_, history_comfort_params_, lane_keeping_params_,
+          driving_direction_params_, vehicle_info_);
+
+        auto & result = parallel_results.at(i);
+        result.metrics = std::move(metrics);
+        result.trajectory_metrics = std::move(trajectory_metrics);
+        result.human_snapshot = std::move(human_snapshot);
+
+        const auto processed = phase1_processed.fetch_add(1U) + 1U;
+        if (processed % kProgressLogInterval == 0U || processed == evaluation_data_list.size()) {
+          log_parallel_progress("Parallel phase 1", processed, evaluation_data_list.size());
+        }
+      } catch (...) {
+        std::lock_guard<std::mutex> lock(worker_exception_mutex);
+        if (!worker_exception) {
+          worker_exception = std::current_exception();
+          stop_requested.store(true);
+        }
+        return;
       }
     }
-    metrics.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
-    metrics.time_to_collision_within_bound_available =
-      trajectory_metrics.time_to_collision_within_bound_available;
-    metrics.time_to_collision_within_bound_reason =
-      trajectory_metrics.time_to_collision_within_bound_reason;
-    metrics.time_to_collision_infraction_time_s =
-      trajectory_metrics.time_to_collision_infraction_time_s;
-    metrics.lane_keeping = trajectory_metrics.lane_keeping;
-    metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
-    metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
-    const auto ego_progress = metrics::calculate_ego_progress(
-      eval_data.synchronized_data ? eval_data.synchronized_data->trajectory : nullptr,
-      eval_data.synchronized_data ? eval_data.synchronized_data->candidate_trajectories : nullptr,
-      route_handler_);
-    metrics.ego_progress = ego_progress.score;
-    metrics.ego_progress_available = ego_progress.available;
-    metrics.ego_progress_reason = ego_progress.reason;
-    metrics.ego_progress_raw_m = ego_progress.raw_progress_m;
-    metrics.ego_progress_best_raw_m = ego_progress.best_raw_progress_m;
-    metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
-    metrics.drivable_area_compliance_available =
-      trajectory_metrics.drivable_area_compliance_available;
-    metrics.drivable_area_compliance_reason = trajectory_metrics.drivable_area_compliance_reason;
-    metrics.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
-    metrics.no_at_fault_collision_available = trajectory_metrics.no_at_fault_collision_available;
-    metrics.no_at_fault_collision_reason = trajectory_metrics.no_at_fault_collision_reason;
-    metrics.time_to_at_fault_collision_s = trajectory_metrics.time_to_at_fault_collision_s;
-    metrics.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
-    metrics.driving_direction_compliance_available =
-      trajectory_metrics.driving_direction_compliance_available;
-    metrics.driving_direction_compliance_reason =
-      trajectory_metrics.driving_direction_compliance_reason;
-    metrics.max_oncoming_progress_m = trajectory_metrics.max_oncoming_progress_m;
-    metrics.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
-    metrics.traffic_light_compliance_available =
-      trajectory_metrics.traffic_light_compliance_available;
-    metrics.traffic_light_compliance_reason = trajectory_metrics.traffic_light_compliance_reason;
-    const auto human_sync_data =
-      clone_with_trajectory(eval_data.synchronized_data, eval_data.ground_truth_trajectory);
-    const auto human_point_metrics = metrics::calculate_trajectory_point_metrics(
-      human_sync_data, route_handler_, history_comfort_params_, lane_keeping_params_,
-      driving_direction_params_, vehicle_info_);
+  };
 
-    metrics::EpdmsMetricSnapshot human_snapshot;
-    human_snapshot.history_comfort = human_point_metrics.history_comfort;
-    human_snapshot.history_comfort_available = true;
-    if (i == 0U) {
-      human_snapshot.extended_comfort = 0.0;
-      human_snapshot.extended_comfort_available = false;
-    } else {
-      const auto human_extended_comfort = metrics::calculate_extended_comfort(
-        evaluation_data_list.at(i - 1U).ground_truth_trajectory, eval_data.ground_truth_trajectory,
-        extended_comfort_parameters_);
-      human_snapshot.extended_comfort = human_extended_comfort.score;
-      human_snapshot.extended_comfort_available = human_extended_comfort.available;
+  std::vector<std::thread> workers;
+  workers.reserve(worker_count > 0U ? worker_count - 1U : 0U);
+  for (std::size_t worker_index = 1U; worker_index < worker_count; ++worker_index) {
+    workers.emplace_back(worker);
+  }
+  worker();
+  for (auto & thread : workers) {
+    thread.join();
+  }
+
+  if (worker_exception) {
+    std::rethrow_exception(worker_exception);
+  }
+
+  RCLCPP_INFO(
+    logger_, "Parallel phase 1 finished: processed %zu trajectory samples",
+    phase1_processed.load());
+
+  std::atomic<std::size_t> finalize_next_index{0U};
+  std::atomic<std::size_t> phase2_processed{0U};
+  stop_requested.store(false);
+  worker_exception = nullptr;
+  RCLCPP_INFO(logger_, "Parallel phase 2 started: extended comfort and synthetic EPDMS horizons");
+
+  auto finalize_worker = [&]() {
+    while (true) {
+      if (stop_requested.load()) {
+        return;
+      }
+
+      const auto i = finalize_next_index.fetch_add(1U);
+      if (i >= evaluation_data_list.size()) {
+        return;
+      }
+
+      try {
+        const auto & eval_data = evaluation_data_list.at(i);
+        auto & result = parallel_results.at(i);
+        auto & metrics = result.metrics;
+        auto human_snapshot = result.human_snapshot;
+
+        if (i == 0U) {
+          metrics.extended_comfort = 0.0;
+          metrics.extended_comfort_available = false;
+          metrics.extended_comfort_reason = "unavailable_no_previous_trajectory";
+        } else {
+          const auto & previous_eval_data = evaluation_data_list.at(i - 1U);
+          const auto & previous_trajectory = previous_eval_data.synchronized_data->trajectory;
+          const auto & current_trajectory = eval_data.synchronized_data->trajectory;
+          if (!previous_trajectory || !current_trajectory) {
+            metrics.extended_comfort = 0.0;
+            metrics.extended_comfort_available = false;
+            metrics.extended_comfort_reason = "unavailable_missing_trajectory";
+          } else {
+            const auto extended_comfort_result = metrics::calculate_extended_comfort(
+              *previous_trajectory, *current_trajectory, extended_comfort_parameters_);
+            metrics.extended_comfort = extended_comfort_result.score;
+            metrics.extended_comfort_available = extended_comfort_result.available;
+            metrics.extended_comfort_reason = extended_comfort_result.reason;
+          }
+        }
+
+        if (i == 0U) {
+          human_snapshot.extended_comfort = 0.0;
+          human_snapshot.extended_comfort_available = false;
+        } else {
+          const auto human_extended_comfort = metrics::calculate_extended_comfort(
+            evaluation_data_list.at(i - 1U).ground_truth_trajectory,
+            eval_data.ground_truth_trajectory, extended_comfort_parameters_);
+          human_snapshot.extended_comfort = human_extended_comfort.score;
+          human_snapshot.extended_comfort_available = human_extended_comfort.available;
+        }
+
+        const auto agent_snapshot = build_epdms_snapshot(metrics);
+        result.human_filter_metrics =
+          metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
+        result.synthetic_epdms =
+          metrics::calculate_synthetic_epdms(agent_snapshot, result.human_filter_metrics);
+
+        result.synthetic_epdms_by_horizon.clear();
+        for (const double horizon_s : epdms_horizons_) {
+          const auto horizon_result = calculate_horizon_synthetic_epdms(
+            eval_data, i > 0U ? &evaluation_data_list.at(i - 1U) : nullptr, horizon_s,
+            route_handler_, history_comfort_params_, lane_keeping_params_,
+            driving_direction_params_, extended_comfort_parameters_, vehicle_info_);
+          result.synthetic_epdms_by_horizon.emplace(
+            format_epdms_horizon_label(horizon_s), horizon_result.second);
+        }
+
+        const auto processed = phase2_processed.fetch_add(1U) + 1U;
+        if (processed % kProgressLogInterval == 0U || processed == evaluation_data_list.size()) {
+          log_parallel_progress("Parallel phase 2", processed, evaluation_data_list.size());
+        }
+      } catch (...) {
+        std::lock_guard<std::mutex> lock(worker_exception_mutex);
+        if (!worker_exception) {
+          worker_exception = std::current_exception();
+          stop_requested.store(true);
+        }
+        return;
+      }
     }
-    human_snapshot.ego_progress = 1.0;
-    human_snapshot.ego_progress_available = false;
-    human_snapshot.time_to_collision_within_bound =
-      human_point_metrics.time_to_collision_within_bound;
-    human_snapshot.time_to_collision_within_bound_available =
-      human_point_metrics.time_to_collision_within_bound_available;
-    human_snapshot.lane_keeping = human_point_metrics.lane_keeping;
-    human_snapshot.lane_keeping_available = human_point_metrics.lane_keeping_available;
-    human_snapshot.drivable_area_compliance = human_point_metrics.drivable_area_compliance;
-    human_snapshot.drivable_area_compliance_available =
-      human_point_metrics.drivable_area_compliance_available;
-    human_snapshot.no_at_fault_collision = human_point_metrics.no_at_fault_collision;
-    human_snapshot.no_at_fault_collision_available =
-      human_point_metrics.no_at_fault_collision_available;
-    human_snapshot.driving_direction_compliance = human_point_metrics.driving_direction_compliance;
-    human_snapshot.driving_direction_compliance_available =
-      human_point_metrics.driving_direction_compliance_available;
-    human_snapshot.traffic_light_compliance = human_point_metrics.traffic_light_compliance;
-    human_snapshot.traffic_light_compliance_available =
-      human_point_metrics.traffic_light_compliance_available;
+  };
 
-    const auto agent_snapshot = build_epdms_snapshot(metrics);
-    const auto human_filter_metrics =
-      metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
-    const auto synthetic_epdms =
-      metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics);
+  workers.clear();
+  workers.reserve(worker_count > 0U ? worker_count - 1U : 0U);
+  for (std::size_t worker_index = 1U; worker_index < worker_count; ++worker_index) {
+    workers.emplace_back(finalize_worker);
+  }
+  finalize_worker();
+  for (auto & thread : workers) {
+    thread.join();
+  }
+
+  if (worker_exception) {
+    std::rethrow_exception(worker_exception);
+  }
+
+  RCLCPP_INFO(
+    logger_, "Parallel phase 2 finished: processed %zu trajectory samples",
+    phase2_processed.load());
+  RCLCPP_INFO(logger_, "Sequential output phase started: bag writing and summary aggregation");
+
+  // Write outputs sequentially to keep output ordering and bag writes deterministic.
+  for (std::size_t i = 0; i < evaluation_data_list.size(); ++i) {
+    const auto & eval_data = evaluation_data_list.at(i);
+    const auto & result = parallel_results.at(i);
+    const auto & metrics = result.metrics;
+    const auto & trajectory_metrics = result.trajectory_metrics;
+    const auto & human_filter_metrics = result.human_filter_metrics;
+    const auto & synthetic_epdms = result.synthetic_epdms;
+    const auto & synthetic_epdms_by_horizon = result.synthetic_epdms_by_horizon;
+
     metrics_list_.push_back(metrics);
     trajectory_point_metrics_list_.push_back(trajectory_metrics);
     human_filter_metrics_list_.push_back(human_filter_metrics);
     synthetic_epdms_metrics_list_.push_back(synthetic_epdms);
+    synthetic_epdms_horizon_metrics_list_.push_back(synthetic_epdms_by_horizon);
 
-    // Save to bag if writer provided
     if (bag_writer) {
-      save_metrics_to_bag(metrics, synthetic_epdms, eval_data, *bag_writer);
+      save_metrics_to_bag(
+        metrics, synthetic_epdms, synthetic_epdms_by_horizon, eval_data, *bag_writer);
       save_trajectory_point_metrics_to_bag_with_variant(
         trajectory_metrics, *bag_writer, eval_data.synchronized_data->bag_timestamp);
     } else {
@@ -348,6 +925,9 @@ void OpenLoopEvaluator::evaluate(
 
   // Calculate summary statistics
   calculate_summary();
+  RCLCPP_INFO(
+    logger_, "Open-loop evaluation finished: processed %zu trajectory samples",
+    evaluation_data_list.size());
 }
 
 std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evaluation_data(
@@ -452,10 +1032,28 @@ OpenLoopEvaluator::generate_ground_truth_trajectory_from_topic(
     prev_time = t;
   }
 
+  if (can_directly_pair_gt_trajectory(predicted, gt_msg)) {
+    for (std::size_t i = 0; i < predicted.points.size(); ++i) {
+      const auto & pred_point = predicted.points[i];
+      const auto & gt_source_point = gt_msg.points[i];
+
+      autoware_planning_msgs::msg::TrajectoryPoint gt_point;
+      gt_point.pose = gt_source_point.pose;
+      gt_point.time_from_start = pred_point.time_from_start;
+      gt_point.longitudinal_velocity_mps = pred_point.longitudinal_velocity_mps;
+      gt_point.lateral_velocity_mps = pred_point.lateral_velocity_mps;
+      gt_point.heading_rate_rps = pred_point.heading_rate_rps;
+      gt_for_eval.points.push_back(gt_point);
+    }
+    return gt_for_eval;
+  }
+
+  const auto gt_abs_times = build_gt_absolute_time_cache(gt_msg);
   for (const auto & pred_point : predicted.points) {
     const auto abs_time =
       rclcpp::Time(predicted.header.stamp) + rclcpp::Duration(pred_point.time_from_start);
-    const auto gt_pose = interpolate_ground_truth_from_trajectory(abs_time, gt_msg);
+    const auto gt_pose = interpolate_ground_truth_from_cached_trajectory_times(
+      abs_time, gt_msg, gt_abs_times, gt_sync_tolerance_ms_);
     if (!gt_pose.has_value()) {
       return std::nullopt;
     }
@@ -469,6 +1067,33 @@ OpenLoopEvaluator::generate_ground_truth_trajectory_from_topic(
     gt_for_eval.points.push_back(gt_point);
   }
   return gt_for_eval;
+}
+
+bool OpenLoopEvaluator::can_directly_pair_gt_trajectory(
+  const autoware_planning_msgs::msg::Trajectory & predicted,
+  const autoware_planning_msgs::msg::Trajectory & gt_trajectory) const
+{
+  constexpr int64_t kDirectPairTimeToleranceNs = 1'000;  // 1 us
+
+  if (predicted.points.size() != gt_trajectory.points.size()) {
+    return false;
+  }
+
+  if (
+    rclcpp::Time(predicted.header.stamp).nanoseconds() !=
+    rclcpp::Time(gt_trajectory.header.stamp).nanoseconds()) {
+    return false;
+  }
+
+  for (std::size_t i = 0; i < predicted.points.size(); ++i) {
+    const auto predicted_time = rclcpp::Duration(predicted.points[i].time_from_start).nanoseconds();
+    const auto gt_time = rclcpp::Duration(gt_trajectory.points[i].time_from_start).nanoseconds();
+    if (std::abs(predicted_time - gt_time) > kDirectPairTimeToleranceNs) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 std::optional<autoware_planning_msgs::msg::Trajectory>
@@ -630,8 +1255,8 @@ OpenLoopTrajectoryMetrics OpenLoopEvaluator::evaluate_trajectory(const Evaluatio
 
     const auto [longitudinal_error, lateral_error] =
       calculate_errors_in_vehicle_frame(traj_point.pose, gt_pose);
-    const double pred_yaw = get_yaw_from_msg(traj_point.pose.orientation);
-    const double gt_yaw = get_yaw_from_msg(gt_pose.orientation);
+    const double pred_yaw = tf2::getYaw(traj_point.pose.orientation);
+    const double gt_yaw = tf2::getYaw(gt_pose.orientation);
     const double heading_error = std::abs(autoware_utils_math::normalize_radian(pred_yaw - gt_yaw));
 
     metrics.longitudinal_deviations[i] = longitudinal_error;
@@ -742,7 +1367,7 @@ std::pair<double, double> OpenLoopEvaluator::calculate_errors_in_vehicle_frame(
   const geometry_msgs::msg::Pose & ground_truth_pose)
 {
   // Get ground truth yaw angle
-  const double gt_yaw = get_yaw_from_msg(ground_truth_pose.orientation);
+  const double gt_yaw = tf2::getYaw(ground_truth_pose.orientation);
 
   // Calculate position difference in global frame
   const double dx_global = trajectory_pose.position.x - ground_truth_pose.position.x;
@@ -812,8 +1437,8 @@ std::optional<geometry_msgs::msg::Pose> OpenLoopEvaluator::interpolate_ground_tr
   interpolated_pose.position.z = p1.z + ratio * (p2.z - p1.z);
 
   // For orientation, use slerp (simplified to linear interpolation of yaw for 2D case)
-  const double yaw1 = get_yaw_from_msg(lower_data->kinematic_state->pose.pose.orientation);
-  const double yaw2 = get_yaw_from_msg(upper_data->kinematic_state->pose.pose.orientation);
+  const double yaw1 = tf2::getYaw(lower_data->kinematic_state->pose.pose.orientation);
+  const double yaw2 = tf2::getYaw(upper_data->kinematic_state->pose.pose.orientation);
 
   // Handle angle wrapping
   double yaw_diff = yaw2 - yaw1;
@@ -898,8 +1523,8 @@ std::optional<geometry_msgs::msg::Pose> OpenLoopEvaluator::interpolate_ground_tr
   pose.position.y = p1.position.y + ratio * (p2.position.y - p1.position.y);
   pose.position.z = p1.position.z + ratio * (p2.position.z - p1.position.z);
 
-  const double yaw1 = get_yaw_from_msg(p1.orientation);
-  const double yaw2 = get_yaw_from_msg(p2.orientation);
+  const double yaw1 = tf2::getYaw(p1.orientation);
+  const double yaw2 = tf2::getYaw(p2.orientation);
   double yaw_diff = yaw2 - yaw1;
   while (yaw_diff > M_PI) yaw_diff -= 2 * M_PI;
   while (yaw_diff < -M_PI) yaw_diff += 2 * M_PI;
@@ -912,6 +1537,7 @@ std::optional<geometry_msgs::msg::Pose> OpenLoopEvaluator::interpolate_ground_tr
 
 void OpenLoopEvaluator::save_metrics_to_bag(
   const OpenLoopTrajectoryMetrics & metrics, const metrics::SyntheticEpdmsMetrics & synthetic_epdms,
+  const std::map<std::string, metrics::SyntheticEpdmsMetrics> & synthetic_epdms_by_horizon,
   const EvaluationData & eval_data, rosbag2_cpp::Writer & bag_writer)
 {
   const auto & ground_truth_trajectory = eval_data.ground_truth_trajectory;
@@ -972,10 +1598,18 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   bag_writer.write(scalar_msg, metric_topic("max_oncoming_progress_m"), message_timestamp);
   scalar_msg.data = metrics.traffic_light_compliance;
   bag_writer.write(scalar_msg, metric_topic("traffic_light_compliance"), message_timestamp);
-  scalar_msg.data = synthetic_epdms.raw.epdms;
+  scalar_msg.data = synthetic_epdms.raw_epdms;
   bag_writer.write(scalar_msg, metric_topic("synthetic_epdms_raw"), message_timestamp);
-  scalar_msg.data = synthetic_epdms.human_filtered.epdms;
+  scalar_msg.data = synthetic_epdms.human_filtered_epdms;
   bag_writer.write(scalar_msg, metric_topic("synthetic_epdms_human_filtered"), message_timestamp);
+  for (const auto & [label, horizon_metrics] : synthetic_epdms_by_horizon) {
+    scalar_msg.data = horizon_metrics.raw_epdms;
+    bag_writer.write(
+      scalar_msg, metric_topic("synthetic_epdms_" + label + "_raw"), message_timestamp);
+    scalar_msg.data = horizon_metrics.human_filtered_epdms;
+    bag_writer.write(
+      scalar_msg, metric_topic("synthetic_epdms_" + label + "_human_filtered"), message_timestamp);
+  }
   std_msgs::msg::Bool availability_msg;
   availability_msg.data = metrics.extended_comfort_available;
   bag_writer.write(availability_msg, metric_topic("extended_comfort_available"), message_timestamp);
@@ -998,12 +1632,22 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   availability_msg.data = metrics.traffic_light_compliance_available;
   bag_writer.write(
     availability_msg, metric_topic("traffic_light_compliance_available"), message_timestamp);
-  availability_msg.data = synthetic_epdms.raw.available;
+  availability_msg.data = synthetic_epdms.raw_available;
   bag_writer.write(
     availability_msg, metric_topic("synthetic_epdms_raw_available"), message_timestamp);
-  availability_msg.data = synthetic_epdms.human_filtered.available;
+  availability_msg.data = synthetic_epdms.human_filtered_available;
   bag_writer.write(
     availability_msg, metric_topic("synthetic_epdms_human_filtered_available"), message_timestamp);
+  for (const auto & [label, horizon_metrics] : synthetic_epdms_by_horizon) {
+    availability_msg.data = horizon_metrics.raw_available;
+    bag_writer.write(
+      availability_msg, metric_topic("synthetic_epdms_" + label + "_raw_available"),
+      message_timestamp);
+    availability_msg.data = horizon_metrics.human_filtered_available;
+    bag_writer.write(
+      availability_msg, metric_topic("synthetic_epdms_" + label + "_human_filtered_available"),
+      message_timestamp);
+  }
   std_msgs::msg::String reason_msg;
   reason_msg.data = metrics.extended_comfort_reason;
   bag_writer.write(reason_msg, metric_topic("extended_comfort_reason"), message_timestamp);
@@ -1478,55 +2122,55 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
   std::vector<double> filtered_tlc_values;
   std::size_t tlc_filter_applied_count = 0;
   for (const auto & m : human_filter_metrics_list_) {
-    if (m.history_comfort.human_reference_available) {
-      human_history_comfort_values.push_back(m.history_comfort.human_reference);
-      filtered_history_comfort_values.push_back(m.history_comfort.filtered);
+    if (m.human_history_comfort_available) {
+      human_history_comfort_values.push_back(m.human_history_comfort);
+      filtered_history_comfort_values.push_back(m.filtered_history_comfort);
     }
     history_comfort_filter_applied_count +=
-      static_cast<std::size_t>(m.history_comfort.filter_applied);
-    if (m.extended_comfort.human_reference_available) {
-      human_extended_comfort_values.push_back(m.extended_comfort.human_reference);
-      filtered_extended_comfort_values.push_back(m.extended_comfort.filtered);
+      static_cast<std::size_t>(m.history_comfort_filter_applied);
+    if (m.human_extended_comfort_available) {
+      human_extended_comfort_values.push_back(m.human_extended_comfort);
+      filtered_extended_comfort_values.push_back(m.filtered_extended_comfort);
     }
     extended_comfort_filter_applied_count +=
-      static_cast<std::size_t>(m.extended_comfort.filter_applied);
-    if (m.ego_progress.human_reference_available) {
-      human_ego_progress_values.push_back(m.ego_progress.human_reference);
-      filtered_ego_progress_values.push_back(m.ego_progress.filtered);
+      static_cast<std::size_t>(m.extended_comfort_filter_applied);
+    if (m.human_ego_progress_available) {
+      human_ego_progress_values.push_back(m.human_ego_progress);
+      filtered_ego_progress_values.push_back(m.filtered_ego_progress);
     }
-    ego_progress_filter_applied_count += static_cast<std::size_t>(m.ego_progress.filter_applied);
-    if (m.time_to_collision_within_bound.human_reference_available) {
-      human_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.human_reference);
-      filtered_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.filtered);
+    ego_progress_filter_applied_count += static_cast<std::size_t>(m.ego_progress_filter_applied);
+    if (m.human_time_to_collision_within_bound_available) {
+      human_ttc_within_bound_values.push_back(m.human_time_to_collision_within_bound);
+      filtered_ttc_within_bound_values.push_back(m.filtered_time_to_collision_within_bound);
     }
     ttc_within_bound_filter_applied_count +=
-      static_cast<std::size_t>(m.time_to_collision_within_bound.filter_applied);
-    if (m.lane_keeping.human_reference_available) {
-      human_lane_keeping_values.push_back(m.lane_keeping.human_reference);
-      filtered_lane_keeping_values.push_back(m.lane_keeping.filtered);
+      static_cast<std::size_t>(m.time_to_collision_within_bound_filter_applied);
+    if (m.human_lane_keeping_available) {
+      human_lane_keeping_values.push_back(m.human_lane_keeping);
+      filtered_lane_keeping_values.push_back(m.filtered_lane_keeping);
     }
-    lane_keeping_filter_applied_count += static_cast<std::size_t>(m.lane_keeping.filter_applied);
-    if (m.drivable_area_compliance.human_reference_available) {
-      human_dac_values.push_back(m.drivable_area_compliance.human_reference);
-      filtered_dac_values.push_back(m.drivable_area_compliance.filtered);
+    lane_keeping_filter_applied_count += static_cast<std::size_t>(m.lane_keeping_filter_applied);
+    if (m.human_drivable_area_compliance_available) {
+      human_dac_values.push_back(m.human_drivable_area_compliance);
+      filtered_dac_values.push_back(m.filtered_drivable_area_compliance);
     }
-    dac_filter_applied_count += static_cast<std::size_t>(m.drivable_area_compliance.filter_applied);
-    if (m.no_at_fault_collision.human_reference_available) {
-      human_nc_values.push_back(m.no_at_fault_collision.human_reference);
-      filtered_nc_values.push_back(m.no_at_fault_collision.filtered);
+    dac_filter_applied_count += static_cast<std::size_t>(m.drivable_area_compliance_filter_applied);
+    if (m.human_no_at_fault_collision_available) {
+      human_nc_values.push_back(m.human_no_at_fault_collision);
+      filtered_nc_values.push_back(m.filtered_no_at_fault_collision);
     }
-    nc_filter_applied_count += static_cast<std::size_t>(m.no_at_fault_collision.filter_applied);
-    if (m.driving_direction_compliance.human_reference_available) {
-      human_ddc_values.push_back(m.driving_direction_compliance.human_reference);
-      filtered_ddc_values.push_back(m.driving_direction_compliance.filtered);
+    nc_filter_applied_count += static_cast<std::size_t>(m.no_at_fault_collision_filter_applied);
+    if (m.human_driving_direction_compliance_available) {
+      human_ddc_values.push_back(m.human_driving_direction_compliance);
+      filtered_ddc_values.push_back(m.filtered_driving_direction_compliance);
     }
     ddc_filter_applied_count +=
-      static_cast<std::size_t>(m.driving_direction_compliance.filter_applied);
-    if (m.traffic_light_compliance.human_reference_available) {
-      human_tlc_values.push_back(m.traffic_light_compliance.human_reference);
-      filtered_tlc_values.push_back(m.traffic_light_compliance.filtered);
+      static_cast<std::size_t>(m.driving_direction_compliance_filter_applied);
+    if (m.human_traffic_light_compliance_available) {
+      human_tlc_values.push_back(m.human_traffic_light_compliance);
+      filtered_tlc_values.push_back(m.filtered_traffic_light_compliance);
     }
-    tlc_filter_applied_count += static_cast<std::size_t>(m.traffic_light_compliance.filter_applied);
+    tlc_filter_applied_count += static_cast<std::size_t>(m.traffic_light_compliance_filter_applied);
   }
   emit_human_filter_metric(
     "history_comfort", "history comfort subscore", human_history_comfort_values,
@@ -1565,16 +2209,16 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
   std::vector<double> synthetic_filtered_epdms_values;
   std::size_t synthetic_filtered_available_count = 0;
   for (const auto & m : synthetic_epdms_metrics_list_) {
-    if (m.raw.available) {
-      synthetic_raw_prod_values.push_back(m.raw.multiplicative_metrics_prod);
-      synthetic_raw_weighted_values.push_back(m.raw.weighted_metrics);
-      synthetic_raw_epdms_values.push_back(m.raw.epdms);
+    if (m.raw_available) {
+      synthetic_raw_prod_values.push_back(m.raw_multiplicative_metrics_prod);
+      synthetic_raw_weighted_values.push_back(m.raw_weighted_metrics);
+      synthetic_raw_epdms_values.push_back(m.raw_epdms);
       ++synthetic_raw_available_count;
     }
-    if (m.human_filtered.available) {
-      synthetic_filtered_prod_values.push_back(m.human_filtered.multiplicative_metrics_prod);
-      synthetic_filtered_weighted_values.push_back(m.human_filtered.weighted_metrics);
-      synthetic_filtered_epdms_values.push_back(m.human_filtered.epdms);
+    if (m.human_filtered_available) {
+      synthetic_filtered_prod_values.push_back(m.human_filtered_multiplicative_metrics_prod);
+      synthetic_filtered_weighted_values.push_back(m.human_filtered_weighted_metrics);
+      synthetic_filtered_epdms_values.push_back(m.human_filtered_epdms);
       ++synthetic_filtered_available_count;
     }
   }
@@ -1606,6 +2250,48 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
     synthetic_filtered_available_count;
   j["aggregate/synthetic_epdms/human_filtered_unavailable_count"] =
     synthetic_epdms_metrics_list_.size() - synthetic_filtered_available_count;
+
+  std::set<std::string> horizon_labels;
+  for (const auto & per_traj_horizon_metrics : synthetic_epdms_horizon_metrics_list_) {
+    for (const auto & [label, _] : per_traj_horizon_metrics) {
+      horizon_labels.insert(label);
+    }
+  }
+  for (const auto & label : horizon_labels) {
+    std::vector<double> raw_values;
+    std::vector<double> filtered_values;
+    std::size_t raw_available_count = 0;
+    std::size_t filtered_available_count = 0;
+    for (const auto & per_traj_horizon_metrics : synthetic_epdms_horizon_metrics_list_) {
+      const auto it = per_traj_horizon_metrics.find(label);
+      if (it == per_traj_horizon_metrics.end()) {
+        continue;
+      }
+      const auto & horizon_metrics = it->second;
+      if (horizon_metrics.raw_available) {
+        raw_values.push_back(horizon_metrics.raw_epdms);
+        ++raw_available_count;
+      }
+      if (horizon_metrics.human_filtered_available) {
+        filtered_values.push_back(horizon_metrics.human_filtered_epdms);
+        ++filtered_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate/synthetic_epdms_horizons/" + label, "raw",
+      "Synthetic EPDMS score across trajectories for " + label + " horizon [-]", raw_values);
+    emit_metric(
+      "aggregate/synthetic_epdms_horizons/" + label, "human_filtered",
+      "Human-filtered synthetic EPDMS score across trajectories for " + label + " horizon [-]",
+      filtered_values);
+    j["aggregate/synthetic_epdms_horizons/" + label + "/raw_available_count"] = raw_available_count;
+    j["aggregate/synthetic_epdms_horizons/" + label + "/raw_unavailable_count"] =
+      synthetic_epdms_horizon_metrics_list_.size() - raw_available_count;
+    j["aggregate/synthetic_epdms_horizons/" + label + "/human_filtered_available_count"] =
+      filtered_available_count;
+    j["aggregate/synthetic_epdms_horizons/" + label + "/human_filtered_unavailable_count"] =
+      synthetic_epdms_horizon_metrics_list_.size() - filtered_available_count;
+  }
 
   return j;
 }
@@ -1685,76 +2371,88 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
     traj["traffic_light_compliance_reason"] = m.traffic_light_compliance_reason;
     if (i < human_filter_metrics_list_.size()) {
       const auto & hf = human_filter_metrics_list_[i];
-      traj["human_reference"]["history_comfort"] = hf.history_comfort.human_reference;
-      traj["human_reference"]["history_comfort_available"] =
-        hf.history_comfort.human_reference_available;
-      traj["human_reference"]["extended_comfort"] = hf.extended_comfort.human_reference;
-      traj["human_reference"]["extended_comfort_available"] =
-        hf.extended_comfort.human_reference_available;
-      traj["human_reference"]["ego_progress"] = hf.ego_progress.human_reference;
-      traj["human_reference"]["ego_progress_available"] = hf.ego_progress.human_reference_available;
+      traj["human_reference"]["history_comfort"] = hf.human_history_comfort;
+      traj["human_reference"]["history_comfort_available"] = hf.human_history_comfort_available;
+      traj["human_reference"]["extended_comfort"] = hf.human_extended_comfort;
+      traj["human_reference"]["extended_comfort_available"] = hf.human_extended_comfort_available;
+      traj["human_reference"]["ego_progress"] = hf.human_ego_progress;
+      traj["human_reference"]["ego_progress_available"] = hf.human_ego_progress_available;
       traj["human_reference"]["time_to_collision_within_bound"] =
-        hf.time_to_collision_within_bound.human_reference;
+        hf.human_time_to_collision_within_bound;
       traj["human_reference"]["time_to_collision_within_bound_available"] =
-        hf.time_to_collision_within_bound.human_reference_available;
-      traj["human_reference"]["lane_keeping"] = hf.lane_keeping.human_reference;
-      traj["human_reference"]["lane_keeping_available"] = hf.lane_keeping.human_reference_available;
-      traj["human_reference"]["drivable_area_compliance"] =
-        hf.drivable_area_compliance.human_reference;
+        hf.human_time_to_collision_within_bound_available;
+      traj["human_reference"]["lane_keeping"] = hf.human_lane_keeping;
+      traj["human_reference"]["lane_keeping_available"] = hf.human_lane_keeping_available;
+      traj["human_reference"]["drivable_area_compliance"] = hf.human_drivable_area_compliance;
       traj["human_reference"]["drivable_area_compliance_available"] =
-        hf.drivable_area_compliance.human_reference_available;
-      traj["human_reference"]["no_at_fault_collision"] = hf.no_at_fault_collision.human_reference;
+        hf.human_drivable_area_compliance_available;
+      traj["human_reference"]["no_at_fault_collision"] = hf.human_no_at_fault_collision;
       traj["human_reference"]["no_at_fault_collision_available"] =
-        hf.no_at_fault_collision.human_reference_available;
+        hf.human_no_at_fault_collision_available;
       traj["human_reference"]["driving_direction_compliance"] =
-        hf.driving_direction_compliance.human_reference;
+        hf.human_driving_direction_compliance;
       traj["human_reference"]["driving_direction_compliance_available"] =
-        hf.driving_direction_compliance.human_reference_available;
-      traj["human_reference"]["traffic_light_compliance"] =
-        hf.traffic_light_compliance.human_reference;
+        hf.human_driving_direction_compliance_available;
+      traj["human_reference"]["traffic_light_compliance"] = hf.human_traffic_light_compliance;
       traj["human_reference"]["traffic_light_compliance_available"] =
-        hf.traffic_light_compliance.human_reference_available;
+        hf.human_traffic_light_compliance_available;
 
-      traj["human_filtered"]["history_comfort"] = hf.history_comfort.filtered;
-      traj["human_filtered"]["history_comfort_filter_applied"] = hf.history_comfort.filter_applied;
-      traj["human_filtered"]["extended_comfort"] = hf.extended_comfort.filtered;
+      traj["human_filtered"]["history_comfort"] = hf.filtered_history_comfort;
+      traj["human_filtered"]["history_comfort_filter_applied"] = hf.history_comfort_filter_applied;
+      traj["human_filtered"]["extended_comfort"] = hf.filtered_extended_comfort;
       traj["human_filtered"]["extended_comfort_filter_applied"] =
-        hf.extended_comfort.filter_applied;
-      traj["human_filtered"]["ego_progress"] = hf.ego_progress.filtered;
-      traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress.filter_applied;
+        hf.extended_comfort_filter_applied;
+      traj["human_filtered"]["ego_progress"] = hf.filtered_ego_progress;
+      traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress_filter_applied;
       traj["human_filtered"]["time_to_collision_within_bound"] =
-        hf.time_to_collision_within_bound.filtered;
+        hf.filtered_time_to_collision_within_bound;
       traj["human_filtered"]["time_to_collision_within_bound_filter_applied"] =
-        hf.time_to_collision_within_bound.filter_applied;
-      traj["human_filtered"]["lane_keeping"] = hf.lane_keeping.filtered;
-      traj["human_filtered"]["lane_keeping_filter_applied"] = hf.lane_keeping.filter_applied;
-      traj["human_filtered"]["drivable_area_compliance"] = hf.drivable_area_compliance.filtered;
+        hf.time_to_collision_within_bound_filter_applied;
+      traj["human_filtered"]["lane_keeping"] = hf.filtered_lane_keeping;
+      traj["human_filtered"]["lane_keeping_filter_applied"] = hf.lane_keeping_filter_applied;
+      traj["human_filtered"]["drivable_area_compliance"] = hf.filtered_drivable_area_compliance;
       traj["human_filtered"]["drivable_area_compliance_filter_applied"] =
-        hf.drivable_area_compliance.filter_applied;
-      traj["human_filtered"]["no_at_fault_collision"] = hf.no_at_fault_collision.filtered;
+        hf.drivable_area_compliance_filter_applied;
+      traj["human_filtered"]["no_at_fault_collision"] = hf.filtered_no_at_fault_collision;
       traj["human_filtered"]["no_at_fault_collision_filter_applied"] =
-        hf.no_at_fault_collision.filter_applied;
+        hf.no_at_fault_collision_filter_applied;
       traj["human_filtered"]["driving_direction_compliance"] =
-        hf.driving_direction_compliance.filtered;
+        hf.filtered_driving_direction_compliance;
       traj["human_filtered"]["driving_direction_compliance_filter_applied"] =
-        hf.driving_direction_compliance.filter_applied;
-      traj["human_filtered"]["traffic_light_compliance"] = hf.traffic_light_compliance.filtered;
+        hf.driving_direction_compliance_filter_applied;
+      traj["human_filtered"]["traffic_light_compliance"] = hf.filtered_traffic_light_compliance;
       traj["human_filtered"]["traffic_light_compliance_filter_applied"] =
-        hf.traffic_light_compliance.filter_applied;
+        hf.traffic_light_compliance_filter_applied;
     }
     if (i < synthetic_epdms_metrics_list_.size()) {
       const auto & s = synthetic_epdms_metrics_list_[i];
-      traj["synthetic_epdms"]["raw_available"] = s.raw.available;
+      traj["synthetic_epdms"]["raw_available"] = s.raw_available;
       traj["synthetic_epdms"]["raw_multiplicative_metrics_prod"] =
-        s.raw.multiplicative_metrics_prod;
-      traj["synthetic_epdms"]["raw_weighted_metrics"] = s.raw.weighted_metrics;
-      traj["synthetic_epdms"]["raw"] = s.raw.epdms;
-      traj["synthetic_epdms"]["human_filtered_available"] = s.human_filtered.available;
+        s.raw_multiplicative_metrics_prod;
+      traj["synthetic_epdms"]["raw_weighted_metrics"] = s.raw_weighted_metrics;
+      traj["synthetic_epdms"]["raw"] = s.raw_epdms;
+      traj["synthetic_epdms"]["human_filtered_available"] = s.human_filtered_available;
       traj["synthetic_epdms"]["human_filtered_multiplicative_metrics_prod"] =
-        s.human_filtered.multiplicative_metrics_prod;
+        s.human_filtered_multiplicative_metrics_prod;
       traj["synthetic_epdms"]["human_filtered_weighted_metrics"] =
-        s.human_filtered.weighted_metrics;
-      traj["synthetic_epdms"]["human_filtered"] = s.human_filtered.epdms;
+        s.human_filtered_weighted_metrics;
+      traj["synthetic_epdms"]["human_filtered"] = s.human_filtered_epdms;
+    }
+    if (i < synthetic_epdms_horizon_metrics_list_.size()) {
+      for (const auto & [label, s] : synthetic_epdms_horizon_metrics_list_[i]) {
+        traj["synthetic_epdms_horizons"][label]["raw_available"] = s.raw_available;
+        traj["synthetic_epdms_horizons"][label]["raw_multiplicative_metrics_prod"] =
+          s.raw_multiplicative_metrics_prod;
+        traj["synthetic_epdms_horizons"][label]["raw_weighted_metrics"] = s.raw_weighted_metrics;
+        traj["synthetic_epdms_horizons"][label]["raw"] = s.raw_epdms;
+        traj["synthetic_epdms_horizons"][label]["human_filtered_available"] =
+          s.human_filtered_available;
+        traj["synthetic_epdms_horizons"][label]["human_filtered_multiplicative_metrics_prod"] =
+          s.human_filtered_multiplicative_metrics_prod;
+        traj["synthetic_epdms_horizons"][label]["human_filtered_weighted_metrics"] =
+          s.human_filtered_weighted_metrics;
+        traj["synthetic_epdms_horizons"][label]["human_filtered"] = s.human_filtered_epdms;
+      }
     }
 
     traj["horizon_results"] = nlohmann::json::object();
@@ -1843,7 +2541,7 @@ void OpenLoopEvaluator::save_dlr_style_result_to_bag(
 
 std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_topics() const
 {
-  return {
+  std::vector<std::pair<std::string, std::string>> topics{
     {dlr_result_topic(), "std_msgs/msg/String"},
     {metric_topic("ade"), "std_msgs/msg/Float64MultiArray"},
     {metric_topic("fde"), "std_msgs/msg/Float64MultiArray"},
@@ -1898,6 +2596,17 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     {"/perception/object_recognition/objects", "autoware_perception_msgs/msg/PredictedObjects"},
     {"/tf", "tf2_msgs/msg/TFMessage"},
     {"/tf_static", "tf2_msgs/msg/TFMessage"}};
+  for (const double horizon_s : epdms_horizons_) {
+    const auto label = format_epdms_horizon_label(horizon_s);
+    topics.emplace_back(metric_topic("synthetic_epdms_" + label + "_raw"), "std_msgs/msg/Float64");
+    topics.emplace_back(
+      metric_topic("synthetic_epdms_" + label + "_raw_available"), "std_msgs/msg/Bool");
+    topics.emplace_back(
+      metric_topic("synthetic_epdms_" + label + "_human_filtered"), "std_msgs/msg/Float64");
+    topics.emplace_back(
+      metric_topic("synthetic_epdms_" + label + "_human_filtered_available"), "std_msgs/msg/Bool");
+  }
+  return topics;
 }
 
 std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag(

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -43,8 +43,6 @@
 namespace autoware::planning_data_analyzer
 {
 
-using autoware::route_handler::RouteHandler;
-
 struct HorizonMetrics
 {
   double ade;
@@ -145,7 +143,8 @@ class OpenLoopEvaluator : public BaseEvaluator
 public:
   enum class GTSourceMode { KINEMATIC_STATE, GT_TRAJECTORY };
   explicit OpenLoopEvaluator(
-    rclcpp::Logger logger, std::shared_ptr<RouteHandler> route_handler = nullptr,
+    rclcpp::Logger logger,
+    std::shared_ptr<autoware::route_handler::RouteHandler> route_handler = nullptr,
     GTSourceMode gt_source_mode = GTSourceMode::KINEMATIC_STATE,
     double gt_sync_tolerance_ms = 200.0,
     metrics::HistoryComfortParameters history_comfort_params = {},
@@ -185,6 +184,8 @@ public:
   {
     evaluation_horizons_ = horizons;
   }
+
+  void set_epdms_horizons(const std::vector<double> & horizons) { epdms_horizons_ = horizons; }
 
   void set_extended_comfort_parameters(const metrics::ExtendedComfortParameters & parameters)
   {
@@ -253,6 +254,10 @@ public:
   generate_ground_truth_trajectory_from_topic(
     const std::shared_ptr<SynchronizedData> & trajectory_data) const;
 
+  bool can_directly_pair_gt_trajectory(
+    const autoware_planning_msgs::msg::Trajectory & predicted,
+    const autoware_planning_msgs::msg::Trajectory & gt_trajectory) const;
+
   /**
    * @brief Evaluate one trajectory against its ground-truth trajectory.
    *
@@ -315,8 +320,9 @@ private:
    */
   void save_metrics_to_bag(
     const OpenLoopTrajectoryMetrics & metrics,
-    const metrics::SyntheticEpdmsMetrics & synthetic_epdms, const EvaluationData & eval_data,
-    rosbag2_cpp::Writer & bag_writer);
+    const metrics::SyntheticEpdmsMetrics & synthetic_epdms,
+    const std::map<std::string, metrics::SyntheticEpdmsMetrics> & synthetic_epdms_by_horizon,
+    const EvaluationData & eval_data, rosbag2_cpp::Writer & bag_writer);
 
   /**
    * @brief Write ADE/FDE results in the driving_log_replayer result format.
@@ -350,6 +356,8 @@ private:
   std::vector<metrics::TrajectoryPointMetrics> trajectory_point_metrics_list_;
   std::vector<metrics::HumanFilterMetrics> human_filter_metrics_list_;
   std::vector<metrics::SyntheticEpdmsMetrics> synthetic_epdms_metrics_list_;
+  std::vector<std::map<std::string, metrics::SyntheticEpdmsMetrics>>
+    synthetic_epdms_horizon_metrics_list_;
   metrics::HistoryComfortParameters history_comfort_params_;
   metrics::ExtendedComfortParameters extended_comfort_parameters_{};
   metrics::LaneKeepingParameters lane_keeping_params_;
@@ -360,6 +368,7 @@ private:
   GTSourceMode gt_source_mode_;
   double gt_sync_tolerance_ms_;
   std::vector<double> evaluation_horizons_;
+  std::vector<double> epdms_horizons_;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/src/or_scene_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/or_scene_evaluator.cpp
@@ -36,8 +36,6 @@
 namespace autoware::planning_data_analyzer
 {
 
-using autoware::route_handler::RouteHandler;
-
 // Helper for statistics calculation
 template <typename Container>
 struct Statistics
@@ -75,9 +73,9 @@ Statistics<Container> calculate_statistics(const Container & values)
 }
 
 ORSceneEvaluator::ORSceneEvaluator(
-  rclcpp::Logger logger, std::shared_ptr<RouteHandler> route_handler, double time_window_sec,
-  const ORSuccessCriteria & success_criteria, bool enable_debug_visualization,
-  const std::string & debug_output_dir)
+  rclcpp::Logger logger, std::shared_ptr<autoware::route_handler::RouteHandler> route_handler,
+  double time_window_sec, const ORSuccessCriteria & success_criteria,
+  bool enable_debug_visualization, const std::string & debug_output_dir)
 : BaseEvaluator(logger, route_handler),
   time_window_sec_(time_window_sec),
   success_criteria_(success_criteria),

--- a/planning/autoware_planning_data_analyzer/src/or_scene_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/or_scene_evaluator.hpp
@@ -34,8 +34,6 @@
 namespace autoware::planning_data_analyzer
 {
 
-using autoware::route_handler::RouteHandler;
-
 /**
  * @brief Evaluates trajectory predictions in Override (OR) scenarios
  *
@@ -70,7 +68,7 @@ public:
    * @param debug_output_dir Directory for debug images (default: "~/or_scene_debug_images")
    */
   ORSceneEvaluator(
-    rclcpp::Logger logger, std::shared_ptr<RouteHandler> route_handler,
+    rclcpp::Logger logger, std::shared_ptr<autoware::route_handler::RouteHandler> route_handler,
     double time_window_sec = 0.5, const ORSuccessCriteria & success_criteria = ORSuccessCriteria(),
     bool enable_debug_visualization = false,
     const std::string & debug_output_dir = "~/or_scene_debug_images");

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
@@ -30,8 +30,8 @@ TEST(EpdmsAggregationTest, HumanFilterPromotesAgentMetricToOneWhenHumanIsZero)
   human.history_comfort_available = true;
 
   const auto result = calculate_human_filter_metrics(agent, human);
-  EXPECT_TRUE(result.history_comfort.filter_applied);
-  EXPECT_DOUBLE_EQ(result.history_comfort.filtered, 1.0);
+  EXPECT_TRUE(result.history_comfort_filter_applied);
+  EXPECT_DOUBLE_EQ(result.filtered_history_comfort, 1.0);
 }
 
 TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
@@ -57,24 +57,24 @@ TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
   agent.traffic_light_compliance_available = true;
 
   HumanFilterMetrics filter;
-  filter.extended_comfort.filtered = 1.0;
-  filter.history_comfort.filtered = 1.0;
-  filter.time_to_collision_within_bound.filtered = 1.0;
-  filter.lane_keeping.filtered = 1.0;
-  filter.no_at_fault_collision.filtered = 1.0;
-  filter.drivable_area_compliance.filtered = 1.0;
-  filter.driving_direction_compliance.filtered = 1.0;
-  filter.traffic_light_compliance.filtered = 1.0;
+  filter.filtered_extended_comfort = 1.0;
+  filter.filtered_history_comfort = 1.0;
+  filter.filtered_time_to_collision_within_bound = 1.0;
+  filter.filtered_lane_keeping = 1.0;
+  filter.filtered_no_at_fault_collision = 1.0;
+  filter.filtered_drivable_area_compliance = 1.0;
+  filter.filtered_driving_direction_compliance = 1.0;
+  filter.filtered_traffic_light_compliance = 1.0;
 
   const auto result = calculate_synthetic_epdms(agent, filter);
-  EXPECT_TRUE(result.raw.available);
-  EXPECT_DOUBLE_EQ(result.raw.multiplicative_metrics_prod, 0.5);
-  EXPECT_DOUBLE_EQ(result.raw.weighted_metrics, 0.703125);
-  EXPECT_DOUBLE_EQ(result.raw.epdms, 0.3515625);
-  EXPECT_TRUE(result.human_filtered.available);
-  EXPECT_DOUBLE_EQ(result.human_filtered.multiplicative_metrics_prod, 1.0);
-  EXPECT_DOUBLE_EQ(result.human_filtered.weighted_metrics, 1.0);
-  EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 1.0);
+  EXPECT_TRUE(result.raw_available);
+  EXPECT_DOUBLE_EQ(result.raw_multiplicative_metrics_prod, 0.5);
+  EXPECT_DOUBLE_EQ(result.raw_weighted_metrics, 0.703125);
+  EXPECT_DOUBLE_EQ(result.raw_epdms, 0.3515625);
+  EXPECT_TRUE(result.human_filtered_available);
+  EXPECT_DOUBLE_EQ(result.human_filtered_multiplicative_metrics_prod, 1.0);
+  EXPECT_DOUBLE_EQ(result.human_filtered_weighted_metrics, 1.0);
+  EXPECT_DOUBLE_EQ(result.human_filtered_epdms, 1.0);
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -98,6 +98,25 @@ TEST_F(OpenLoopGTSourceModeTest, GTTrajectoryModeSucceedsWithValidGTTopic)
   EXPECT_GT(metrics.front().displacement_errors.front(), 0.0);
 }
 
+TEST_F(OpenLoopGTSourceModeTest, GTTrajectoryFastPathAllowsSmallGridDrift)
+{
+  const rclcpp::Time start_time(12, 0);
+  const auto prediction = make_trajectory(start_time, {0.0, 1.0, 2.0, 3.0});
+  auto gt_exact = make_trajectory(start_time, {0.1, 1.1, 2.1, 3.1});
+  auto gt_within_tolerance = gt_exact;
+  gt_within_tolerance.points.back().time_from_start.nanosec += 500;
+  auto gt_outside_tolerance = gt_exact;
+  gt_outside_tolerance.points.back().time_from_start.nanosec += 2'000;
+
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+
+  EXPECT_TRUE(evaluator.can_directly_pair_gt_trajectory(prediction, gt_exact));
+  EXPECT_TRUE(evaluator.can_directly_pair_gt_trajectory(prediction, gt_within_tolerance));
+  EXPECT_FALSE(evaluator.can_directly_pair_gt_trajectory(prediction, gt_outside_tolerance));
+}
+
 TEST_F(OpenLoopGTSourceModeTest, GTTrajectoryModeSkipsWhenGTIsMissing)
 {
   const rclcpp::Time start_time(20, 0);
@@ -139,6 +158,7 @@ TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)
     OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
 
   evaluator.set_metric_variant("raw");
+  evaluator.set_epdms_horizons({2.0, 3.0, 4.0});
 
   const auto topics = evaluator.get_result_topics();
   const auto has_topic = [&topics](const std::string & topic_name) {
@@ -160,6 +180,18 @@ TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)
   EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_raw_available"));
   EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_human_filtered"));
   EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_human_filtered_available"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_2s_raw"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_2s_raw_available"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_2s_human_filtered"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_2s_human_filtered_available"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_3s_raw"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_3s_raw_available"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_3s_human_filtered"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_3s_human_filtered_available"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_4s_raw"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_4s_raw_available"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_4s_human_filtered"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/raw/synthetic_epdms_4s_human_filtered_available"));
 }
 
 TEST_F(OpenLoopGTSourceModeTest, HistoryComfortIsReportedForComfortableAndUncomfortableTrajectories)
@@ -169,11 +201,9 @@ TEST_F(OpenLoopGTSourceModeTest, HistoryComfortIsReportedForComfortableAndUncomf
   auto uncomfortable_prediction = make_trajectory(start_time, {0.0, 0.5, 1.0, 1.5});
   const auto gt = std::make_shared<Trajectory>(make_trajectory(start_time, {0.0, 0.5, 1.0, 1.5}));
 
-  for (auto & point : comfortable_prediction.points) {
-    point.longitudinal_velocity_mps = 2.0;
-  }
-  for (auto & point : uncomfortable_prediction.points) {
-    point.longitudinal_velocity_mps = 2.0;
+  for (size_t i = 0; i < comfortable_prediction.points.size(); ++i) {
+    comfortable_prediction.points[i].longitudinal_velocity_mps = 2.0;
+    uncomfortable_prediction.points[i].longitudinal_velocity_mps = 2.0;
   }
   uncomfortable_prediction.points[1].longitudinal_velocity_mps = 3.0;
   uncomfortable_prediction.points[2].longitudinal_velocity_mps = 5.0;
@@ -221,11 +251,9 @@ TEST_F(OpenLoopGTSourceModeTest, HumanFilterPromotesAgentHistoryComfortWhenHuman
   auto prediction = make_trajectory(start_time, {0.0, 0.5, 1.0, 1.5});
   auto gt = std::make_shared<Trajectory>(make_trajectory(start_time, {0.0, 0.5, 1.0, 1.5}));
 
-  for (auto & point : prediction.points) {
-    point.longitudinal_velocity_mps = 2.0;
-  }
-  for (auto & point : gt->points) {
-    point.longitudinal_velocity_mps = 2.0;
+  for (size_t i = 0; i < prediction.points.size(); ++i) {
+    prediction.points[i].longitudinal_velocity_mps = 2.0;
+    gt->points[i].longitudinal_velocity_mps = 2.0;
   }
   prediction.points[1].longitudinal_velocity_mps = 3.0;
   prediction.points[2].longitudinal_velocity_mps = 5.0;
@@ -303,10 +331,8 @@ TEST_F(OpenLoopGTSourceModeTest, ExtendedComfortAvailabilityIsReportedAcrossCons
     make_trajectory(start_time + rclcpp::Duration::from_seconds(0.1), {0.0, 0.5, 1.1, 1.7}));
 
   for (auto * prediction : {&first_prediction, &second_prediction}) {
-    double velocity_mps = 2.0;
-    for (auto & point : prediction->points) {
-      point.longitudinal_velocity_mps = velocity_mps;
-      velocity_mps += 0.1;
+    for (size_t i = 0; i < prediction->points.size(); ++i) {
+      prediction->points[i].longitudinal_velocity_mps = 2.0 + 0.1 * static_cast<double>(i);
     }
   }
 
@@ -334,16 +360,15 @@ TEST_F(
   auto turning_prediction = make_trajectory(start_time, {0.0, 1.0, 2.0, 3.0});
   const auto gt = std::make_shared<Trajectory>(make_trajectory(start_time, {0.0, 1.0, 2.0, 3.0}));
 
-  for (auto & point : turning_prediction.points) {
-    point.longitudinal_velocity_mps = 10.0;
-    point.lateral_velocity_mps = 0.0;
+  for (size_t i = 0; i < turning_prediction.points.size(); ++i) {
+    turning_prediction.points[i].longitudinal_velocity_mps = 10.0;
+    turning_prediction.points[i].lateral_velocity_mps = 0.0;
   }
 
-  double yaw = 0.0;
-  for (auto & point : turning_prediction.points) {
-    point.pose.orientation.z = std::sin(yaw * 0.5);
-    point.pose.orientation.w = std::cos(yaw * 0.5);
-    yaw += 0.05;
+  for (size_t i = 0; i < turning_prediction.points.size(); ++i) {
+    const double yaw = 0.05 * static_cast<double>(i);
+    turning_prediction.points[i].pose.orientation.z = std::sin(yaw * 0.5);
+    turning_prediction.points[i].pose.orientation.w = std::cos(yaw * 0.5);
   }
 
   std::vector<std::shared_ptr<SynchronizedData>> sync_data_list{
@@ -388,12 +413,7 @@ TEST_F(OpenLoopGTSourceModeTest, HeadingMetricsUseWrappedYawErrorPerHorizon)
   OpenLoopEvaluator evaluator(
     rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
     OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
-  {
-    // Avoid initializer list to prevent GCC 13 false-positive -Wstringop-overread
-    std::vector<double> horizons;
-    horizons.push_back(0.2);
-    evaluator.set_evaluation_horizons(horizons);
-  }
+  evaluator.set_evaluation_horizons({0.2});
 
   evaluator.evaluate(sync_data_list, nullptr);
   const auto metrics = evaluator.get_metrics();


### PR DESCRIPTION
## Description

This PR parallelizes open-loop evaluation in `autoware_planning_data_analyzer` and ports the implementation onto the current `autowarefoundation/autoware_tools` `main` base.

Included in this PR:

- parallel trajectory evaluation with worker threads for open-loop metrics
- parallel phase split for base metrics and extended comfort / synthetic EPDMS horizon evaluation
- preservation of bag-output equivalence by restoring merge-based final bag generation

The bag finalization path keeps the final output behavior aligned with the previous sequential implementation:

- intermediate bag -> analyzer temp bag -> merged final bag
- no build artifacts are included in this PR

## How was this PR tested?

 ran the full offline pipeline and compared the artifact created before the change this time with the current output:

Validation results from the full pipeline:

- output bag size matched: `56G` vs `56G`
- EPDMS-related aggregate values matched exactly between reference and rerun

Observed analyzer runtime from the successful rerun:

- total analyzer runtime: about `1431.82 s` (`23m 51.8s`)
- open-loop evaluation core: about `1211.38 s` (`20m 11.4s`)
- parallel phase 1: about `527.44 s`
- parallel phase 2: about `611.36 s`

## Notes for reviewers
