### PR TITLE
feat(tier4_debug_tools): remove unused autoware_universe_utils dependency

### DIFF
--- a/common/tier4_debug_tools/package.xml
+++ b/common/tier4_debug_tools/package.xml
@@ -13,7 +13,6 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_universe_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
## Description

Removes the unused `autoware_universe_utils` dependency from `tier4_debug_tools/package.xml`. No source files in this package actually use `autoware_universe_utils`.

## Changes

**`common/tier4_debug_tools/package.xml`**
- Removed `<depend>autoware_universe_utils</depend>` (unused)

## Related Issue

Part of the `autoware_universe_utils` deprecation effort tracked in autowarefoundation/autoware_universe#12376 (the `autoware_tools` checklist item).

## Additional notes

Part of a series of similar PRs for `autoware_tools`, grouped by top-level directory:

- [x] vehicle (#404)
- [x] driving_environment_analyzer (#405)
- [ ] common (in progress — this PR covers `tier4_debug_tools`; separate PRs will follow for `tier4_automatic_goal_rviz_plugin` and `tier4_control_rviz_plugin`)
- [ ] planning
- [ ] localization