### PR TITLE
feat(tier4_control_rviz_plugin): replace autoware_universe_utils with autoware_utils_rclcpp

### DIFF
--- a/common/tier4_control_rviz_plugin/package.xml
+++ b/common/tier4_control_rviz_plugin/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_control_msgs</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp
@@ -103,10 +103,10 @@ void ManualController::update()
 {
   if (!raw_node_) return;
 
-  const auto velocity = sub_velocity_->takeData();
+  const auto velocity = sub_velocity_->take_data();
   const double current_velocity = velocity ? velocity->longitudinal_velocity : 0.0;
 
-  const auto accel = sub_accel_->takeData();
+  const auto accel = sub_accel_->take_data();
   const double current_acceleration = accel ? accel->accel.accel.linear.x : 0.0;
 
   Control control_cmd;
@@ -166,10 +166,10 @@ void ManualController::onInitialize()
     "/control/current_gate_mode", 10, std::bind(&ManualController::onGateMode, this, _1));
 
   sub_velocity_ =
-    autoware::universe_utils::InterProcessPollingSubscriber<VelocityReport>::create_subscription(
+    autoware_utils_rclcpp::InterProcessPollingSubscriber<VelocityReport>::create_subscription(
       raw_node_.get(), "/vehicle/status/velocity_status", 1);
 
-  sub_accel_ = autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>::
+  sub_accel_ = autoware_utils_rclcpp::InterProcessPollingSubscriber<AccelWithCovarianceStamped>::
     create_subscription(raw_node_.get(), "/localization/acceleration", 1);
 
   sub_engage_ = raw_node_->create_subscription<Engage>(

--- a/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
+++ b/common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp
@@ -21,7 +21,7 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QSpinBox>
-#include <autoware/universe_utils/ros/polling_subscriber.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
 
@@ -73,8 +73,8 @@ protected:
   void onGear(const GearReport::ConstSharedPtr msg);
   rclcpp::Node::SharedPtr raw_node_;
   rclcpp::Subscription<GateMode>::SharedPtr sub_gate_mode_;
-  autoware::universe_utils::InterProcessPollingSubscriber<VelocityReport>::SharedPtr sub_velocity_;
-  autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<VelocityReport>::SharedPtr sub_velocity_;
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
     sub_accel_;
   rclcpp::Subscription<Engage>::SharedPtr sub_engage_;
   rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;


### PR DESCRIPTION
## Description

Replaces `autoware_universe_utils` dependency in the `tier4_control_rviz_plugin` package with the specific `autoware_utils_rclcpp` sub-package, following the minimum-dependency principle.

## Changes

**`common/tier4_control_rviz_plugin/package.xml`**
- `<depend>autoware_universe_utils</depend>` → `<depend>autoware_utils_rclcpp</depend>`

**`common/tier4_control_rviz_plugin/src/tools/manual_controller.hpp`**
- `#include <autoware/universe_utils/ros/polling_subscriber.hpp>` → `#include <autoware_utils_rclcpp/polling_subscriber.hpp>`
- `autoware::universe_utils::InterProcessPollingSubscriber` → `autoware_utils_rclcpp::InterProcessPollingSubscriber`

**`common/tier4_control_rviz_plugin/src/tools/manual_controller.cpp`**
- `autoware::universe_utils::InterProcessPollingSubscriber` → `autoware_utils_rclcpp::InterProcessPollingSubscriber`
- `->takeData()` → `->take_data()` (method renamed camelCase → snake_case in new class API)

## Related Issue

Part of the `autoware_universe_utils` deprecation effort tracked in autowarefoundation/autoware_universe#12376 (the `autoware_tools` checklist item).

## Additional notes

Part of a series of similar PRs for `autoware_tools`, grouped by top-level directory:

- [x] vehicle (#404)
- [x] driving_environment_analyzer (#405)
- [x] common (complete after this PR)
  - [x] tier4_debug_tools (#406)
  - [x] tier4_automatic_goal_rviz_plugin (#407)
  - [x] tier4_control_rviz_plugin (this PR)
- [ ] planning
- [ ] localization