### PR TITLE
docs: migrate map_path examples to ~/autoware_data/maps

### DIFF
--- a/common/tier4_simulated_clock_rviz_plugin/README.md
+++ b/common/tier4_simulated_clock_rviz_plugin/README.md
@@ -15,7 +15,7 @@ This plugin allows publishing and controlling the simulated ROS time.
 1. Launch [planning simulator](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/#1-launch-autoware) with `use_sim_time:=true`.
 
    ```shell
-   ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit use_sim_time:=true
+   ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit use_sim_time:=true
    ```
 
    > <span style="color: orange; font-weight: bold;">Warning</span>

--- a/control_data_collecting_tool/README.md
+++ b/control_data_collecting_tool/README.md
@@ -50,7 +50,7 @@ This package provides tools for automatically collecting data using pure pursuit
 1. Launch Autoware.
 
     ```bash
-    ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+    ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
     ```
 
 2. Set an initial pose, see [here](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/#2-set-an-initial-pose-for-the-ego-vehicle).
@@ -60,7 +60,7 @@ This package provides tools for automatically collecting data using pure pursuit
 4. Launch control_data_collecting_tool.
 
     ```bash
-    ros2 launch control_data_collecting_tool control_data_collecting_tool.launch.py map_path:=$HOME/autoware_map/sample-map-planning accel_brake_map_path:=/path/to/your/accel_brake_map_dir
+    ros2 launch control_data_collecting_tool control_data_collecting_tool.launch.py map_path:=$HOME/autoware_data/maps/sample-map-planning accel_brake_map_path:=/path/to/your/accel_brake_map_dir
     ```
 
     - If you use the `along_road` course, please specify the same map for `map_path` as the one used when launching Autoware. `map_path` is not necessary when using courses other than `along_road`.
@@ -359,7 +359,7 @@ You can create an original mask to specify the data collection range for the hea
    and relaunch the control_data_collecting_tool with
 
    ```bash
-   ros2 launch control_data_collecting_tool control_data_collecting_tool.launch.py map_path:=$HOME/autoware_map/sample-map-planning
+   ros2 launch control_data_collecting_tool control_data_collecting_tool.launch.py map_path:=$HOME/autoware_data/maps/sample-map-planning
    ```
 
    This will allow you to see the selected mask applied.


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7068
- Migrate the `map_path:=$HOME/autoware_map/sample-map-planning` copy-paste examples in two READMEs to `$HOME/autoware_data/maps/demos/sample-map-planning`, matching the new asset-typed `~/autoware_data/{maps,ml_models,...}/` layout.

## Why

Sample maps now live under `~/autoware_data/maps/demos/` (placed there by the `demo_artifacts` ansible role added in autowarefoundation/autoware#7067), not under the legacy `~/autoware_map/` root. These two READMEs were the last copy-paste examples in the tools repo still pointing at the old path; updating them keeps the documented launch lines working out of the box for users who follow the new layout.

---

- Pairs with autowarefoundation/autoware#7077 (ansible default + docker demos), autowarefoundation/autoware_launch#1835 (launch defaults), autowarefoundation/autoware_universe#12523 (universe launches and READMEs).
- Builds on autowarefoundation/autoware#7067 (already merged) which introduced the `demo_artifacts` role placing maps under `~/autoware_data/maps/demos/`.

## Test plan

- [ ] No leftover legacy references in this repo:

  ```bash
  grep -rn '$HOME/autoware_map' --include='*.md' .
  ```

  Expect no output.

- [ ] Documented commands are syntactically valid as posted (rendering check):

  - [`common/tier4_simulated_clock_rviz_plugin/README.md`](https://github.com/autowarefoundation/autoware_tools/blob/5a58a10062734bad21bb3a5c15b086bd708cc931/common/tier4_simulated_clock_rviz_plugin/README.md)
  - [`control_data_collecting_tool/README.md`](https://github.com/autowarefoundation/autoware_tools/blob/5a58a10062734bad21bb3a5c15b086bd708cc931/control_data_collecting_tool/README.md)
