### PR TITLE
feat(pitch_checker): replace autoware_universe_utils with autoware_utils_tf

### DIFF
--- a/vehicle/pitch_checker/include/pitch_checker/pitch_checker.hpp
+++ b/vehicle/pitch_checker/include/pitch_checker/pitch_checker.hpp
@@ -35,7 +35,7 @@
 #else
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #endif
-#include "autoware/universe_utils/ros/transform_listener.hpp"
+#include <autoware_utils_tf/transform_listener.hpp>
 
 struct TfInfo
 {
@@ -52,7 +52,7 @@ public:
   explicit PitchChecker(const rclcpp::NodeOptions & node_options);
 
 private:
-  std::shared_ptr<autoware::universe_utils::TransformListener> transform_listener_;
+  std::shared_ptr<autoware_utils_tf::TransformListener> transform_listener_;
 
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;

--- a/vehicle/pitch_checker/package.xml
+++ b/vehicle/pitch_checker/package.xml
@@ -11,7 +11,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_tf</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>

--- a/vehicle/pitch_checker/src/pitch_checker_node.cpp
+++ b/vehicle/pitch_checker/src/pitch_checker_node.cpp
@@ -24,7 +24,7 @@
 PitchChecker::PitchChecker(const rclcpp::NodeOptions & node_options)
 : Node("pitch_checker", node_options)
 {
-  transform_listener_ = std::make_shared<autoware::universe_utils::TransformListener>(this);
+  transform_listener_ = std::make_shared<autoware_utils_tf::TransformListener>(this);
   using std::placeholders::_1;
   using std::placeholders::_2;
   using std::placeholders::_3;
@@ -80,7 +80,7 @@ bool PitchChecker::getTf()
 {
   geometry_msgs::msg::TransformStamped::ConstSharedPtr transform;
   try {
-    transform = transform_listener_->getTransform(
+    transform = transform_listener_->get_transform(
       "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
   } catch (tf2::TransformException & ex) {
     auto & clk = *this->get_clock();


### PR DESCRIPTION
## Description

Replaces `autoware_universe_utils` dependency in the `pitch_checker` package with the specific `autoware_utils_tf` sub-package, following the minimum-dependency principle.

## Changes

**`vehicle/pitch_checker/package.xml`**
- `<depend>autoware_universe_utils</depend>` → `<depend>autoware_utils_tf</depend>`

**`vehicle/pitch_checker/include/pitch_checker/pitch_checker.hpp`**
- `#include "autoware/universe_utils/ros/transform_listener.hpp"` → `#include <autoware_utils_tf/transform_listener.hpp>`
- `autoware::universe_utils::TransformListener` → `autoware_utils_tf::TransformListener`

**`vehicle/pitch_checker/src/pitch_checker_node.cpp`**
- `autoware::universe_utils::TransformListener` → `autoware_utils_tf::TransformListener`

## Related Issue

Part of the `autoware_universe_utils` deprecation effort tracked in autowarefoundation/autoware_universe#12376 (the `autoware_tools` checklist item).

## Additional notes

This is the first of a series of similar PRs for `autoware_tools`, grouped by top-level directory:
- [x] vehicle (this PR)
- [ ] driving_environment_analyzer
- [ ] common
- [ ] planning
- [ ] localization