### PR TITLE
feat(planning_debug_tools): replace autoware_universe_utils with specific autoware_utils sub-packages

### DIFF
--- a/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
+++ b/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
@@ -16,10 +16,11 @@
 #define PLANNING_DEBUG_TOOLS__TRAJECTORY_ANALYZER_HPP_
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include <autoware_utils_geometry/geometry.hpp>
 #include "planning_debug_tools/msg/trajectory_debug_info.hpp"
 #include "planning_debug_tools/util.hpp"
 #include "rclcpp/rclcpp.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include "autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp"
 #include "autoware_internal_planning_msgs/msg/path_with_lane_id.hpp"

--- a/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
+++ b/planning/planning_debug_tools/include/planning_debug_tools/trajectory_analyzer.hpp
@@ -16,7 +16,7 @@
 #define PLANNING_DEBUG_TOOLS__TRAJECTORY_ANALYZER_HPP_
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include <autoware_utils_geometry/geometry.hpp>
 #include "planning_debug_tools/msg/trajectory_debug_info.hpp"
 #include "planning_debug_tools/util.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/planning/planning_debug_tools/include/planning_debug_tools/util.hpp
+++ b/planning/planning_debug_tools/include/planning_debug_tools/util.hpp
@@ -16,7 +16,7 @@
 #define PLANNING_DEBUG_TOOLS__UTIL_HPP_
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include <autoware_utils_geometry/geometry.hpp>
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_internal_planning_msgs/msg/path_with_lane_id.hpp"
@@ -28,9 +28,9 @@
 namespace planning_debug_tools
 {
 
-using autoware::universe_utils::calcDistance2d;
-using autoware::universe_utils::getPoint;
-using autoware::universe_utils::getRPY;
+using autoware_utils_geometry::calc_distance2d;
+using autoware_utils_geometry::get_point;
+using autoware_utils_geometry::get_rpy;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_planning_msgs::msg::PathPoint;
 using autoware_planning_msgs::msg::TrajectoryPoint;
@@ -50,15 +50,15 @@ double getVelocity(const TrajectoryPoint & p)
 
 double getYaw(const PathPoint & p)
 {
-  return getRPY(p.pose.orientation).z;
+  return get_rpy(p.pose.orientation).z;
 }
 double getYaw(const PathPointWithLaneId & p)
 {
-  return getRPY(p.point.pose.orientation).z;
+  return get_rpy(p.point.pose.orientation).z;
 }
 double getYaw(const TrajectoryPoint & p)
 {
-  return getRPY(p.pose.orientation).z;
+  return get_rpy(p.pose.orientation).z;
 }
 
 template <class T>
@@ -88,7 +88,7 @@ inline std::vector<double> getAccelerationArray(const T & points)
     const auto & prev_point = points.at(i);
     const auto & next_point = points.at(i + 1);
 
-    const double delta_s = autoware::universe_utils::calcDistance2d(prev_point, next_point);
+    const double delta_s = autoware_utils_geometry::calc_distance2d(prev_point, next_point);
     if (delta_s == 0.0) {
       segment_wise_a_arr.push_back(0.0);
     } else {
@@ -125,7 +125,7 @@ std::vector<double> calcPathArcLengthArray(const T & points, const double offset
   out.push_back(offset);
   double sum = offset;
   for (size_t i = 1; i < points.size(); ++i) {
-    sum += calcDistance2d(getPoint(points.at(i)), getPoint(points.at(i - 1)));
+    sum += calc_distance2d(get_point(points.at(i)), get_point(points.at(i - 1)));
     out.push_back(sum);
   }
   return out;

--- a/planning/planning_debug_tools/include/planning_debug_tools/util.hpp
+++ b/planning/planning_debug_tools/include/planning_debug_tools/util.hpp
@@ -16,8 +16,9 @@
 #define PLANNING_DEBUG_TOOLS__UTIL_HPP_
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include <autoware_utils_geometry/geometry.hpp>
 #include "rclcpp/rclcpp.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include "autoware_internal_planning_msgs/msg/path_with_lane_id.hpp"
 #include "autoware_planning_msgs/msg/path.hpp"
@@ -28,12 +29,12 @@
 namespace planning_debug_tools
 {
 
-using autoware_utils_geometry::calc_distance2d;
-using autoware_utils_geometry::get_point;
-using autoware_utils_geometry::get_rpy;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_planning_msgs::msg::PathPoint;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils_geometry::calc_distance2d;
+using autoware_utils_geometry::get_point;
+using autoware_utils_geometry::get_rpy;
 
 double getVelocity(const PathPoint & p)
 {

--- a/planning/planning_debug_tools/package.xml
+++ b/planning/planning_debug_tools/package.xml
@@ -27,7 +27,8 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_visualization</depend>
   <depend>geometry_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/planning/planning_debug_tools/src/stop_reason_visualizer.cpp
+++ b/planning/planning_debug_tools/src/stop_reason_visualizer.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/universe_utils/ros/marker_helper.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <std_msgs/msg/header.hpp>
@@ -49,10 +49,10 @@ public:
 private:
   void onStopReasonArray(const StopReasonArray::ConstSharedPtr msg)
   {
-    using autoware::universe_utils::appendMarkerArray;
-    using autoware::universe_utils::createDefaultMarker;
-    using autoware::universe_utils::createMarkerColor;
-    using autoware::universe_utils::createMarkerScale;
+    using autoware_utils_visualization::append_marker_array;
+    using autoware_utils_visualization::create_default_marker;
+    using autoware_utils_visualization::create_marker_color;
+    using autoware_utils_visualization::create_marker_scale;
 
     MarkerArray all_marker_array;
     const auto header = msg->header;
@@ -69,18 +69,18 @@ private:
         const auto stop_factor_point = stop_factor.stop_factor_points.front();
         // base stop pose marker
         {
-          auto stop_point_marker = createDefaultMarker(
+          auto stop_point_marker = create_default_marker(
             "map", current_time, prefix + ":stop_factor_point", id, Marker::SPHERE,
-            createMarkerScale(0.25, 0.25, 0.25), createMarkerColor(1.0, 0.0, 0.0, 0.999));
+            create_marker_scale(0.25, 0.25, 0.25), create_marker_color(1.0, 0.0, 0.0, 0.999));
           stop_point_marker.pose.position = stop_factor_point;
           marker_array.markers.emplace_back(stop_point_marker);
         }
         // attention ! marker
         {
-          auto attention_text_marker = createDefaultMarker(
+          auto attention_text_marker = create_default_marker(
             "map", current_time, prefix + ":attention text", id,
-            visualization_msgs::msg::Marker::TEXT_VIEW_FACING, createMarkerScale(0.0, 0.0, 1.0),
-            createMarkerColor(1.0, 1.0, 1.0, 0.999));
+            visualization_msgs::msg::Marker::TEXT_VIEW_FACING, create_marker_scale(0.0, 0.0, 1.0),
+            create_marker_color(1.0, 1.0, 1.0, 0.999));
           attention_text_marker.pose.position = stop_factor_point;
           attention_text_marker.pose.position.z += offset_z;
           attention_text_marker.text = "!";
@@ -88,26 +88,26 @@ private:
         }
         // point to pose
         {
-          auto stop_to_pose_marker = createDefaultMarker(
+          auto stop_to_pose_marker = create_default_marker(
             "map", current_time, prefix + ":stop_to_pose", id, Marker::LINE_STRIP,
-            createMarkerScale(0.02, 0.0, 0.0), createMarkerColor(0.0, 1.0, 1.0, 0.999));
+            create_marker_scale(0.02, 0.0, 0.0), create_marker_color(0.0, 1.0, 1.0, 0.999));
           stop_to_pose_marker.points.emplace_back(stop_factor.stop_factor_points.front());
           stop_to_pose_marker.points.emplace_back(stop_factor.stop_pose.position);
           marker_array.markers.emplace_back(stop_to_pose_marker);
         }
         // point to pose
         {
-          auto stop_pose_marker = createDefaultMarker(
+          auto stop_pose_marker = create_default_marker(
             "map", current_time, prefix + ":stop_pose", id, Marker::ARROW,
-            createMarkerScale(0.4, 0.2, 0.2), createMarkerColor(1.0, 0.0, 0.0, 0.999));
+            create_marker_scale(0.4, 0.2, 0.2), create_marker_color(1.0, 0.0, 0.0, 0.999));
           stop_pose_marker.pose = stop_factor.stop_pose;
           marker_array.markers.emplace_back(stop_pose_marker);
         }
         // add view distance text
         {
-          auto reason_text_marker = createDefaultMarker(
+          auto reason_text_marker = create_default_marker(
             "map", current_time, prefix + ":reason", id, Marker::TEXT_VIEW_FACING,
-            createMarkerScale(0.0, 0.0, 0.2), createMarkerColor(1.0, 1.0, 1.0, 0.999));
+            create_marker_scale(0.0, 0.0, 0.2), create_marker_color(1.0, 1.0, 1.0, 0.999));
           reason_text_marker.pose = stop_factor.stop_pose;
           reason_text_marker.text = prefix;
           marker_array.markers.emplace_back(reason_text_marker);
@@ -115,7 +115,7 @@ private:
         id++;
       }
       if (!marker_array.markers.empty())
-        appendMarkerArray(marker_array, &all_marker_array, current_time);
+        append_marker_array(marker_array, &all_marker_array, current_time);
     }
     pub_stop_reasons_marker_->publish(all_marker_array);
   }


### PR DESCRIPTION
## Description

Replaces the `autoware_universe_utils` dependency in the `planning_debug_tools` package with the specific `autoware_utils_*` sub-packages that are actually used, following the minimum-dependency principle.

## Changes

**`planning/planning_debug_tools/package.xml`**
- Removed: `<depend>autoware_universe_utils</depend>`
- Added: `<depend>autoware_utils_geometry</depend>`
- Added: `<depend>autoware_utils_visualization</depend>`

**Header include swaps**
- `autoware/universe_utils/geometry/geometry.hpp` → `autoware_utils_geometry/geometry.hpp` (in `trajectory_analyzer.hpp` and `util.hpp`)
- `autoware/universe_utils/ros/marker_helper.hpp` → `autoware_utils_visualization/marker_helper.hpp` (in `stop_reason_visualizer.cpp`)

**Geometry symbols → `autoware_utils_geometry::`**
- `calcDistance2d` → `calc_distance2d`
- `getPoint` → `get_point`
- `getRPY` → `get_rpy`

**Visualization symbols → `autoware_utils_visualization::`**
- `appendMarkerArray` → `append_marker_array`
- `createDefaultMarker` → `create_default_marker`
- `createMarkerColor` → `create_marker_color`
- `createMarkerScale` → `create_marker_scale`

Both the `using` declarations (in `util.hpp` and inside `StopReasonVisualizerNode::onStopReasonArray`) and the bare call sites they introduce have been updated to the new snake_case names.

Note: The `tf2::Matrix3x3::getRPY` method call in `src/perception_replayer/utils.hpp` is an unrelated tf2 API and is intentionally left unchanged.

Files touched: `package.xml`, `include/planning_debug_tools/trajectory_analyzer.hpp`, `include/planning_debug_tools/util.hpp`, `src/stop_reason_visualizer.cpp`.

## Related Issue

Part of the `autoware_universe_utils` deprecation effort tracked in autowarefoundation/autoware_universe#12376 (the `autoware_tools` checklist item).

## Additional notes

Part of a series of similar PRs for `autoware_tools`, grouped by top-level directory:

- [x] vehicle (#404)
- [x] driving_environment_analyzer (#405)
- [x] common
  - [x] tier4_debug_tools (#406)
  - [x] tier4_automatic_goal_rviz_plugin (#407)
  - [x] tier4_control_rviz_plugin (#408)
- [x] planning (complete after this PR)
  - [x] autoware_static_centerline_generator (#411)
  - [x] planning_debug_tools (this PR)
- [ ] localization
