### PR TITLE
feat: add autoware_lanelet2_map_divider package

### DIFF
--- a/map/autoware_lanelet2_map_divider/CMakeLists.txt
+++ b/map/autoware_lanelet2_map_divider/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_lanelet2_map_divider)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+ament_auto_find_build_dependencies()
+
+find_package(yaml-cpp REQUIRED)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/lanelet2_map_divider.cpp
+  src/lanelet2_map_divider_node.cpp
+)
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::lanelet2_map_divider::Lanelet2MapDividerNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_lanelet2_map_divider test/test_lanelet2_map_divider.cpp)
+  target_link_libraries(test_lanelet2_map_divider ${PROJECT_NAME} yaml-cpp)
+endif()
+
+ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/map/autoware_lanelet2_map_divider/README.md
+++ b/map/autoware_lanelet2_map_divider/README.md
@@ -63,7 +63,7 @@ ros2 launch autoware_lanelet2_map_divider lanelet2_map_divider.launch.xml \
 
 ## Output directory layout
 
-```
+```text
 <OUTPUT_DIR>
 ├── lanelet2_map.osm
 │   ├── <gx0>_<gy0>.osm

--- a/map/autoware_lanelet2_map_divider/README.md
+++ b/map/autoware_lanelet2_map_divider/README.md
@@ -32,14 +32,14 @@ ros2 launch autoware_lanelet2_map_divider lanelet2_map_divider.launch.xml \
   [grid_size_x:=<GRID_SIZE_X>] [grid_size_y:=<GRID_SIZE_Y>] [prefix:=<PREFIX>]
 ```
 
-| Name                    | Description                                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------------- |
-| INPUT_OSM               | Path to the input `.osm` file                                                                  |
-| OUTPUT_DIR              | Output directory. Contains `lanelet2_map.osm/<gx>_<gy>.osm` files and the metadata YAML        |
-| PROJECTOR_YAML          | Path to `map_projector_info.yaml` used when loading/saving the Lanelet2 map                    |
-| GRID_SIZE_X             | The X size (m) of each output segment. Default 100.0                                           |
-| GRID_SIZE_Y             | The Y size (m) of each output segment. Default 100.0                                           |
-| PREFIX                  | Optional prefix for output file names (if empty, files are named `<gx>_<gy>.osm`)              |
+| Name           | Description                                                                             |
+| -------------- | --------------------------------------------------------------------------------------- |
+| INPUT_OSM      | Path to the input `.osm` file                                                           |
+| OUTPUT_DIR     | Output directory. Contains `lanelet2_map.osm/<gx>_<gy>.osm` files and the metadata YAML |
+| PROJECTOR_YAML | Path to `map_projector_info.yaml` used when loading/saving the Lanelet2 map             |
+| GRID_SIZE_X    | The X size (m) of each output segment. Default 100.0                                    |
+| GRID_SIZE_Y    | The Y size (m) of each output segment. Default 100.0                                    |
+| PREFIX         | Optional prefix for output file names (if empty, files are named `<gx>_<gy>.osm`)       |
 
 `INPUT_OSM`, `OUTPUT_DIR`, and `PROJECTOR_YAML` should be specified as **absolute paths**.
 
@@ -96,8 +96,8 @@ consumed by `lanelet2_map_loader`:
 ```yaml
 x_resolution: 100.0
 y_resolution: 100.0
-0_0.osm: [0.0, 0.0]        # -> 0 <= x < 100, 0 <= y < 100
-100_0.osm: [100.0, 0.0]    # -> 100 <= x < 200, 0 <= y < 100
+0_0.osm: [0.0, 0.0] # -> 0 <= x < 100, 0 <= y < 100
+100_0.osm: [100.0, 0.0] # -> 100 <= x < 200, 0 <= y < 100
 0_100.osm: [0.0, 100.0]
 100_100.osm: [100.0, 100.0]
 ```

--- a/map/autoware_lanelet2_map_divider/README.md
+++ b/map/autoware_lanelet2_map_divider/README.md
@@ -1,0 +1,139 @@
+# autoware_lanelet2_map_divider
+
+This is a tool for processing Lanelet2 (`.osm`) map files. It can perform the following functions:
+
+- Dividing a Lanelet2 map into grid-aligned segments
+- Generating metadata to efficiently handle the divided maps
+
+The produced directory layout and metadata are compatible with the
+`lanelet2_map_loader` selected-map-loading feature, as described in the
+[`autoware_map_loader` README](https://github.com/autowarefoundation/autoware_core/tree/main/map/autoware_map_loader).
+
+## Supported Data Format
+
+- Input: a single `.osm` Lanelet2 map file. If you have a map that is already split
+  across multiple `.osm` files, merge it into one first with
+  [`autoware_lanelet2_map_merger`](../autoware_lanelet2_map_merger/README.md).
+- Output: one `.osm` file per non-empty grid cell, plus a `lanelet2_map_metadata.yaml`
+  file describing the grid.
+
+The projection required to load/save the map is obtained from a
+`map_projector_info.yaml` file (identical to the one consumed by
+`autoware_map_projection_loader`). `MGRS`, `LocalCartesianUTM`, `LocalCartesian`,
+`TransverseMercator`, and `Local` are supported.
+
+## Usage
+
+```bash
+ros2 launch autoware_lanelet2_map_divider lanelet2_map_divider.launch.xml \
+  input_lanelet2_map:=<INPUT_OSM> \
+  output_lanelet2_map_dir:=<OUTPUT_DIR> \
+  map_projector_info_path:=<PROJECTOR_YAML> \
+  [grid_size_x:=<GRID_SIZE_X>] [grid_size_y:=<GRID_SIZE_Y>] [prefix:=<PREFIX>]
+```
+
+| Name                    | Description                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------- |
+| INPUT_OSM               | Path to the input `.osm` file                                                                  |
+| OUTPUT_DIR              | Output directory. Contains `lanelet2_map.osm/<gx>_<gy>.osm` files and the metadata YAML        |
+| PROJECTOR_YAML          | Path to `map_projector_info.yaml` used when loading/saving the Lanelet2 map                    |
+| GRID_SIZE_X             | The X size (m) of each output segment. Default 100.0                                           |
+| GRID_SIZE_Y             | The Y size (m) of each output segment. Default 100.0                                           |
+| PREFIX                  | Optional prefix for output file names (if empty, files are named `<gx>_<gy>.osm`)              |
+
+`INPUT_OSM`, `OUTPUT_DIR`, and `PROJECTOR_YAML` should be specified as **absolute paths**.
+
+NOTE: The folder `OUTPUT_DIR` is auto-generated. If it already exists, all files inside
+will be deleted before the tool runs. Back up important files beforehand.
+
+### Parameters
+
+{{ json_to_markdown("map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json") }}
+
+### Parameter example
+
+Dividing a map into 100 m x 100 m segments:
+
+```bash
+ros2 launch autoware_lanelet2_map_divider lanelet2_map_divider.launch.xml \
+  input_lanelet2_map:=/path/to/lanelet2_map.osm \
+  output_lanelet2_map_dir:=/path/to/output_dir \
+  map_projector_info_path:=/path/to/map_projector_info.yaml
+```
+
+## Output directory layout
+
+```
+<OUTPUT_DIR>
+├── lanelet2_map.osm
+│   ├── <gx0>_<gy0>.osm
+│   ├── <gx1>_<gy0>.osm
+│   └── ...
+└── lanelet2_map_metadata.yaml
+```
+
+The directory is shaped so that it can be copied next to an existing
+`pointcloud_map.pcd/` and `map_projector_info.yaml` to form a map package
+that `lanelet2_map_loader` can consume in selected-map-loading mode.
+
+## Grid alignment and file naming
+
+- A point `(x, y)` belongs to grid cell `(gx, gy)` where
+  `gx = floor(x / grid_size_x) * grid_size_x` and
+  `gy = floor(y / grid_size_y) * grid_size_y`.
+- The file name for a cell is `<prefix>_<gx>_<gy>.osm` (or `<gx>_<gy>.osm` if
+  `prefix` is empty).
+- Grid indices are coordinate-aligned (not bounding-box-relative), so re-running the
+  divider on a larger/smaller input that overlaps the same region produces the same
+  file names for the overlapping cells. This makes the tool friendly to
+  differential-update workflows.
+
+## Metadata YAML Format
+
+The metadata file is `lanelet2_map_metadata.yaml` and follows the same format
+consumed by `lanelet2_map_loader`:
+
+```yaml
+x_resolution: 100.0
+y_resolution: 100.0
+0_0.osm: [0.0, 0.0]        # -> 0 <= x < 100, 0 <= y < 100
+100_0.osm: [100.0, 0.0]    # -> 100 <= x < 200, 0 <= y < 100
+0_100.osm: [0.0, 100.0]
+100_100.osm: [100.0, 100.0]
+```
+
+- `x_resolution` and `y_resolution` are the grid sizes in meters.
+- Each other entry maps a file name to `[min_x, min_y]`, the coordinates of the
+  lower-left corner of that cell in the projected frame. The cell covers
+  `[min_x, min_x + x_resolution)` x `[min_y, min_y + y_resolution)`.
+
+## How the map is split
+
+1. Load the input `.osm` file using the projector from `map_projector_info.yaml`.
+2. Compute the axis-aligned bounding box from all points in the map and
+   determine the grid cells covered by the bounding box (coordinate-aligned).
+3. For each cell, query `laneletLayer`, `areaLayer`, `lineStringLayer`, and
+   `pointLayer` using the cell's 2D bounding box and add the matches to a new
+   `LaneletMap`.
+4. Write the cell map with `lanelet::write`, using the same projector as the one
+   used during loading, so coordinates round-trip through lat/lon correctly.
+5. Write `lanelet2_map_metadata.yaml` alongside the cell directory.
+
+Cells with no overlapping primitives are skipped — no empty files are produced.
+
+## Relation to `lanelet2_map_loader`
+
+The generated directory can be fed directly to
+[`lanelet2_map_loader`](https://github.com/autowarefoundation/autoware_core/tree/main/map/autoware_map_loader)
+with
+
+- `lanelet2_map_path:=<OUTPUT_DIR>/lanelet2_map.osm`
+- `metadata_file_path:=<OUTPUT_DIR>/lanelet2_map_metadata.yaml`
+- `enable_selected_map_loading:=true`
+
+so that the loader can serve per-cell maps via
+`service/get_selected_lanelet2_map`.
+
+## LICENSE
+
+Apache License 2.0.

--- a/map/autoware_lanelet2_map_divider/config/lanelet2_map_divider.param.yaml
+++ b/map/autoware_lanelet2_map_divider/config/lanelet2_map_divider.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    grid_size_x: 100.0
+    grid_size_y: 100.0
+    input_lanelet2_map: "$(var input_lanelet2_map)"
+    output_lanelet2_map_dir: "$(var output_lanelet2_map_dir)"
+    map_projector_info_path: "$(var map_projector_info_path)"
+    prefix: "$(var prefix)"

--- a/map/autoware_lanelet2_map_divider/launch/lanelet2_map_divider.launch.xml
+++ b/map/autoware_lanelet2_map_divider/launch/lanelet2_map_divider.launch.xml
@@ -2,7 +2,7 @@
   <arg name="config_file_path" default="$(find-pkg-share autoware_lanelet2_map_divider)/config/lanelet2_map_divider.param.yaml" description="Path to the configuration YAML file"/>
   <arg name="grid_size_x" default="100.0" description="The X size (m) of each output segment"/>
   <arg name="grid_size_y" default="100.0" description="The Y size (m) of each output segment"/>
-  <arg name="input_lanelet2_map" description="Path to a single .osm file or a directory containing .osm files"/>
+  <arg name="input_lanelet2_map" description="Path to a single .osm file"/>
   <arg name="output_lanelet2_map_dir" description="Path to the output directory"/>
   <arg name="map_projector_info_path" description="Path to the map_projector_info.yaml file"/>
   <arg name="prefix" default="" description="Prefix for the name of the output .osm files"/>

--- a/map/autoware_lanelet2_map_divider/launch/lanelet2_map_divider.launch.xml
+++ b/map/autoware_lanelet2_map_divider/launch/lanelet2_map_divider.launch.xml
@@ -1,0 +1,21 @@
+<launch>
+  <arg name="config_file_path" default="$(find-pkg-share autoware_lanelet2_map_divider)/config/lanelet2_map_divider.param.yaml" description="Path to the configuration YAML file"/>
+  <arg name="grid_size_x" default="100.0" description="The X size (m) of each output segment"/>
+  <arg name="grid_size_y" default="100.0" description="The Y size (m) of each output segment"/>
+  <arg name="input_lanelet2_map" description="Path to a single .osm file or a directory containing .osm files"/>
+  <arg name="output_lanelet2_map_dir" description="Path to the output directory"/>
+  <arg name="map_projector_info_path" description="Path to the map_projector_info.yaml file"/>
+  <arg name="prefix" default="" description="Prefix for the name of the output .osm files"/>
+
+  <group>
+    <node pkg="autoware_lanelet2_map_divider" exec="autoware_lanelet2_map_divider_node" name="lanelet2_map_divider" output="screen">
+      <param from="$(var config_file_path)" allow_substs="true"/>
+      <param name="grid_size_x" value="$(var grid_size_x)"/>
+      <param name="grid_size_y" value="$(var grid_size_y)"/>
+      <param name="input_lanelet2_map" value="$(var input_lanelet2_map)"/>
+      <param name="output_lanelet2_map_dir" value="$(var output_lanelet2_map_dir)"/>
+      <param name="map_projector_info_path" value="$(var map_projector_info_path)"/>
+      <param name="prefix" value="$(var prefix)"/>
+    </node>
+  </group>
+</launch>

--- a/map/autoware_lanelet2_map_divider/package.xml
+++ b/map/autoware_lanelet2_map_divider/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_lanelet2_map_divider</name>
+  <version>0.6.0</version>
+  <description>A package for dividing a Lanelet2 map (.osm) into grid-aligned segments</description>
+  <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_geography_utils</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_map_projection_loader</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>yaml-cpp</depend>
+
+  <exec_depend>ros2launch</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json
+++ b/map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for autoware lanelet2 map divider node",
+  "type": "object",
+  "definitions": {
+    "autoware_lanelet2_map_divider": {
+      "type": "object",
+      "properties": {
+        "grid_size_x": {
+          "type": "number",
+          "description": "The X size in meters of the output segments",
+          "default": "100.0"
+        },
+        "grid_size_y": {
+          "type": "number",
+          "description": "The Y size in meters of the output segments",
+          "default": "100.0"
+        },
+        "input_lanelet2_map": {
+          "type": "string",
+          "description": "Path to a single .osm file or a directory containing .osm files",
+          "default": ""
+        },
+        "output_lanelet2_map_dir": {
+          "type": "string",
+          "description": "Path to the output directory. Will contain lanelet2_map.osm/ and lanelet2_map_metadata.yaml",
+          "default": ""
+        },
+        "map_projector_info_path": {
+          "type": "string",
+          "description": "Path to the map_projector_info.yaml file that describes the projection of the input map",
+          "default": ""
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Prefix for the name of the output .osm files",
+          "default": ""
+        }
+      },
+      "required": [
+        "grid_size_x",
+        "grid_size_y",
+        "input_lanelet2_map",
+        "output_lanelet2_map_dir",
+        "map_projector_info_path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/autoware_lanelet2_map_divider"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json
+++ b/map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json
@@ -42,7 +42,8 @@
         "grid_size_y",
         "input_lanelet2_map",
         "output_lanelet2_map_dir",
-        "map_projector_info_path"
+        "map_projector_info_path",
+        "prefix"
       ],
       "additionalProperties": false
     }

--- a/map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json
+++ b/map/autoware_lanelet2_map_divider/schema/lanelet2_map_divider.schema.json
@@ -18,7 +18,7 @@
         },
         "input_lanelet2_map": {
           "type": "string",
-          "description": "Path to a single .osm file or a directory containing .osm files",
+          "description": "Path to a single .osm file",
           "default": ""
         },
         "output_lanelet2_map_dir": {

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
@@ -214,6 +214,8 @@ void Lanelet2MapDivider::write_metadata(
 
 void Lanelet2MapDivider::run()
 {
+  // Grid sizes below 1.0 truncate to a step of 0 in divide_and_save's int-cast loop,
+  // which would spin forever.
   if (grid_size_x_ < 1.0 || grid_size_y_ < 1.0) {
     RCLCPP_ERROR(
       logger_, "Grid size must be >= 1.0 (got x=%f, y=%f).", grid_size_x_, grid_size_y_);

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
@@ -102,14 +102,6 @@ lanelet::LaneletMapPtr Lanelet2MapDivider::load_map(
   return rebuilt;
 }
 
-void Lanelet2MapDivider::prepare_output_directory(const std::string & cell_dir) const
-{
-  if (fs::exists(output_dir_)) {
-    fs::remove_all(output_dir_);
-  }
-  fs::create_directories(cell_dir);
-}
-
 std::string Lanelet2MapDivider::make_file_name(int gx, int gy) const
 {
   std::string name;
@@ -259,7 +251,7 @@ void Lanelet2MapDivider::run()
   }
 
   const std::string cell_dir = output_dir_ + "/lanelet2_map.osm";
-  prepare_output_directory(cell_dir);
+  fs::create_directories(cell_dir);
 
   std::vector<std::tuple<std::string, int, int>> cells;
   divide_and_save(*map, *projector, cell_dir, cells);

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
@@ -1,0 +1,273 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_divider.hpp"
+
+#include "local_projector.hpp"
+
+#include <autoware/geography_utils/lanelet2_projector.hpp>
+#include <autoware/map_projection_loader/map_projection_loader.hpp>
+#include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
+
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/primitives/BoundingBox.h>
+#include <lanelet2_io/Io.h>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace autoware::lanelet2_map_divider
+{
+
+namespace
+{
+
+bool is_osm_file(const fs::path & path)
+{
+  if (!fs::exists(path) || fs::is_directory(path)) {
+    return false;
+  }
+  const std::string ext = path.extension().string();
+  return ext == ".osm" || ext == ".OSM";
+}
+
+}  // namespace
+
+std::unique_ptr<lanelet::Projector> Lanelet2MapDivider::create_projector(
+  const autoware_map_msgs::msg::MapProjectorInfo & projector_info) const
+{
+  if (projector_info.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL) {
+    return std::make_unique<LocalProjector>();
+  }
+  return autoware::geography_utils::get_lanelet2_projector(projector_info);
+}
+
+lanelet::LaneletMapPtr Lanelet2MapDivider::load_map(
+  const std::string & osm_file,
+  const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
+  lanelet::Projector & projector) const
+{
+  lanelet::ErrorMessages errors;
+  lanelet::LaneletMapPtr loaded =
+    lanelet::load(osm_file, "autoware_osm_handler", projector, &errors);
+  for (const auto & error : errors) {
+    RCLCPP_ERROR(logger_, "Error loading %s: %s", osm_file.c_str(), error.c_str());
+  }
+  if (!errors.empty() || !loaded) {
+    return nullptr;
+  }
+
+  if (projector_info.projector_type != autoware_map_msgs::msg::MapProjectorInfo::LOCAL) {
+    return loaded;
+  }
+
+  // LOCAL projection: override each point's x/y from its `local_x`/`local_y` tags,
+  // then rebuild the map so the spatial index reflects the updated coordinates
+  // (mutating points in place leaves the rtree stale and breaks layer search).
+  for (lanelet::Point3d point : loaded->pointLayer) {
+    if (point.hasAttribute("local_x")) {
+      point.x() = point.attribute("local_x").asDouble().value();
+    }
+    if (point.hasAttribute("local_y")) {
+      point.y() = point.attribute("local_y").asDouble().value();
+    }
+  }
+
+  auto rebuilt = std::make_shared<lanelet::LaneletMap>();
+  for (auto & llt : loaded->laneletLayer) rebuilt->add(llt);
+  for (auto & area : loaded->areaLayer) rebuilt->add(area);
+  for (auto & reg : loaded->regulatoryElementLayer) rebuilt->add(reg);
+  for (auto & ls : loaded->lineStringLayer) rebuilt->add(ls);
+  for (auto & poly : loaded->polygonLayer) rebuilt->add(poly);
+  for (auto & pt : loaded->pointLayer) rebuilt->add(pt);
+  return rebuilt;
+}
+
+void Lanelet2MapDivider::prepare_output_directory(const std::string & cell_dir) const
+{
+  if (fs::exists(output_dir_)) {
+    fs::remove_all(output_dir_);
+  }
+  fs::create_directories(cell_dir);
+}
+
+std::string Lanelet2MapDivider::make_file_name(int gx, int gy) const
+{
+  std::string name;
+  if (!prefix_.empty()) {
+    name += prefix_ + "_";
+  }
+  name += std::to_string(gx) + "_" + std::to_string(gy) + ".osm";
+  return name;
+}
+
+void Lanelet2MapDivider::divide_and_save(
+  lanelet::LaneletMap & map, lanelet::Projector & projector, const std::string & cell_dir,
+  std::vector<std::tuple<std::string, int, int>> & out_cells) const
+{
+  if (map.pointLayer.empty()) {
+    RCLCPP_WARN(logger_, "Input map has no points; nothing to divide.");
+    return;
+  }
+
+  double min_x = std::numeric_limits<double>::max();
+  double min_y = std::numeric_limits<double>::max();
+  double max_x = std::numeric_limits<double>::lowest();
+  double max_y = std::numeric_limits<double>::lowest();
+  for (const lanelet::ConstPoint3d & pt : map.pointLayer) {
+    min_x = std::min(min_x, pt.x());
+    min_y = std::min(min_y, pt.y());
+    max_x = std::max(max_x, pt.x());
+    max_y = std::max(max_y, pt.y());
+  }
+
+  const auto gx_start =
+    static_cast<int>(std::floor(min_x / grid_size_x_) * grid_size_x_);
+  const auto gy_start =
+    static_cast<int>(std::floor(min_y / grid_size_y_) * grid_size_y_);
+  const auto gx_end =
+    static_cast<int>(std::floor(max_x / grid_size_x_) * grid_size_x_);
+  const auto gy_end =
+    static_cast<int>(std::floor(max_y / grid_size_y_) * grid_size_y_);
+
+  RCLCPP_INFO(
+    logger_, "Map bounding box: [%.3f, %.3f] to [%.3f, %.3f]", min_x, min_y, max_x, max_y);
+  RCLCPP_INFO(
+    logger_, "Grid range (coord-aligned): x=[%d, %d], y=[%d, %d]", gx_start, gx_end, gy_start,
+    gy_end);
+
+  const auto step_x = static_cast<int>(grid_size_x_);
+  const auto step_y = static_cast<int>(grid_size_y_);
+
+  for (int gx = gx_start; gx <= gx_end; gx += step_x) {
+    for (int gy = gy_start; gy <= gy_end; gy += step_y) {
+      const lanelet::BoundingBox2d cell_bbox(
+        lanelet::BasicPoint2d(gx, gy),
+        lanelet::BasicPoint2d(gx + grid_size_x_, gy + grid_size_y_));
+
+      const auto lanelets = map.laneletLayer.search(cell_bbox);
+      const auto areas = map.areaLayer.search(cell_bbox);
+      const auto linestrings = map.lineStringLayer.search(cell_bbox);
+      const auto points = map.pointLayer.search(cell_bbox);
+
+      if (lanelets.empty() && areas.empty() && linestrings.empty() && points.empty()) {
+        continue;
+      }
+
+      lanelet::LaneletMapPtr cell_map(new lanelet::LaneletMap);
+      for (const auto & llt : lanelets) {
+        cell_map->add(llt);
+      }
+      for (const auto & area : areas) {
+        cell_map->add(area);
+      }
+      for (const auto & ls : linestrings) {
+        cell_map->add(ls);
+      }
+      for (const auto & pt : points) {
+        cell_map->add(pt);
+      }
+
+      const std::string file_name = make_file_name(gx, gy);
+      const std::string out_path = cell_dir + "/" + file_name;
+      lanelet::write(out_path, *cell_map, projector);
+      RCLCPP_INFO(
+        logger_, "Saved cell [%d, %d] -> %s (lanelets=%zu, areas=%zu, linestrings=%zu, points=%zu)",
+        gx, gy, out_path.c_str(), lanelets.size(), areas.size(), linestrings.size(), points.size());
+
+      out_cells.emplace_back(file_name, gx, gy);
+    }
+  }
+}
+
+void Lanelet2MapDivider::write_metadata(
+  const std::string & yaml_path,
+  const std::vector<std::tuple<std::string, int, int>> & cells) const
+{
+  std::ofstream file(yaml_path);
+  if (!file.is_open()) {
+    RCLCPP_ERROR(logger_, "Cannot open metadata file: %s", yaml_path.c_str());
+    return;
+  }
+
+  file << "x_resolution: " << grid_size_x_ << "\n";
+  file << "y_resolution: " << grid_size_y_ << "\n";
+  for (const auto & cell : cells) {
+    const auto & [file_name, gx, gy] = cell;
+    file << file_name << ": [" << gx << ", " << gy << "]\n";
+  }
+  RCLCPP_INFO(logger_, "Saved metadata: %s", yaml_path.c_str());
+}
+
+void Lanelet2MapDivider::run()
+{
+  if (!is_osm_file(input_lanelet2_map_)) {
+    RCLCPP_ERROR(
+      logger_,
+      "Input must be a single .osm file: %s. "
+      "If your map is split across multiple files, merge them first with "
+      "autoware_lanelet2_map_merger.",
+      input_lanelet2_map_.c_str());
+    return;
+  }
+  RCLCPP_INFO(logger_, "Input Lanelet2 map file: %s", input_lanelet2_map_.c_str());
+
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  try {
+    projector_info =
+      autoware::map_projection_loader::load_info_from_yaml(map_projector_info_path_);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      logger_, "Failed to load map projector info from %s: %s", map_projector_info_path_.c_str(),
+      e.what());
+    return;
+  }
+  RCLCPP_INFO(logger_, "Projector type: %s", projector_info.projector_type.c_str());
+
+  std::unique_ptr<lanelet::Projector> projector;
+  try {
+    projector = create_projector(projector_info);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(logger_, "Failed to create projector: %s", e.what());
+    return;
+  }
+
+  lanelet::LaneletMapPtr map = load_map(input_lanelet2_map_, projector_info, *projector);
+  if (!map) {
+    RCLCPP_ERROR(logger_, "Failed to load Lanelet2 map: %s", input_lanelet2_map_.c_str());
+    return;
+  }
+
+  const std::string cell_dir = output_dir_ + "/lanelet2_map.osm";
+  prepare_output_directory(cell_dir);
+
+  std::vector<std::tuple<std::string, int, int>> cells;
+  divide_and_save(*map, *projector, cell_dir, cells);
+
+  const std::string yaml_path = output_dir_ + "/lanelet2_map_metadata.yaml";
+  write_metadata(yaml_path, cells);
+
+  RCLCPP_INFO(logger_, "Saved %zu cells to %s", cells.size(), cell_dir.c_str());
+}
+
+}  // namespace autoware::lanelet2_map_divider

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
@@ -63,8 +63,7 @@ std::unique_ptr<lanelet::Projector> Lanelet2MapDivider::create_projector(
 }
 
 lanelet::LaneletMapPtr Lanelet2MapDivider::load_map(
-  const std::string & osm_file,
-  const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
+  const std::string & osm_file, const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
   lanelet::Projector & projector) const
 {
   lanelet::ErrorMessages errors;
@@ -141,14 +140,10 @@ void Lanelet2MapDivider::divide_and_save(
     max_y = std::max(max_y, pt.y());
   }
 
-  const auto gx_start =
-    static_cast<int>(std::floor(min_x / grid_size_x_) * grid_size_x_);
-  const auto gy_start =
-    static_cast<int>(std::floor(min_y / grid_size_y_) * grid_size_y_);
-  const auto gx_end =
-    static_cast<int>(std::floor(max_x / grid_size_x_) * grid_size_x_);
-  const auto gy_end =
-    static_cast<int>(std::floor(max_y / grid_size_y_) * grid_size_y_);
+  const auto gx_start = static_cast<int>(std::floor(min_x / grid_size_x_) * grid_size_x_);
+  const auto gy_start = static_cast<int>(std::floor(min_y / grid_size_y_) * grid_size_y_);
+  const auto gx_end = static_cast<int>(std::floor(max_x / grid_size_x_) * grid_size_x_);
+  const auto gy_end = static_cast<int>(std::floor(max_y / grid_size_y_) * grid_size_y_);
 
   RCLCPP_INFO(
     logger_, "Map bounding box: [%.3f, %.3f] to [%.3f, %.3f]", min_x, min_y, max_x, max_y);
@@ -162,8 +157,7 @@ void Lanelet2MapDivider::divide_and_save(
   for (int gx = gx_start; gx <= gx_end; gx += step_x) {
     for (int gy = gy_start; gy <= gy_end; gy += step_y) {
       const lanelet::BoundingBox2d cell_bbox(
-        lanelet::BasicPoint2d(gx, gy),
-        lanelet::BasicPoint2d(gx + grid_size_x_, gy + grid_size_y_));
+        lanelet::BasicPoint2d(gx, gy), lanelet::BasicPoint2d(gx + grid_size_x_, gy + grid_size_y_));
 
       const auto lanelets = map.laneletLayer.search(cell_bbox);
       const auto areas = map.areaLayer.search(cell_bbox);
@@ -201,8 +195,7 @@ void Lanelet2MapDivider::divide_and_save(
 }
 
 void Lanelet2MapDivider::write_metadata(
-  const std::string & yaml_path,
-  const std::vector<std::tuple<std::string, int, int>> & cells) const
+  const std::string & yaml_path, const std::vector<std::tuple<std::string, int, int>> & cells) const
 {
   std::ofstream file(yaml_path);
   if (!file.is_open()) {
@@ -234,8 +227,7 @@ void Lanelet2MapDivider::run()
 
   autoware_map_msgs::msg::MapProjectorInfo projector_info;
   try {
-    projector_info =
-      autoware::map_projection_loader::load_info_from_yaml(map_projector_info_path_);
+    projector_info = autoware::map_projection_loader::load_info_from_yaml(map_projector_info_path_);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(
       logger_, "Failed to load map projector info from %s: %s", map_projector_info_path_.c_str(),

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
@@ -209,8 +209,7 @@ void Lanelet2MapDivider::run()
   // Grid sizes below 1.0 truncate to a step of 0 in divide_and_save's int-cast loop,
   // which would spin forever.
   if (grid_size_x_ < 1.0 || grid_size_y_ < 1.0) {
-    RCLCPP_ERROR(
-      logger_, "Grid size must be >= 1.0 (got x=%f, y=%f).", grid_size_x_, grid_size_y_);
+    RCLCPP_ERROR(logger_, "Grid size must be >= 1.0 (got x=%f, y=%f).", grid_size_x_, grid_size_y_);
     return;
   }
 

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.cpp
@@ -214,6 +214,12 @@ void Lanelet2MapDivider::write_metadata(
 
 void Lanelet2MapDivider::run()
 {
+  if (grid_size_x_ < 1.0 || grid_size_y_ < 1.0) {
+    RCLCPP_ERROR(
+      logger_, "Grid size must be >= 1.0 (got x=%f, y=%f).", grid_size_x_, grid_size_y_);
+    return;
+  }
+
   if (!is_osm_file(input_lanelet2_map_)) {
     RCLCPP_ERROR(
       logger_,

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.hpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.hpp
@@ -1,0 +1,76 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_DIVIDER_HPP_
+#define LANELET2_MAP_DIVIDER_HPP_
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_io/Projection.h>
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace autoware::lanelet2_map_divider
+{
+
+class Lanelet2MapDivider
+{
+public:
+  explicit Lanelet2MapDivider(const rclcpp::Logger & logger) : logger_(logger) {}
+
+  void set_input(const std::string & input_lanelet2_map) { input_lanelet2_map_ = input_lanelet2_map; }
+  void set_output_dir(const std::string & output_dir) { output_dir_ = output_dir; }
+  void set_prefix(const std::string & prefix) { prefix_ = prefix; }
+  void set_grid_size(double grid_size_x, double grid_size_y)
+  {
+    grid_size_x_ = grid_size_x;
+    grid_size_y_ = grid_size_y;
+  }
+  void set_map_projector_info_path(const std::string & path) { map_projector_info_path_ = path; }
+
+  void run();
+
+private:
+  std::unique_ptr<lanelet::Projector> create_projector(
+    const autoware_map_msgs::msg::MapProjectorInfo & projector_info) const;
+  lanelet::LaneletMapPtr load_map(
+    const std::string & osm_file,
+    const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
+    lanelet::Projector & projector) const;
+  void prepare_output_directory(const std::string & cell_dir) const;
+  std::string make_file_name(int gx, int gy) const;
+  void divide_and_save(
+    lanelet::LaneletMap & map, lanelet::Projector & projector, const std::string & cell_dir,
+    std::vector<std::tuple<std::string, int, int>> & out_cells) const;
+  void write_metadata(
+    const std::string & yaml_path,
+    const std::vector<std::tuple<std::string, int, int>> & cells) const;
+
+  std::string input_lanelet2_map_;
+  std::string output_dir_;
+  std::string prefix_;
+  std::string map_projector_info_path_;
+  double grid_size_x_ = 100.0;
+  double grid_size_y_ = 100.0;
+  rclcpp::Logger logger_;
+};
+
+}  // namespace autoware::lanelet2_map_divider
+
+#endif  // LANELET2_MAP_DIVIDER_HPP_

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.hpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.hpp
@@ -15,8 +15,9 @@
 #ifndef LANELET2_MAP_DIVIDER_HPP_
 #define LANELET2_MAP_DIVIDER_HPP_
 
-#include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_io/Projection.h>
@@ -34,7 +35,10 @@ class Lanelet2MapDivider
 public:
   explicit Lanelet2MapDivider(const rclcpp::Logger & logger) : logger_(logger) {}
 
-  void set_input(const std::string & input_lanelet2_map) { input_lanelet2_map_ = input_lanelet2_map; }
+  void set_input(const std::string & input_lanelet2_map)
+  {
+    input_lanelet2_map_ = input_lanelet2_map;
+  }
   void set_output_dir(const std::string & output_dir) { output_dir_ = output_dir; }
   void set_prefix(const std::string & prefix) { prefix_ = prefix; }
   void set_grid_size(double grid_size_x, double grid_size_y)
@@ -50,8 +54,7 @@ private:
   std::unique_ptr<lanelet::Projector> create_projector(
     const autoware_map_msgs::msg::MapProjectorInfo & projector_info) const;
   lanelet::LaneletMapPtr load_map(
-    const std::string & osm_file,
-    const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
+    const std::string & osm_file, const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
     lanelet::Projector & projector) const;
   void prepare_output_directory(const std::string & cell_dir) const;
   std::string make_file_name(int gx, int gy) const;

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.hpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider.hpp
@@ -56,7 +56,6 @@ private:
   lanelet::LaneletMapPtr load_map(
     const std::string & osm_file, const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
     lanelet::Projector & projector) const;
-  void prepare_output_directory(const std::string & cell_dir) const;
   std::string make_file_name(int gx, int gy) const;
   void divide_and_save(
     lanelet::LaneletMap & map, lanelet::Projector & projector, const std::string & cell_dir,

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider_node.cpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider_node.cpp
@@ -1,0 +1,64 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_divider_node.hpp"
+
+#include "lanelet2_map_divider.hpp"
+
+#include <sstream>
+#include <string>
+
+namespace autoware::lanelet2_map_divider
+{
+
+Lanelet2MapDividerNode::Lanelet2MapDividerNode(const rclcpp::NodeOptions & node_options)
+: Node("lanelet2_map_divider", node_options)
+{
+  const double grid_size_x = declare_parameter<double>("grid_size_x");
+  const double grid_size_y = declare_parameter<double>("grid_size_y");
+  const std::string input_lanelet2_map = declare_parameter<std::string>("input_lanelet2_map");
+  const std::string output_lanelet2_map_dir =
+    declare_parameter<std::string>("output_lanelet2_map_dir");
+  const std::string map_projector_info_path =
+    declare_parameter<std::string>("map_projector_info_path");
+  const std::string prefix = declare_parameter<std::string>("prefix");
+
+  std::ostringstream oss;
+  oss << "\n########## Input Parameters ##########\n"
+      << "\tgrid_size_x: " << grid_size_x << "\n"
+      << "\tgrid_size_y: " << grid_size_y << "\n"
+      << "\tinput_lanelet2_map: " << input_lanelet2_map << "\n"
+      << "\toutput_lanelet2_map_dir: " << output_lanelet2_map_dir << "\n"
+      << "\tmap_projector_info_path: " << map_projector_info_path << "\n"
+      << "\tprefix: " << prefix << "\n"
+      << "######################################";
+  RCLCPP_INFO(get_logger(), "%s", oss.str().c_str());
+
+  Lanelet2MapDivider divider(get_logger());
+  divider.set_grid_size(grid_size_x, grid_size_y);
+  divider.set_input(input_lanelet2_map);
+  divider.set_output_dir(output_lanelet2_map_dir);
+  divider.set_map_projector_info_path(map_projector_info_path);
+  divider.set_prefix(prefix);
+
+  divider.run();
+
+  rclcpp::shutdown();
+}
+
+}  // namespace autoware::lanelet2_map_divider
+
+#include <rclcpp_components/register_node_macro.hpp>
+
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::lanelet2_map_divider::Lanelet2MapDividerNode)

--- a/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider_node.hpp
+++ b/map/autoware_lanelet2_map_divider/src/lanelet2_map_divider_node.hpp
@@ -1,0 +1,31 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_DIVIDER_NODE_HPP_
+#define LANELET2_MAP_DIVIDER_NODE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::lanelet2_map_divider
+{
+
+class Lanelet2MapDividerNode : public rclcpp::Node
+{
+public:
+  explicit Lanelet2MapDividerNode(const rclcpp::NodeOptions & node_options);
+};
+
+}  // namespace autoware::lanelet2_map_divider
+
+#endif  // LANELET2_MAP_DIVIDER_NODE_HPP_

--- a/map/autoware_lanelet2_map_divider/src/local_projector.hpp
+++ b/map/autoware_lanelet2_map_divider/src/local_projector.hpp
@@ -1,0 +1,41 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LOCAL_PROJECTOR_HPP_
+#define LOCAL_PROJECTOR_HPP_
+
+#include <lanelet2_io/Projection.h>
+
+namespace autoware::lanelet2_map_divider
+{
+
+class LocalProjector : public lanelet::Projector
+{
+public:
+  LocalProjector() : Projector(lanelet::Origin(lanelet::GPSPoint{})) {}
+
+  lanelet::BasicPoint3d forward(const lanelet::GPSPoint & gps) const override  // NOLINT
+  {
+    return lanelet::BasicPoint3d{0.0, 0.0, gps.ele};
+  }
+
+  [[nodiscard]] lanelet::GPSPoint reverse(const lanelet::BasicPoint3d & point) const override
+  {
+    return lanelet::GPSPoint{0.0, 0.0, point.z()};
+  }
+};
+
+}  // namespace autoware::lanelet2_map_divider
+
+#endif  // LOCAL_PROJECTOR_HPP_

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -26,6 +26,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <cmath>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -133,9 +134,12 @@ class Lanelet2MapDividerTest : public ::testing::Test
 protected:
   void SetUp() override
   {
-    tmp_dir_ = fs::temp_directory_path() / "test_lanelet2_map_divider";
-    fs::remove_all(tmp_dir_);
-    fs::create_directories(tmp_dir_);
+    // mkdtemp atomically creates a uniquely-named directory so concurrent test
+    // runs (parallel runners, repeated invocations) cannot collide.
+    std::string tmpl = (fs::temp_directory_path() / "test_lanelet2_map_divider_XXXXXX").string();
+    std::vector<char> buf(tmpl.c_str(), tmpl.c_str() + tmpl.size() + 1);
+    ASSERT_NE(mkdtemp(buf.data()), nullptr);
+    tmp_dir_ = fs::path(buf.data());
   }
 
   void TearDown() override { fs::remove_all(tmp_dir_); }

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -27,6 +27,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -1,0 +1,324 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/lanelet2_map_divider.hpp"
+
+#include "../src/local_projector.hpp"
+
+#include <rclcpp/logger.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+#include <lanelet2_io/Io.h>
+#include <yaml-cpp/yaml.h>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+// Build a small LaneletMap with four lanelets arranged on a 2x2 grid of 10m cells.
+// Each point carries `local_x`/`local_y` attributes so that the LOCAL projector in the
+// divider can recover its original x/y values on load.
+lanelet::LaneletMapPtr make_sample_map()
+{
+  auto make_point = [](lanelet::Id id, double x, double y) {
+    lanelet::Point3d p(id, x, y, 0.0);
+    p.attributes()["local_x"] = std::to_string(x);
+    p.attributes()["local_y"] = std::to_string(y);
+    return p;
+  };
+
+  // Four 10m x 10m lanelets tiled at (0..20) x (0..20) so a 10m grid divider produces
+  // four cells: (0,0), (10,0), (0,10), (10,10).
+  struct Cell
+  {
+    lanelet::Id ll_id, left_id, right_id;
+    double x0, y0;  // lower-left corner
+  };
+  const std::vector<Cell> cells = {
+    {100, 10, 11, 0.0, 0.0},
+    {101, 12, 13, 10.0, 0.0},
+    {102, 14, 15, 0.0, 10.0},
+    {103, 16, 17, 10.0, 10.0},
+  };
+
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  lanelet::Id next_pt_id = 1;
+  for (const auto & c : cells) {
+    // Left border (bottom-left → top-left of cell)
+    auto pl1 = make_point(next_pt_id++, c.x0 + 1.0, c.y0 + 1.0);
+    auto pl2 = make_point(next_pt_id++, c.x0 + 1.0, c.y0 + 9.0);
+    lanelet::LineString3d left(c.left_id, {pl1, pl2});
+    left.attributes()["type"] = "line_thin";
+    left.attributes()["subtype"] = "solid";
+
+    // Right border (bottom-right → top-right)
+    auto pr1 = make_point(next_pt_id++, c.x0 + 9.0, c.y0 + 1.0);
+    auto pr2 = make_point(next_pt_id++, c.x0 + 9.0, c.y0 + 9.0);
+    lanelet::LineString3d right(c.right_id, {pr1, pr2});
+    right.attributes()["type"] = "line_thin";
+    right.attributes()["subtype"] = "solid";
+
+    lanelet::Lanelet llt(c.ll_id, left, right);
+    llt.attributes()["type"] = "lanelet";
+    llt.attributes()["subtype"] = "road";
+    llt.attributes()["location"] = "urban";
+    llt.attributes()["one_way"] = "yes";
+    map->add(llt);
+  }
+  return map;
+}
+
+std::string write_projector_info_local(const fs::path & dir)
+{
+  const auto path = dir / "map_projector_info.yaml";
+  std::ofstream(path) << "projector_type: Local\n";
+  return path.string();
+}
+
+std::string write_sample_osm(const fs::path & dir, const std::string & filename = "input.osm")
+{
+  const auto osm_path = (dir / filename).string();
+  auto map = make_sample_map();
+  autoware::lanelet2_map_divider::LocalProjector projector;
+  lanelet::write(osm_path, *map, projector);
+  return osm_path;
+}
+
+// Parse the output metadata YAML into a map: filename -> {min_x, min_y}.
+struct CellMeta
+{
+  double x;
+  double y;
+};
+std::map<std::string, CellMeta> parse_metadata(const std::string & yaml_path)
+{
+  std::map<std::string, CellMeta> out;
+  const YAML::Node root = YAML::LoadFile(yaml_path);
+  for (const auto & kv : root) {
+    const std::string key = kv.first.as<std::string>();
+    if (key == "x_resolution" || key == "y_resolution") continue;
+    out[key] = {kv.second[0].as<double>(), kv.second[1].as<double>()};
+  }
+  return out;
+}
+
+}  // namespace
+
+class Lanelet2MapDividerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    tmp_dir_ = fs::temp_directory_path() / "test_lanelet2_map_divider";
+    fs::remove_all(tmp_dir_);
+    fs::create_directories(tmp_dir_);
+  }
+
+  void TearDown() override { fs::remove_all(tmp_dir_); }
+
+  fs::path tmp_dir_;
+};
+
+TEST_F(Lanelet2MapDividerTest, SingleFileInputProducesFourCells)
+{
+  const auto input_osm = write_sample_osm(tmp_dir_);
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input(input_osm);
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(10.0, 10.0);
+  divider.set_prefix("");
+  divider.run();
+
+  // Cell directory and four .osm files must exist.
+  const auto cell_dir = fs::path(output_dir) / "lanelet2_map.osm";
+  ASSERT_TRUE(fs::exists(cell_dir));
+
+  std::set<std::string> cell_files;
+  for (const auto & e : fs::directory_iterator(cell_dir)) {
+    cell_files.insert(e.path().filename().string());
+  }
+  EXPECT_EQ(cell_files.size(), 4u);
+  EXPECT_TRUE(cell_files.count("0_0.osm"));
+  EXPECT_TRUE(cell_files.count("10_0.osm"));
+  EXPECT_TRUE(cell_files.count("0_10.osm"));
+  EXPECT_TRUE(cell_files.count("10_10.osm"));
+}
+
+TEST_F(Lanelet2MapDividerTest, MetadataYamlMatchesOutputFiles)
+{
+  const auto input_osm = write_sample_osm(tmp_dir_);
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input(input_osm);
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(10.0, 10.0);
+  divider.set_prefix("");
+  divider.run();
+
+  const auto metadata_path = (fs::path(output_dir) / "lanelet2_map_metadata.yaml").string();
+  ASSERT_TRUE(fs::exists(metadata_path));
+
+  const YAML::Node root = YAML::LoadFile(metadata_path);
+  EXPECT_DOUBLE_EQ(root["x_resolution"].as<double>(), 10.0);
+  EXPECT_DOUBLE_EQ(root["y_resolution"].as<double>(), 10.0);
+
+  const auto cells = parse_metadata(metadata_path);
+  ASSERT_EQ(cells.size(), 4u);
+  EXPECT_DOUBLE_EQ(cells.at("0_0.osm").x, 0.0);
+  EXPECT_DOUBLE_EQ(cells.at("0_0.osm").y, 0.0);
+  EXPECT_DOUBLE_EQ(cells.at("10_0.osm").x, 10.0);
+  EXPECT_DOUBLE_EQ(cells.at("10_0.osm").y, 0.0);
+  EXPECT_DOUBLE_EQ(cells.at("0_10.osm").x, 0.0);
+  EXPECT_DOUBLE_EQ(cells.at("0_10.osm").y, 10.0);
+  EXPECT_DOUBLE_EQ(cells.at("10_10.osm").x, 10.0);
+  EXPECT_DOUBLE_EQ(cells.at("10_10.osm").y, 10.0);
+}
+
+TEST_F(Lanelet2MapDividerTest, PrefixIsAppliedToOutputFilenames)
+{
+  const auto input_osm = write_sample_osm(tmp_dir_);
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input(input_osm);
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(10.0, 10.0);
+  divider.set_prefix("tile");
+  divider.run();
+
+  const auto cell_dir = fs::path(output_dir) / "lanelet2_map.osm";
+  std::set<std::string> cell_files;
+  for (const auto & e : fs::directory_iterator(cell_dir)) {
+    cell_files.insert(e.path().filename().string());
+  }
+  EXPECT_EQ(cell_files.size(), 4u);
+  EXPECT_TRUE(cell_files.count("tile_0_0.osm"));
+  EXPECT_TRUE(cell_files.count("tile_10_0.osm"));
+  EXPECT_TRUE(cell_files.count("tile_0_10.osm"));
+  EXPECT_TRUE(cell_files.count("tile_10_10.osm"));
+}
+
+TEST_F(Lanelet2MapDividerTest, GridIsCoordinateAligned)
+{
+  // A 10m grid applied to a map with points starting at x=1,y=1 should still emit
+  // the (0,0) cell, not a (1,1) cell. This is the defining property of coord-aligned
+  // indices.
+  const auto input_osm = write_sample_osm(tmp_dir_);
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input(input_osm);
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(10.0, 10.0);
+  divider.run();
+
+  const auto metadata_path = (fs::path(output_dir) / "lanelet2_map_metadata.yaml").string();
+  const auto cells = parse_metadata(metadata_path);
+
+  // Every cell's min_x and min_y must be an exact multiple of the grid size.
+  for (const auto & [name, c] : cells) {
+    EXPECT_DOUBLE_EQ(std::fmod(c.x, 10.0), 0.0) << name;
+    EXPECT_DOUBLE_EQ(std::fmod(c.y, 10.0), 0.0) << name;
+  }
+}
+
+TEST_F(Lanelet2MapDividerTest, LargeGridSizeProducesSingleCell)
+{
+  const auto input_osm = write_sample_osm(tmp_dir_);
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  // With a 100m grid, all points (in 0..20) fall into the single (0,0) cell.
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input(input_osm);
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(100.0, 100.0);
+  divider.run();
+
+  const auto cell_dir = fs::path(output_dir) / "lanelet2_map.osm";
+  std::vector<std::string> files;
+  for (const auto & e : fs::directory_iterator(cell_dir)) {
+    files.push_back(e.path().filename().string());
+  }
+  ASSERT_EQ(files.size(), 1u);
+  EXPECT_EQ(files.front(), "0_0.osm");
+}
+
+TEST_F(Lanelet2MapDividerTest, DirectoryInputIsRejected)
+{
+  // Users with a split map are expected to merge it first; the divider only
+  // accepts a single .osm file.
+  const fs::path input_dir = tmp_dir_ / "input_dir";
+  fs::create_directories(input_dir);
+  auto map = make_sample_map();
+  autoware::lanelet2_map_divider::LocalProjector projector;
+  lanelet::write((input_dir / "a.osm").string(), *map, projector);
+
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input(input_dir.string());
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(10.0, 10.0);
+
+  EXPECT_NO_THROW(divider.run());
+  EXPECT_FALSE(fs::exists(output_dir));
+}
+
+TEST_F(Lanelet2MapDividerTest, NonExistentInputDoesNotCrash)
+{
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_dir = (tmp_dir_ / "out").string();
+
+  autoware::lanelet2_map_divider::Lanelet2MapDivider divider(rclcpp::get_logger("test"));
+  divider.set_input((tmp_dir_ / "does_not_exist.osm").string());
+  divider.set_output_dir(output_dir);
+  divider.set_map_projector_info_path(projector_info);
+  divider.set_grid_size(10.0, 10.0);
+
+  // Should log errors and return without throwing.
+  EXPECT_NO_THROW(divider.run());
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -136,8 +136,10 @@ protected:
   {
     // mkdtemp atomically creates a uniquely-named directory so concurrent test
     // runs (parallel runners, repeated invocations) cannot collide.
-    std::string tmp_dir_template = (fs::temp_directory_path() / "test_lanelet2_map_divider_XXXXXX").string();
-    std::vector<char> buf(tmp_dir_template.c_str(), tmp_dir_template.c_str() + tmp_dir_template.size() + 1);
+    std::string tmp_dir_template =
+      (fs::temp_directory_path() / "test_lanelet2_map_divider_XXXXXX").string();
+    std::vector<char> buf(
+      tmp_dir_template.c_str(), tmp_dir_template.c_str() + tmp_dir_template.size() + 1);
     ASSERT_NE(mkdtemp(buf.data()), nullptr);
     tmp_dir_ = fs::path(buf.data());
   }

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -25,6 +25,7 @@
 #include <lanelet2_io/Io.h>
 #include <yaml-cpp/yaml.h>
 
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <map>

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -136,8 +136,8 @@ protected:
   {
     // mkdtemp atomically creates a uniquely-named directory so concurrent test
     // runs (parallel runners, repeated invocations) cannot collide.
-    std::string tmpl = (fs::temp_directory_path() / "test_lanelet2_map_divider_XXXXXX").string();
-    std::vector<char> buf(tmpl.c_str(), tmpl.c_str() + tmpl.size() + 1);
+    std::string tmp_dir_template = (fs::temp_directory_path() / "test_lanelet2_map_divider_XXXXXX").string();
+    std::vector<char> buf(tmp_dir_template.c_str(), tmp_dir_template.c_str() + tmp_dir_template.size() + 1);
     ASSERT_NE(mkdtemp(buf.data()), nullptr);
     tmp_dir_ = fs::path(buf.data());
   }

--- a/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
+++ b/map/autoware_lanelet2_map_divider/test/test_lanelet2_map_divider.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "../src/lanelet2_map_divider.hpp"
-
 #include "../src/local_projector.hpp"
 
 #include <rclcpp/logger.hpp>


### PR DESCRIPTION
## Description

This is part of https://github.com/autowarefoundation/autoware_core/issues/887

Add a new `autoware_lanelet2_map_divider` package that splits a single Lanelet2 (`.osm`) map into grid-aligned segments and emits a metadata file compatible with `lanelet2_map_loader`'s selected-map-loading mode.

- New ROS 2 node `autoware_lanelet2_map_divider_node` with a launch file
- Loads the input map using the projector from `map_projector_info.yaml` (`MGRS`, `LocalCartesianUTM`, `LocalCartesian`, `TransverseMercator`, and `Local` supported), computes the axis-aligned bounding box of all points, and queries `laneletLayer`, `areaLayer`, `lineStringLayer`, and `pointLayer` per cell to build per-cell `LaneletMap`s.
- Writes one `<prefix>_<gx>_<gy>.osm` file per non-empty cell under `<OUTPUT_DIR>/lanelet2_map.osm/` with the same projector used at load time, plus `lanelet2_map_metadata.yaml` (`x_resolution`, `y_resolution`, and `file: [min_x, min_y]` entries).
- Includes README and a gtest suite (`test_lanelet2_map_divider`).

## How was this PR tested?

- Built the package with `colcon build --packages-select autoware_lanelet2_map_divider`.
- Ran the included gtest suite (`test_lanelet2_map_divider`) via `colcon test`.
- Verified end-to-end by running the divider on a sample `lanelet2_map.osm`, inspecting the generated `lanelet2_map.osm/<gx>_<gy>.osm` files and `lanelet2_map_metadata.yaml`, and confirming `lanelet2_map_loader` can consume the output in selected-map-loading mode.

## Notes for reviewers

None.

## Effects on system behavior

None.