### PR TITLE
feat(driving_environment_analyzer): replace autoware_universe_utils with autoware_utils_geometry

### DIFF
--- a/driving_environment_analyzer/package.xml
+++ b/driving_environment_analyzer/package.xml
@@ -24,7 +24,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_signal_processing</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/driving_environment_analyzer/src/utils.cpp
+++ b/driving_environment_analyzer/src/utils.cpp
@@ -15,7 +15,7 @@
 #include "driving_environment_analyzer/utils.hpp"
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
@@ -59,9 +59,9 @@ std::vector<double> calcElevationAngle(const T & points)
   }
 
   for (size_t i = 0; i < points.size() - 1; ++i) {
-    const auto p1 = autoware::universe_utils::getPoint(points.at(i));
-    const auto p2 = autoware::universe_utils::getPoint(points.at(i + 1));
-    elevation_vec.at(i) = autoware::universe_utils::calcElevationAngle(p1, p2);
+    const auto p1 = autoware_utils_geometry::get_point(points.at(i));
+    const auto p2 = autoware_utils_geometry::get_point(points.at(i + 1));
+    elevation_vec.at(i) = autoware_utils_geometry::calc_elevation_angle(p1, p2);
   }
   elevation_vec.at(elevation_vec.size() - 1) = elevation_vec.at(elevation_vec.size() - 2);
 
@@ -86,9 +86,9 @@ double calcElevationAngle(const lanelet::ConstLanelet & lane, const Pose & pose)
 
   const size_t idx = autoware::motion_utils::findNearestSegmentIndex(points, pose.position);
 
-  const auto p1 = autoware::universe_utils::getPoint(points.at(idx));
-  const auto p2 = autoware::universe_utils::getPoint(points.at(idx + 1));
-  return autoware::universe_utils::calcElevationAngle(p1, p2);
+  const auto p1 = autoware_utils_geometry::get_point(points.at(idx));
+  const auto p2 = autoware_utils_geometry::get_point(points.at(idx + 1));
+  return autoware_utils_geometry::calc_elevation_angle(p1, p2);
 }
 
 double getLaneWidth(const lanelet::ConstLanelet & lane)

--- a/driving_environment_analyzer/src/utils.cpp
+++ b/driving_environment_analyzer/src/utils.cpp
@@ -15,10 +15,10 @@
 #include "driving_environment_analyzer/utils.hpp"
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include <autoware_utils_geometry/geometry.hpp>
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <magic_enum.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>


### PR DESCRIPTION
## Description

Replaces `autoware_universe_utils` dependency in the `driving_environment_analyzer` package with the specific `autoware_utils_geometry` sub-package, following the minimum-dependency principle.

## Changes

**`driving_environment_analyzer/package.xml`**
- `<depend>autoware_universe_utils</depend>` → `<depend>autoware_utils_geometry</depend>`

**`driving_environment_analyzer/src/utils.cpp`**
- `#include "autoware/universe_utils/geometry/geometry.hpp"` → `#include <autoware_utils_geometry/geometry.hpp>`
- `autoware::universe_utils::getPoint` → `autoware_utils_geometry::get_point`
- `autoware::universe_utils::calcElevationAngle` → `autoware_utils_geometry::calc_elevation_angle`

Note: Local wrapper functions `utils::calcElevationAngle` remain unchanged as they are internal to this package (out of scope for this migration).

## Related Issue

Part of the `autoware_universe_utils` deprecation effort tracked in autowarefoundation/autoware_universe#12376 (the `autoware_tools` checklist item).

## Additional notes

This is part of a series of similar PRs for `autoware_tools`, grouped by top-level directory:

- [x] vehicle (#404)
- [x] driving_environment_analyzer (this PR)
- [ ] common
- [ ] planning
- [ ] localization