### PR TITLE
feat: add autoware_lanelet2_map_merger package

### DIFF
--- a/map/autoware_lanelet2_map_merger/CMakeLists.txt
+++ b/map/autoware_lanelet2_map_merger/CMakeLists.txt
@@ -17,6 +17,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gtest(test_lanelet2_map_merger test/test_lanelet2_map_merger.cpp)

--- a/map/autoware_lanelet2_map_merger/CMakeLists.txt
+++ b/map/autoware_lanelet2_map_merger/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_lanelet2_map_merger)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/lanelet2_map_merger.cpp
+  src/lanelet2_map_merger_node.cpp
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::lanelet2_map_merger::Lanelet2MapMergerNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_lanelet2_map_merger test/test_lanelet2_map_merger.cpp)
+  target_link_libraries(test_lanelet2_map_merger ${PROJECT_NAME})
+endif()
+
+ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/map/autoware_lanelet2_map_merger/README.md
+++ b/map/autoware_lanelet2_map_merger/README.md
@@ -1,0 +1,75 @@
+# autoware_lanelet2_map_merger
+
+This is a tool for processing Lanelet2 (`.osm`) map files. It can perform the following
+function:
+
+- Merging multiple divided `.osm` files into a single `.osm` file
+
+It is the inverse of
+[`autoware_lanelet2_map_divider`](../autoware_lanelet2_map_divider/README.md).
+
+## Supported Data Format
+
+- Input: a directory containing `.osm` files (typically the `lanelet2_map.osm/`
+  directory produced by `autoware_lanelet2_map_divider`).
+- Output: a single merged `.osm` file.
+
+The projection required to load/save the maps is obtained from a
+`map_projector_info.yaml` file (identical to the one consumed by
+`autoware_map_projection_loader`). `MGRS`, `LocalCartesianUTM`, `LocalCartesian`,
+and `TransverseMercator` are supported.
+
+## Usage
+
+```bash
+ros2 launch autoware_lanelet2_map_merger lanelet2_map_merger.launch.xml \
+  input_lanelet2_map_dir:=<INPUT_DIR> \
+  output_lanelet2_map:=<OUTPUT_OSM> \
+  map_projector_info_path:=<PROJECTOR_YAML>
+```
+
+| Name                  | Description                                                       |
+| --------------------- | ----------------------------------------------------------------- |
+| INPUT_DIR             | Directory containing the input `.osm` files                       |
+| OUTPUT_OSM            | Path of the output merged `.osm` file                             |
+| PROJECTOR_YAML        | Path to `map_projector_info.yaml`                                 |
+
+`INPUT_DIR`, `OUTPUT_OSM`, and `PROJECTOR_YAML` should be specified as **absolute paths**.
+
+## Parameters
+
+{{ json_to_markdown("map/autoware_lanelet2_map_merger/schema/lanelet2_map_merger.schema.json") }}
+
+## How the maps are merged
+
+1. Discover every `.osm` file inside the input directory.
+2. Load each map using the projector from `map_projector_info.yaml`.
+3. Merge all loaded maps into a single `LaneletMap` using the same logic as
+   `lanelet2_map_loader` (`merge_lanelet2_maps`): lanelets, areas, regulatory
+   elements, line strings, polygons, and points are all copied, and points shared
+   between maps (same ID) are deduplicated so that successor/predecessor
+   relationships are preserved.
+4. Write the merged map with `lanelet::write` using the same projector.
+
+## Relation to `autoware_lanelet2_map_divider`
+
+Running the merger on the output of the divider reconstructs the original map.
+For example:
+
+```bash
+# divide
+ros2 launch autoware_lanelet2_map_divider lanelet2_map_divider.launch.xml \
+  input_lanelet2_map:=/map/lanelet2_map.osm \
+  output_lanelet2_map_dir:=/map_divided \
+  map_projector_info_path:=/map/map_projector_info.yaml
+
+# merge back
+ros2 launch autoware_lanelet2_map_merger lanelet2_map_merger.launch.xml \
+  input_lanelet2_map_dir:=/map_divided/lanelet2_map.osm \
+  output_lanelet2_map:=/map/lanelet2_map_merged.osm \
+  map_projector_info_path:=/map/map_projector_info.yaml
+```
+
+## LICENSE
+
+Apache License 2.0.

--- a/map/autoware_lanelet2_map_merger/README.md
+++ b/map/autoware_lanelet2_map_merger/README.md
@@ -28,11 +28,11 @@ ros2 launch autoware_lanelet2_map_merger lanelet2_map_merger.launch.xml \
   map_projector_info_path:=<PROJECTOR_YAML>
 ```
 
-| Name                  | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| INPUT_DIR             | Directory containing the input `.osm` files                       |
-| OUTPUT_OSM            | Path of the output merged `.osm` file                             |
-| PROJECTOR_YAML        | Path to `map_projector_info.yaml`                                 |
+| Name           | Description                                 |
+| -------------- | ------------------------------------------- |
+| INPUT_DIR      | Directory containing the input `.osm` files |
+| OUTPUT_OSM     | Path of the output merged `.osm` file       |
+| PROJECTOR_YAML | Path to `map_projector_info.yaml`           |
 
 `INPUT_DIR`, `OUTPUT_OSM`, and `PROJECTOR_YAML` should be specified as **absolute paths**.
 

--- a/map/autoware_lanelet2_map_merger/config/lanelet2_map_merger.param.yaml
+++ b/map/autoware_lanelet2_map_merger/config/lanelet2_map_merger.param.yaml
@@ -1,0 +1,5 @@
+/**:
+  ros__parameters:
+    input_lanelet2_map_dir: "$(var input_lanelet2_map_dir)"
+    output_lanelet2_map: "$(var output_lanelet2_map)"
+    map_projector_info_path: "$(var map_projector_info_path)"

--- a/map/autoware_lanelet2_map_merger/launch/lanelet2_map_merger.launch.xml
+++ b/map/autoware_lanelet2_map_merger/launch/lanelet2_map_merger.launch.xml
@@ -1,0 +1,15 @@
+<launch>
+  <arg name="config_file_path" default="$(find-pkg-share autoware_lanelet2_map_merger)/config/lanelet2_map_merger.param.yaml" description="Path to the configuration YAML file"/>
+  <arg name="input_lanelet2_map_dir" description="Directory containing the input .osm files"/>
+  <arg name="output_lanelet2_map" description="Path of the output merged .osm file"/>
+  <arg name="map_projector_info_path" description="Path to the map_projector_info.yaml file"/>
+
+  <group>
+    <node pkg="autoware_lanelet2_map_merger" exec="autoware_lanelet2_map_merger_node" name="lanelet2_map_merger" output="screen">
+      <param from="$(var config_file_path)" allow_substs="true"/>
+      <param name="input_lanelet2_map_dir" value="$(var input_lanelet2_map_dir)"/>
+      <param name="output_lanelet2_map" value="$(var output_lanelet2_map)"/>
+      <param name="map_projector_info_path" value="$(var map_projector_info_path)"/>
+    </node>
+  </group>
+</launch>

--- a/map/autoware_lanelet2_map_merger/package.xml
+++ b/map/autoware_lanelet2_map_merger/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_lanelet2_map_merger</name>
+  <version>0.6.0</version>
+  <description>A package for merging divided Lanelet2 (.osm) map files into a single .osm file</description>
+  <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_geography_utils</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_map_projection_loader</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
+  <exec_depend>ros2launch</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/map/autoware_lanelet2_map_merger/schema/lanelet2_map_merger.schema.json
+++ b/map/autoware_lanelet2_map_merger/schema/lanelet2_map_merger.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for autoware lanelet2 map merger node",
+  "type": "object",
+  "definitions": {
+    "autoware_lanelet2_map_merger": {
+      "type": "object",
+      "properties": {
+        "input_lanelet2_map_dir": {
+          "type": "string",
+          "description": "Path to the directory containing the input .osm files",
+          "default": ""
+        },
+        "output_lanelet2_map": {
+          "type": "string",
+          "description": "Path to the merged output .osm file",
+          "default": ""
+        },
+        "map_projector_info_path": {
+          "type": "string",
+          "description": "Path to the map_projector_info.yaml file",
+          "default": ""
+        }
+      },
+      "required": ["input_lanelet2_map_dir", "output_lanelet2_map", "map_projector_info_path"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/autoware_lanelet2_map_merger"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.cpp
@@ -98,7 +98,7 @@ lanelet::LaneletMapPtr Lanelet2MapMerger::load_and_merge_maps(
     }
 
     if (is_local) {
-      for (lanelet::Point3d point : map->pointLayer) {
+      for (lanelet::Point3d & point : map->pointLayer) {
         if (point.hasAttribute("local_x")) {
           point.x() = point.attribute("local_x").asDouble().value();
         }

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.cpp
@@ -79,8 +79,7 @@ std::unique_ptr<lanelet::Projector> Lanelet2MapMerger::create_projector(
 
 lanelet::LaneletMapPtr Lanelet2MapMerger::load_and_merge_maps(
   const std::vector<std::string> & osm_files,
-  const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
-  lanelet::Projector & projector)
+  const autoware_map_msgs::msg::MapProjectorInfo & projector_info, lanelet::Projector & projector)
 {
   auto merged = std::make_shared<lanelet::LaneletMap>();
 
@@ -90,8 +89,7 @@ lanelet::LaneletMapPtr Lanelet2MapMerger::load_and_merge_maps(
   for (const auto & path : osm_files) {
     RCLCPP_INFO(logger_, "Loading %s", path.c_str());
     lanelet::ErrorMessages errors;
-    lanelet::LaneletMapPtr map =
-      lanelet::load(path, "autoware_osm_handler", projector, &errors);
+    lanelet::LaneletMapPtr map = lanelet::load(path, "autoware_osm_handler", projector, &errors);
     for (const auto & error : errors) {
       RCLCPP_ERROR(logger_, "Error loading %s: %s", path.c_str(), error.c_str());
     }
@@ -156,8 +154,7 @@ void Lanelet2MapMerger::run()
 
   autoware_map_msgs::msg::MapProjectorInfo projector_info;
   try {
-    projector_info =
-      autoware::map_projection_loader::load_info_from_yaml(map_projector_info_path_);
+    projector_info = autoware::map_projection_loader::load_info_from_yaml(map_projector_info_path_);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(
       logger_, "Failed to load map projector info from %s: %s", map_projector_info_path_.c_str(),

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.cpp
@@ -1,0 +1,195 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_merger.hpp"
+
+#include "local_projector.hpp"
+
+#include <autoware/geography_utils/lanelet2_projector.hpp>
+#include <autoware/map_projection_loader/map_projection_loader.hpp>
+#include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
+
+#include <lanelet2_io/Io.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace autoware::lanelet2_map_merger
+{
+
+namespace
+{
+
+bool is_osm_file(const fs::path & path)
+{
+  if (fs::is_directory(path)) {
+    return false;
+  }
+  const std::string ext = path.extension().string();
+  return ext == ".osm" || ext == ".OSM";
+}
+
+}  // namespace
+
+std::vector<std::string> Lanelet2MapMerger::discover_osm_files(const std::string & input_dir) const
+{
+  std::vector<std::string> osm_files;
+  fs::path input_path(input_dir);
+
+  if (!fs::exists(input_path) || !fs::is_directory(input_path)) {
+    RCLCPP_ERROR(logger_, "Input is not a valid directory: %s", input_dir.c_str());
+    return osm_files;
+  }
+
+  for (const auto & entry : fs::directory_iterator(input_path)) {
+    if (is_osm_file(entry.path())) {
+      osm_files.push_back(entry.path().string());
+    }
+  }
+  std::sort(osm_files.begin(), osm_files.end());
+
+  RCLCPP_INFO(logger_, "Found %zu .osm files in %s", osm_files.size(), input_dir.c_str());
+  return osm_files;
+}
+
+std::unique_ptr<lanelet::Projector> Lanelet2MapMerger::create_projector(
+  const autoware_map_msgs::msg::MapProjectorInfo & projector_info) const
+{
+  if (projector_info.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL) {
+    return std::make_unique<LocalProjector>();
+  }
+  return autoware::geography_utils::get_lanelet2_projector(projector_info);
+}
+
+lanelet::LaneletMapPtr Lanelet2MapMerger::load_and_merge_maps(
+  const std::vector<std::string> & osm_files,
+  const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
+  lanelet::Projector & projector)
+{
+  auto merged = std::make_shared<lanelet::LaneletMap>();
+
+  const bool is_local =
+    projector_info.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL;
+
+  for (const auto & path : osm_files) {
+    RCLCPP_INFO(logger_, "Loading %s", path.c_str());
+    lanelet::ErrorMessages errors;
+    lanelet::LaneletMapPtr map =
+      lanelet::load(path, "autoware_osm_handler", projector, &errors);
+    for (const auto & error : errors) {
+      RCLCPP_ERROR(logger_, "Error loading %s: %s", path.c_str(), error.c_str());
+    }
+    if (!errors.empty() || !map) {
+      return nullptr;
+    }
+
+    if (is_local) {
+      for (lanelet::Point3d point : map->pointLayer) {
+        if (point.hasAttribute("local_x")) {
+          point.x() = point.attribute("local_x").asDouble().value();
+        }
+        if (point.hasAttribute("local_y")) {
+          point.y() = point.attribute("local_y").asDouble().value();
+        }
+      }
+    }
+
+    // Merge with deduplication of shared points (same id), matching
+    // lanelet2_map_loader's merge_lanelet2_maps behavior.
+    for (lanelet::Lanelet & llt : map->laneletLayer) {
+      merged->add(llt);
+    }
+    for (lanelet::Area & area : map->areaLayer) {
+      merged->add(area);
+    }
+    for (lanelet::RegulatoryElementPtr & reg : map->regulatoryElementLayer) {
+      merged->add(reg);
+    }
+    for (lanelet::LineString3d & ls : map->lineStringLayer) {
+      for (lanelet::Point3d & pt : ls) {
+        if (merged->pointLayer.find(pt.id()) != merged->pointLayer.end()) {
+          pt = merged->pointLayer.get(pt.id());
+        }
+      }
+      merged->add(ls);
+    }
+    for (lanelet::Polygon3d & poly : map->polygonLayer) {
+      merged->add(poly);
+    }
+    for (lanelet::Point3d & pt : map->pointLayer) {
+      if (merged->pointLayer.find(pt.id()) == merged->pointLayer.end()) {
+        merged->add(pt);
+      }
+    }
+
+    // Keep the source map alive so weak references from regulatory elements
+    // (e.g., parameters referencing other lanelets/linestrings) do not expire.
+    loaded_maps_.push_back(map);
+  }
+
+  return merged;
+}
+
+void Lanelet2MapMerger::run()
+{
+  const auto osm_files = discover_osm_files(input_dir_);
+  if (osm_files.empty()) {
+    RCLCPP_ERROR(logger_, "No .osm files found under %s", input_dir_.c_str());
+    return;
+  }
+
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  try {
+    projector_info =
+      autoware::map_projection_loader::load_info_from_yaml(map_projector_info_path_);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      logger_, "Failed to load map projector info from %s: %s", map_projector_info_path_.c_str(),
+      e.what());
+    return;
+  }
+  RCLCPP_INFO(logger_, "Projector type: %s", projector_info.projector_type.c_str());
+
+  std::unique_ptr<lanelet::Projector> projector;
+  try {
+    projector = create_projector(projector_info);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(logger_, "Failed to create projector: %s", e.what());
+    return;
+  }
+
+  lanelet::LaneletMapPtr merged = load_and_merge_maps(osm_files, projector_info, *projector);
+  if (!merged) {
+    RCLCPP_ERROR(logger_, "Failed to load Lanelet2 maps from %s", input_dir_.c_str());
+    return;
+  }
+
+  const fs::path out_path(output_);
+  if (out_path.has_parent_path()) {
+    fs::create_directories(out_path.parent_path());
+  }
+  if (fs::exists(out_path)) {
+    fs::remove(out_path);
+  }
+
+  lanelet::write(output_, *merged, *projector);
+  RCLCPP_INFO(logger_, "Saved merged map: %s", output_.c_str());
+}
+
+}  // namespace autoware::lanelet2_map_merger

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.hpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.hpp
@@ -1,0 +1,61 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_MERGER_HPP_
+#define LANELET2_MAP_MERGER_HPP_
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_io/Projection.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::lanelet2_map_merger
+{
+
+class Lanelet2MapMerger
+{
+public:
+  explicit Lanelet2MapMerger(const rclcpp::Logger & logger) : logger_(logger) {}
+
+  void set_input_dir(const std::string & input_dir) { input_dir_ = input_dir; }
+  void set_output(const std::string & output) { output_ = output; }
+  void set_map_projector_info_path(const std::string & path) { map_projector_info_path_ = path; }
+
+  void run();
+
+private:
+  std::vector<std::string> discover_osm_files(const std::string & input_dir) const;
+  std::unique_ptr<lanelet::Projector> create_projector(
+    const autoware_map_msgs::msg::MapProjectorInfo & projector_info) const;
+  lanelet::LaneletMapPtr load_and_merge_maps(
+    const std::vector<std::string> & osm_files,
+    const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
+    lanelet::Projector & projector);
+
+  std::string input_dir_;
+  std::string output_;
+  std::string map_projector_info_path_;
+  // Keep loaded source maps alive so references from merged primitives do not expire.
+  std::vector<lanelet::LaneletMapPtr> loaded_maps_;
+  rclcpp::Logger logger_;
+};
+
+}  // namespace autoware::lanelet2_map_merger
+
+#endif  // LANELET2_MAP_MERGER_HPP_

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.hpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger.hpp
@@ -15,8 +15,9 @@
 #ifndef LANELET2_MAP_MERGER_HPP_
 #define LANELET2_MAP_MERGER_HPP_
 
-#include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_io/Projection.h>

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger_node.cpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger_node.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet2_map_merger_node.hpp"
+
+#include "lanelet2_map_merger.hpp"
+
+#include <sstream>
+#include <string>
+
+namespace autoware::lanelet2_map_merger
+{
+
+Lanelet2MapMergerNode::Lanelet2MapMergerNode(const rclcpp::NodeOptions & node_options)
+: Node("lanelet2_map_merger", node_options)
+{
+  const std::string input_lanelet2_map_dir =
+    declare_parameter<std::string>("input_lanelet2_map_dir");
+  const std::string output_lanelet2_map = declare_parameter<std::string>("output_lanelet2_map");
+  const std::string map_projector_info_path =
+    declare_parameter<std::string>("map_projector_info_path");
+
+  std::ostringstream oss;
+  oss << "\n########## Input Parameters ##########\n"
+      << "\tinput_lanelet2_map_dir: " << input_lanelet2_map_dir << "\n"
+      << "\toutput_lanelet2_map: " << output_lanelet2_map << "\n"
+      << "\tmap_projector_info_path: " << map_projector_info_path << "\n"
+      << "######################################";
+  RCLCPP_INFO(get_logger(), "%s", oss.str().c_str());
+
+  Lanelet2MapMerger merger(get_logger());
+  merger.set_input_dir(input_lanelet2_map_dir);
+  merger.set_output(output_lanelet2_map);
+  merger.set_map_projector_info_path(map_projector_info_path);
+
+  merger.run();
+
+  rclcpp::shutdown();
+}
+
+}  // namespace autoware::lanelet2_map_merger
+
+#include <rclcpp_components/register_node_macro.hpp>
+
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::lanelet2_map_merger::Lanelet2MapMergerNode)

--- a/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger_node.hpp
+++ b/map/autoware_lanelet2_map_merger/src/lanelet2_map_merger_node.hpp
@@ -1,0 +1,31 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_MERGER_NODE_HPP_
+#define LANELET2_MAP_MERGER_NODE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::lanelet2_map_merger
+{
+
+class Lanelet2MapMergerNode : public rclcpp::Node
+{
+public:
+  explicit Lanelet2MapMergerNode(const rclcpp::NodeOptions & node_options);
+};
+
+}  // namespace autoware::lanelet2_map_merger
+
+#endif  // LANELET2_MAP_MERGER_NODE_HPP_

--- a/map/autoware_lanelet2_map_merger/src/local_projector.hpp
+++ b/map/autoware_lanelet2_map_merger/src/local_projector.hpp
@@ -1,0 +1,41 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LOCAL_PROJECTOR_HPP_
+#define LOCAL_PROJECTOR_HPP_
+
+#include <lanelet2_io/Projection.h>
+
+namespace autoware::lanelet2_map_merger
+{
+
+class LocalProjector : public lanelet::Projector
+{
+public:
+  LocalProjector() : Projector(lanelet::Origin(lanelet::GPSPoint{})) {}
+
+  lanelet::BasicPoint3d forward(const lanelet::GPSPoint & gps) const override  // NOLINT
+  {
+    return lanelet::BasicPoint3d{0.0, 0.0, gps.ele};
+  }
+
+  [[nodiscard]] lanelet::GPSPoint reverse(const lanelet::BasicPoint3d & point) const override
+  {
+    return lanelet::GPSPoint{0.0, 0.0, point.z()};
+  }
+};
+
+}  // namespace autoware::lanelet2_map_merger
+
+#endif  // LOCAL_PROJECTOR_HPP_

--- a/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
@@ -24,9 +24,13 @@
 #include <lanelet2_core/primitives/Point.h>
 #include <lanelet2_io/Io.h>
 
+#include <unistd.h>
+
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <random>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -128,12 +132,18 @@ class Lanelet2MapMergerTest : public ::testing::Test
 protected:
   void SetUp() override
   {
-    tmp_dir_ = fs::temp_directory_path() / "test_lanelet2_map_merger";
-    fs::remove_all(tmp_dir_);
+    std::random_device rd;
+    std::ostringstream name;
+    name << "test_lanelet2_map_merger_" << ::getpid() << "_" << std::hex << rd() << rd();
+    tmp_dir_ = fs::temp_directory_path() / name.str();
     fs::create_directories(tmp_dir_);
   }
 
-  void TearDown() override { fs::remove_all(tmp_dir_); }
+  void TearDown() override
+  {
+    std::error_code ec;
+    fs::remove_all(tmp_dir_, ec);
+  }
 
   fs::path tmp_dir_;
 };

--- a/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
@@ -23,7 +23,6 @@
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Point.h>
 #include <lanelet2_io/Io.h>
-
 #include <unistd.h>
 
 #include <filesystem>

--- a/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
@@ -1,0 +1,252 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/lanelet2_map_merger.hpp"
+
+#include "../src/local_projector.hpp"
+
+#include <rclcpp/logger.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+#include <lanelet2_io/Io.h>
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+// Build a tiny two-lanelet map that reuses two border points so that writing it
+// into separate cells exercises the merger's point-deduplication path.
+lanelet::LaneletMapPtr make_sample_map()
+{
+  auto make_point = [](lanelet::Id id, double x, double y) {
+    lanelet::Point3d p(id, x, y, 0.0);
+    p.attributes()["local_x"] = std::to_string(x);
+    p.attributes()["local_y"] = std::to_string(y);
+    return p;
+  };
+
+  // Lanelet 100 in cell (0,0); lanelet 101 in cell (10,0). They share left border
+  // points (points 3, 4) because right border of 100 == left border of 101.
+  lanelet::Point3d p1 = make_point(1, 1.0, 1.0);
+  lanelet::Point3d p2 = make_point(2, 1.0, 9.0);
+  lanelet::Point3d p3 = make_point(3, 9.0, 1.0);
+  lanelet::Point3d p4 = make_point(4, 9.0, 9.0);
+  lanelet::Point3d p5 = make_point(5, 19.0, 1.0);
+  lanelet::Point3d p6 = make_point(6, 19.0, 9.0);
+
+  lanelet::LineString3d ls_left_a(10, {p1, p2});
+  lanelet::LineString3d ls_right_a(11, {p3, p4});  // shared with lanelet 101
+  lanelet::LineString3d ls_right_b(12, {p5, p6});
+  for (auto ls : {ls_left_a, ls_right_a, ls_right_b}) {
+    ls.attributes()["type"] = "line_thin";
+    ls.attributes()["subtype"] = "solid";
+  }
+
+  lanelet::Lanelet ll_a(100, ls_left_a, ls_right_a);
+  lanelet::Lanelet ll_b(101, ls_right_a, ls_right_b);
+  for (auto ll : {ll_a, ll_b}) {
+    ll.attributes()["type"] = "lanelet";
+    ll.attributes()["subtype"] = "road";
+    ll.attributes()["location"] = "urban";
+    ll.attributes()["one_way"] = "yes";
+  }
+
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  map->add(ll_a);
+  map->add(ll_b);
+  return map;
+}
+
+std::string write_projector_info_local(const fs::path & dir)
+{
+  const auto path = dir / "map_projector_info.yaml";
+  std::ofstream(path) << "projector_type: Local\n";
+  return path.string();
+}
+
+// Write the given map into N .osm files in @dir by splitting lanelets one-per-file,
+// simulating the output of a divider.
+void write_split_maps(lanelet::LaneletMap & map, const fs::path & dir)
+{
+  fs::create_directories(dir);
+  autoware::lanelet2_map_merger::LocalProjector projector;
+
+  size_t idx = 0;
+  for (lanelet::Lanelet & llt : map.laneletLayer) {
+    auto sub = std::make_shared<lanelet::LaneletMap>();
+    sub->add(llt);
+    const auto path = dir / (std::to_string(idx++) + ".osm");
+    lanelet::write(path.string(), *sub, projector);
+  }
+}
+
+// Count how many <node>, <way>, <relation> primitives appear in an .osm file.
+struct OsmCounts
+{
+  size_t nodes = 0;
+  size_t ways = 0;
+  size_t relations = 0;
+};
+OsmCounts count_osm_primitives(const std::string & path)
+{
+  OsmCounts c;
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.find("<node ") != std::string::npos) ++c.nodes;
+    if (line.find("<way ") != std::string::npos) ++c.ways;
+    if (line.find("<relation ") != std::string::npos) ++c.relations;
+  }
+  return c;
+}
+
+}  // namespace
+
+class Lanelet2MapMergerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    tmp_dir_ = fs::temp_directory_path() / "test_lanelet2_map_merger";
+    fs::remove_all(tmp_dir_);
+    fs::create_directories(tmp_dir_);
+  }
+
+  void TearDown() override { fs::remove_all(tmp_dir_); }
+
+  fs::path tmp_dir_;
+};
+
+TEST_F(Lanelet2MapMergerTest, MergesSplitMapsIntoSingleFile)
+{
+  const auto map = make_sample_map();
+  const fs::path input_dir = tmp_dir_ / "in";
+  write_split_maps(*map, input_dir);
+
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_path = (tmp_dir_ / "merged.osm").string();
+
+  autoware::lanelet2_map_merger::Lanelet2MapMerger merger(rclcpp::get_logger("test"));
+  merger.set_input_dir(input_dir.string());
+  merger.set_output(output_path);
+  merger.set_map_projector_info_path(projector_info);
+  merger.run();
+
+  ASSERT_TRUE(fs::exists(output_path));
+}
+
+TEST_F(Lanelet2MapMergerTest, MergedOutputDeduplicatesSharedPoints)
+{
+  const auto map = make_sample_map();
+  const fs::path input_dir = tmp_dir_ / "in";
+  write_split_maps(*map, input_dir);
+
+  // Sanity-check: across the split files, a shared linestring's points appear twice.
+  size_t total_nodes_in_inputs = 0;
+  for (const auto & entry : fs::directory_iterator(input_dir)) {
+    total_nodes_in_inputs += count_osm_primitives(entry.path().string()).nodes;
+  }
+  // Points 3 and 4 are shared → 6 unique nodes * 2 files where they appear in one = 8.
+  EXPECT_EQ(total_nodes_in_inputs, 8u);
+
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_path = (tmp_dir_ / "merged.osm").string();
+
+  autoware::lanelet2_map_merger::Lanelet2MapMerger merger(rclcpp::get_logger("test"));
+  merger.set_input_dir(input_dir.string());
+  merger.set_output(output_path);
+  merger.set_map_projector_info_path(projector_info);
+  merger.run();
+
+  const auto counts = count_osm_primitives(output_path);
+  // After dedup, exactly 6 unique points and 3 unique line strings remain; 2 lanelets
+  // produce 2 relations.
+  EXPECT_EQ(counts.nodes, 6u);
+  EXPECT_EQ(counts.ways, 3u);
+  EXPECT_EQ(counts.relations, 2u);
+}
+
+TEST_F(Lanelet2MapMergerTest, MergedMapCanBeReloaded)
+{
+  const auto map = make_sample_map();
+  const fs::path input_dir = tmp_dir_ / "in";
+  write_split_maps(*map, input_dir);
+
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_path = (tmp_dir_ / "merged.osm").string();
+
+  autoware::lanelet2_map_merger::Lanelet2MapMerger merger(rclcpp::get_logger("test"));
+  merger.set_input_dir(input_dir.string());
+  merger.set_output(output_path);
+  merger.set_map_projector_info_path(projector_info);
+  merger.run();
+
+  // Reload the merged file via lanelet2's IO and inspect layer sizes.
+  autoware::lanelet2_map_merger::LocalProjector projector;
+  lanelet::ErrorMessages errors;
+  auto reloaded = lanelet::load(output_path, projector, &errors);
+  ASSERT_TRUE(errors.empty()) << "Lanelet2 reported load errors on merged output";
+  ASSERT_TRUE(reloaded);
+  EXPECT_EQ(reloaded->laneletLayer.size(), 2u);
+  EXPECT_EQ(reloaded->lineStringLayer.size(), 3u);
+  EXPECT_EQ(reloaded->pointLayer.size(), 6u);
+}
+
+TEST_F(Lanelet2MapMergerTest, NonExistentInputDirDoesNotCrash)
+{
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_path = (tmp_dir_ / "merged.osm").string();
+
+  autoware::lanelet2_map_merger::Lanelet2MapMerger merger(rclcpp::get_logger("test"));
+  merger.set_input_dir((tmp_dir_ / "nope").string());
+  merger.set_output(output_path);
+  merger.set_map_projector_info_path(projector_info);
+
+  EXPECT_NO_THROW(merger.run());
+  EXPECT_FALSE(fs::exists(output_path));
+}
+
+TEST_F(Lanelet2MapMergerTest, EmptyInputDirDoesNotCrash)
+{
+  const fs::path input_dir = tmp_dir_ / "empty";
+  fs::create_directories(input_dir);
+
+  const auto projector_info = write_projector_info_local(tmp_dir_);
+  const auto output_path = (tmp_dir_ / "merged.osm").string();
+
+  autoware::lanelet2_map_merger::Lanelet2MapMerger merger(rclcpp::get_logger("test"));
+  merger.set_input_dir(input_dir.string());
+  merger.set_output(output_path);
+  merger.set_map_projector_info_path(projector_info);
+
+  EXPECT_NO_THROW(merger.run());
+  EXPECT_FALSE(fs::exists(output_path));
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "../src/lanelet2_map_merger.hpp"
-
 #include "../src/local_projector.hpp"
 
 #include <rclcpp/logger.hpp>

--- a/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
+++ b/map/autoware_lanelet2_map_merger/test/test_lanelet2_map_merger.cpp
@@ -180,8 +180,8 @@ TEST_F(Lanelet2MapMergerTest, MergedOutputDeduplicatesSharedPoints)
   merger.run();
 
   const auto counts = count_osm_primitives(output_path);
-  // After dedup, exactly 6 unique points and 3 unique line strings remain; 2 lanelets
-  // produce 2 relations.
+  // After deduplication, exactly 6 unique points and 3 unique line strings remain;
+  // 2 lanelets produce 2 relations.
   EXPECT_EQ(counts.nodes, 6u);
   EXPECT_EQ(counts.ways, 3u);
   EXPECT_EQ(counts.relations, 2u);


### PR DESCRIPTION
## Description

Part of https://github.com/autowarefoundation/autoware_core/issues/887

Add a new `autoware_lanelet2_map_merger` package that merges a directory of divided Lanelet2 (`.osm`) map files into a single `.osm` file.

- New ROS 2 node `autoware_lanelet2_map_merger_node` with launch file, parameter YAML, and JSON schema.
- Loads every `.osm` file in the input directory using the projector described in `map_projector_info.yaml` (`MGRS`, `LocalCartesianUTM`, `LocalCartesian`, and `TransverseMercator` are supported).
- Merges the loaded maps using the same logic as `lanelet2_map_loader` (`merge_lanelet2_maps`), deduplicating points shared across maps by ID so successor/predecessor relationships are preserved, then writes the merged map with `lanelet::write`.
- Includes README and a gtest covering the merge behavior.

## How was this PR tested?

- Built the package with `colcon build --packages-select autoware_lanelet2_map_merger`.
- Ran the included gtest suite (`test_lanelet2_map_merger`) via `colcon test`.
- Verified end-to-end round-trip by running `autoware_lanelet2_map_divider` on a sample `lanelet2_map.osm` and then running this merger on its output, confirming the reconstructed map matches the original.

## Notes for reviewers

None.

## Effects on system behavior

None.