### PR TITLE
fix(planning_debug_tools): migrate to rclcpp typesupport helpers

### DIFF
--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -79,13 +79,11 @@ void PerceptionReplayerCommon::load_rosbag(
   // try to load type support for each topic
   for (const auto & topic_meta : topics) {
     try {
-      auto library =
-        rclcpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
+      auto library = rclcpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
       type_support_libs[topic_meta.name] = library;
 
       const rosidl_message_type_support_t * type_support =
-        rclcpp::get_message_typesupport_handle(
-          topic_meta.type, "rosidl_typesupport_cpp", *library);
+        rclcpp::get_message_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", *library);
 
       if (type_support) {
         type_support_map[topic_meta.name] = std::shared_ptr<const rosidl_message_type_support_t>(

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -82,8 +82,13 @@ void PerceptionReplayerCommon::load_rosbag(
       auto library = rclcpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
       type_support_libs[topic_meta.name] = library;
 
+#ifdef ROS_DISTRO_HUMBLE
+      const rosidl_message_type_support_t * type_support =
+        rclcpp::get_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", *library);
+#else
       const rosidl_message_type_support_t * type_support =
         rclcpp::get_message_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", *library);
+#endif
 
       if (type_support) {
         type_support_map[topic_meta.name] = std::shared_ptr<const rosidl_message_type_support_t>(

--- a/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp
@@ -17,9 +17,9 @@
 #include "serialized_bag_message.hpp"
 #include "utils.hpp"
 
+#include <rclcpp/typesupport_helpers.hpp>
 #include <rosbag2_cpp/reader.hpp>
 #include <rosbag2_cpp/readers/sequential_reader.hpp>
-#include <rosbag2_cpp/typesupport_helpers.hpp>
 #include <rosbag2_storage/storage_filter.hpp>
 #include <rosbag2_storage/storage_options.hpp>
 
@@ -80,11 +80,12 @@ void PerceptionReplayerCommon::load_rosbag(
   for (const auto & topic_meta : topics) {
     try {
       auto library =
-        rosbag2_cpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
+        rclcpp::get_typesupport_library(topic_meta.type, "rosidl_typesupport_cpp");
       type_support_libs[topic_meta.name] = library;
 
       const rosidl_message_type_support_t * type_support =
-        rosbag2_cpp::get_typesupport_handle(topic_meta.type, "rosidl_typesupport_cpp", library);
+        rclcpp::get_message_typesupport_handle(
+          topic_meta.type, "rosidl_typesupport_cpp", *library);
 
       if (type_support) {
         type_support_map[topic_meta.name] = std::shared_ptr<const rosidl_message_type_support_t>(


### PR DESCRIPTION
- Replace the deprecated `rosbag2_cpp::get_typesupport_library` and `rosbag2_cpp::get_typesupport_handle` calls in [planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp](https://github.com/autowarefoundation/autoware_tools/blob/6106a5c361240fe3abfd0d47a99fa5e46ec7b135/planning/planning_debug_tools/src/perception_replayer/perception_replayer_common.cpp) with their `rclcpp` counterparts.
- Swap the include from `<rosbag2_cpp/typesupport_helpers.hpp>` to `<rclcpp/typesupport_helpers.hpp>`; dereference the `shared_ptr<rcpputils::SharedLibrary>` since the `rclcpp` variants take a reference, not a `shared_ptr`.
- Gate the handle call on `ROS_DISTRO_HUMBLE` (a compile definition set by `autoware_package()`), because the function was renamed between distros.

## Why
The `rosbag2_cpp` typesupport helpers are deprecated in Jazzy:

> This function will be deleted in the next 'Lyrical Luth' ROS release. Please use the rclcpp counterpart functions.

With Autoware's `-Werror=deprecated-declarations` policy, this broke the `autoware_core` `build-and-test-jazzy-above` CI job. The `rclcpp` helpers are the upstream-recommended replacement.

### Cross-distro detail

The handle function was renamed between Humble and Jazzy in `rclcpp`, while the `rosbag2_cpp` and `rclcpp` variants already differ in their 3rd argument (shared_ptr vs. reference):

| API | Humble | Jazzy |
|---|---|---|
| [`rclcpp::get_typesupport_library`](https://github.com/ros2/rclcpp/blob/humble/rclcpp/include/rclcpp/typesupport_helpers.hpp#L38) | returns `shared_ptr<SharedLibrary>` | returns `shared_ptr<SharedLibrary>` |
| [`rclcpp::get_typesupport_handle`](https://github.com/ros2/rclcpp/blob/humble/rclcpp/include/rclcpp/typesupport_helpers.hpp#L50-L54) | takes `SharedLibrary &` | **deprecated**, renamed to `get_message_typesupport_handle` |
| `rclcpp::get_message_typesupport_handle` | does not exist | takes `SharedLibrary &` |
| [`rosbag2_cpp::get_typesupport_handle`](https://github.com/ros2/rosbag2/blob/humble/rosbag2_cpp/include/rosbag2_cpp/typesupport_helpers.hpp#L40-L46) | takes `shared_ptr<SharedLibrary>` | deprecated |

So on Humble we call `rclcpp::get_typesupport_handle(..., *library)`, and on Jazzy `rclcpp::get_message_typesupport_handle(..., *library)` — both take the `SharedLibrary &`, hence the dereference.

---

## Test plan

- [ ] Build on Jazzy:
  ```bash
  source /opt/ros/jazzy/setup.bash && \
    colcon build --symlink-install --event-handlers=console_cohesion+ \
      --cmake-args -DCMAKE_BUILD_TYPE=Release \
      --packages-select planning_debug_tools
  ```
  Expect: `Finished <<< planning_debug_tools` with no `-Wdeprecated-declarations` errors (previously failed at `perception_replayer_common.cpp:83` and `:87`).
- [ ] Build on Humble with the same command (sourcing `/opt/ros/humble/setup.bash`); expect no `get_message_typesupport_handle is not a member of rclcpp` error.
- [ ] Re-run the `autoware_core` `build-and-test-jazzy-above` workflow after the sub-repo pin is updated; job should pass the Build step.