### PR TITLE
feat(planning_data_analyzer): aggregate ADE/FDE only for override scenes

### DIFF
--- a/planning/autoware_planning_data_analyzer/CMakeLists.txt
+++ b/planning/autoware_planning_data_analyzer/CMakeLists.txt
@@ -23,6 +23,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/metrics/trajectory_metrics.cpp
   src/utils/bag_utils.cpp
   src/utils/json_utils.cpp
+  src/utils/override_windows.cpp
   src/utils/path_utils.cpp
   src/autoware_planning_data_analyzer_node.cpp
 )
@@ -52,6 +53,7 @@ if(BUILD_TESTING)
     test/metrics/test_ttc_within_bound.cpp
     test/metrics/test_no_at_fault_collision.cpp
     test/metrics/test_traffic_light_compliance.cpp
+    test/utils/test_override_windows.cpp
   )
 
   target_include_directories(test_metrics

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -29,6 +29,7 @@
     tf_topic: "/tf"
     acceleration_topic: "/localization/acceleration"
     steering_topic: "/vehicle/status/steering_status"
+    control_mode_topic: "/vehicle/status/control_mode"
 
     open_loop:
       # "kinematic_state" (default): synthesize GT from odometry topic
@@ -60,3 +61,7 @@
       lane_keep:
         max_lateral_deviation: 0.5  # Maximum absolute lateral deviation allowed for LK [m]
         max_continuous_violation_time: 2.0  # Continuous over-threshold duration allowed for LK [s]
+      override:
+        # Time window [s] after every AUTONOMOUS->MANUAL transition used to compute
+        # the override_only/* aggregate statistics in the summary JSON.
+        window_sec: 0.5

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -157,6 +157,9 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   tf_topic_name_ = get_or_declare_parameter<std::string>(*this, "tf_topic");
   acceleration_topic_name_ = get_or_declare_parameter<std::string>(*this, "acceleration_topic");
   steering_topic_name_ = get_or_declare_parameter<std::string>(*this, "steering_topic");
+  control_mode_topic_name_ = get_or_declare_parameter<std::string>(*this, "control_mode_topic");
+  override_window_sec_ =
+    get_or_declare_parameter<double>(*this, "open_loop.override.window_sec");
 
   if (evaluation_interval_ms_ <= 0.0) {
     throw std::runtime_error(
@@ -468,6 +471,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   topic_names.tf_topic = tf_topic_name_;
   topic_names.acceleration_topic = acceleration_topic_name_;
   topic_names.steering_topic = steering_topic_name_;
+  topic_names.control_mode_topic = control_mode_topic_name_;
   topic_names.evaluation_interval_ms = evaluation_interval_ms_;
   topic_names.sync_tolerance_ms = sync_tolerance_ms_;
   auto output_dir = get_or_declare_parameter<std::string>(*this, "output_dir");
@@ -497,6 +501,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       evaluator.set_metric_variant(open_loop_metric_variant);
       evaluator.set_evaluation_horizons(evaluation_horizons);
       evaluator.set_extended_comfort_parameters(extended_comfort_parameters_);
+      evaluator.set_override_window_sec(override_window_sec_);
       auto times =
         evaluator.run_evaluation_from_bag(bag_path_, evaluation_bag_writer_.get(), topic_names);
       start_time = times.first;

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -158,8 +158,7 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   acceleration_topic_name_ = get_or_declare_parameter<std::string>(*this, "acceleration_topic");
   steering_topic_name_ = get_or_declare_parameter<std::string>(*this, "steering_topic");
   control_mode_topic_name_ = get_or_declare_parameter<std::string>(*this, "control_mode_topic");
-  override_window_sec_ =
-    get_or_declare_parameter<double>(*this, "open_loop.override.window_sec");
+  override_window_sec_ = get_or_declare_parameter<double>(*this, "open_loop.override.window_sec");
 
   if (evaluation_interval_ms_ <= 0.0) {
     throw std::runtime_error(

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -97,6 +97,8 @@ private:
   std::string tf_topic_name_;
   std::string acceleration_topic_name_;
   std::string steering_topic_name_;
+  std::string control_mode_topic_name_;
+  double override_window_sec_ = 0.0;
 
   EvaluationMode evaluation_mode_;
   std::string bag_path_;

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -22,9 +22,11 @@
 
 #include <std_msgs/msg/float64_multi_array.hpp>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace autoware::planning_data_analyzer
 {
@@ -100,8 +102,28 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
     } else if (topic_name == topic_names.tf_topic) {
       process_and_append_message<TFMessage>(
         serialized_message, bag_data, topic_names.tf_topic, false, logger_);
+    } else if (
+      !topic_names.control_mode_topic.empty() && topic_name == topic_names.control_mode_topic) {
+      try {
+        ControlModeReport mode_msg;
+        rclcpp::Serialization<ControlModeReport> serializer;
+        rclcpp::SerializedMessage serialized_msg(*serialized_message->serialized_data);
+        serializer.deserialize_message(&serialized_msg, &mode_msg);
+        // Prefer the message stamp; fall back to bag timestamp when unset.
+        const rclcpp::Time stamp(mode_msg.stamp);
+        const auto stamp_ns =
+          stamp.nanoseconds() != 0 ? stamp.nanoseconds() : get_timestamp_ns(*serialized_message);
+        result.control_mode_events.emplace_back(stamp_ns, mode_msg.mode);
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(logger_, "Failed to deserialize control_mode message: %s", e.what());
+      }
     }
   }
+
+  // Sort control_mode events by timestamp so override windows can be derived.
+  std::sort(
+    result.control_mode_events.begin(), result.control_mode_events.end(),
+    [](const auto & a, const auto & b) { return a.first < b.first; });
 
   // Get kinematic states at regular intervals
   auto kinematic_states =

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -17,6 +17,7 @@
 
 #include "bag_handler.hpp"
 #include "metrics/trajectory_metrics.hpp"
+#include "utils/override_windows.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <nlohmann/json.hpp>
@@ -153,7 +154,7 @@ protected:
     // Timeline of /vehicle/status/control_mode samples sorted by stamp,
     // captured as (timestamp_ns, mode) tuples. Used to detect override
     // windows (AUTONOMOUS -> MANUAL transitions).
-    std::vector<std::pair<rcutils_time_point_value_t, uint8_t>> control_mode_events;
+    std::vector<utils::ControlModeEvent> control_mode_events;
   };
 
   BagProcessingResult process_bag_common(

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -150,6 +150,10 @@ protected:
     tf2_msgs::msg::TFMessage tf_static_msgs;
     bool gt_trajectory_topic_seen = false;
     size_t gt_trajectory_message_count = 0;
+    // Timeline of /vehicle/status/control_mode samples sorted by stamp,
+    // captured as (timestamp_ns, mode) tuples. Used to detect override
+    // windows (AUTONOMOUS -> MANUAL transitions).
+    std::vector<std::pair<rcutils_time_point_value_t, uint8_t>> control_mode_events;
   };
 
   BagProcessingResult process_bag_common(

--- a/planning/autoware_planning_data_analyzer/src/data_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/data_types.hpp
@@ -21,6 +21,7 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -41,6 +42,7 @@ using PredictedObjects = autoware_perception_msgs::msg::PredictedObjects;
 using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
 using AccelWithCovarianceStamped = geometry_msgs::msg::AccelWithCovarianceStamped;
 using SteeringReport = autoware_vehicle_msgs::msg::SteeringReport;
+using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
 
 // Synchronized data from multiple topics at a specific timestamp
 struct SynchronizedData
@@ -70,6 +72,7 @@ struct TopicNames
   std::string tf_topic;
   std::string acceleration_topic;
   std::string steering_topic;
+  std::string control_mode_topic;
   double evaluation_interval_ms = 100.0;
   double sync_tolerance_ms = 100.0;
 };

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -1390,6 +1390,43 @@ void OpenLoopEvaluator::calculate_summary()
   }
 }
 
+std::vector<std::pair<rclcpp::Time, rclcpp::Time>>
+OpenLoopEvaluator::compute_override_windows() const
+{
+  std::vector<std::pair<rclcpp::Time, rclcpp::Time>> windows;
+  if (override_window_sec_ <= 0.0 || control_mode_events_.size() < 2u) {
+    return windows;
+  }
+
+  const auto window_ns =
+    static_cast<rcutils_duration_value_t>(override_window_sec_ * 1e9);
+
+  auto previous_mode = control_mode_events_.front().second;
+  for (std::size_t i = 1; i < control_mode_events_.size(); ++i) {
+    const auto current_mode = control_mode_events_[i].second;
+    if (
+      previous_mode == ControlModeReport::AUTONOMOUS &&
+      current_mode == ControlModeReport::MANUAL) {
+      const auto start_ns = control_mode_events_[i].first;
+      windows.emplace_back(rclcpp::Time(start_ns), rclcpp::Time(start_ns + window_ns));
+    }
+    previous_mode = current_mode;
+  }
+  return windows;
+}
+
+bool OpenLoopEvaluator::is_within_any_window(
+  const rclcpp::Time & t,
+  const std::vector<std::pair<rclcpp::Time, rclcpp::Time>> & windows)
+{
+  for (const auto & [start, end] : windows) {
+    if (t >= start && t <= end) {
+      return true;
+    }
+  }
+  return false;
+}
+
 nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
 {
   nlohmann::json j;
@@ -1804,6 +1841,63 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
   j["aggregate/synthetic_epdms/human_filtered_unavailable_count"] =
     synthetic_epdms_metrics_list_.size() - synthetic_filtered_available_count;
 
+  // ----- override_only aggregation -----
+  // Re-aggregate per-horizon ADE/FDE (plus the rest of the horizon metrics for symmetry)
+  // using only trajectory samples whose timestamp falls inside an override window derived
+  // from AUTONOMOUS->MANUAL transitions in /vehicle/status/control_mode.
+  const auto override_windows = compute_override_windows();
+  j["override_only/num_windows"] = override_windows.size();
+
+  for (const auto & tag : all_keys) {
+    std::vector<double> ade_vals, fde_vals, ahe_vals, fhe_vals;
+    std::vector<double> avg_lat_vals, max_lat_vals, avg_lon_vals, max_lon_vals;
+    std::vector<double> min_ttc_vals;
+    for (const auto & m : metrics_list_) {
+      if (!is_within_any_window(m.trajectory_timestamp, override_windows)) continue;
+      const auto it = std::find_if(
+        m.horizon_results.begin(), m.horizon_results.end(),
+        [&tag](const auto & p) { return p.first == tag; });
+      if (it == m.horizon_results.end()) continue;
+      const auto & hm = it->second;
+      ade_vals.push_back(hm.ade);
+      fde_vals.push_back(hm.fde);
+      ahe_vals.push_back(hm.ahe);
+      fhe_vals.push_back(hm.fhe);
+      avg_lat_vals.push_back(hm.average_lateral_deviation);
+      max_lat_vals.push_back(hm.max_lateral_deviation);
+      avg_lon_vals.push_back(hm.average_longitudinal_deviation);
+      max_lon_vals.push_back(hm.max_longitudinal_deviation);
+      min_ttc_vals.push_back(hm.min_ttc);
+    }
+
+    const std::string prefix = "override_only/" + tag;
+    j[prefix + "/count"] = ade_vals.size();
+    emit_metric(
+      prefix, "ade", "Override-only ADE within " + tag + " horizon [m]", ade_vals);
+    emit_metric(
+      prefix, "fde", "Override-only FDE at " + tag + " horizon [m]", fde_vals);
+    emit_metric(
+      prefix, "ahe", "Override-only AHE within " + tag + " horizon [rad]", ahe_vals);
+    emit_metric(
+      prefix, "fhe", "Override-only FHE at " + tag + " horizon [rad]", fhe_vals);
+    emit_metric(
+      prefix, "average_lateral_deviation",
+      "Override-only average lateral deviation within " + tag + " horizon [m]", avg_lat_vals);
+    emit_metric(
+      prefix, "max_lateral_deviation",
+      "Override-only max lateral deviation within " + tag + " horizon [m]", max_lat_vals);
+    emit_metric(
+      prefix, "average_longitudinal_deviation",
+      "Override-only average longitudinal deviation within " + tag + " horizon [m]",
+      avg_lon_vals);
+    emit_metric(
+      prefix, "max_longitudinal_deviation",
+      "Override-only max longitudinal deviation within " + tag + " horizon [m]", max_lon_vals);
+    emit_metric(
+      prefix, "min_ttc", "Override-only minimum TTC within " + tag + " horizon [s]",
+      min_ttc_vals);
+  }
+
   return j;
 }
 
@@ -2105,6 +2199,9 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
 
   // Use base class method to process bag and get synchronized data
   auto bag_result = process_bag_common(bag_path, evaluation_bag_writer, topic_names);
+
+  // Pass the control_mode timeline to enable override-only aggregation in the summary.
+  set_control_mode_events(std::move(bag_result.control_mode_events));
 
   if (gt_source_mode_ == GTSourceMode::GT_TRAJECTORY) {
     if (!bag_result.gt_trajectory_topic_seen || bag_result.gt_trajectory_message_count == 0) {

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -1836,14 +1836,10 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
 
     const std::string prefix = "override_only/" + tag;
     j[prefix + "/count"] = ade_vals.size();
-    emit_metric(
-      prefix, "ade", "Override-only ADE within " + tag + " horizon [m]", ade_vals);
-    emit_metric(
-      prefix, "fde", "Override-only FDE at " + tag + " horizon [m]", fde_vals);
-    emit_metric(
-      prefix, "ahe", "Override-only AHE within " + tag + " horizon [rad]", ahe_vals);
-    emit_metric(
-      prefix, "fhe", "Override-only FHE at " + tag + " horizon [rad]", fhe_vals);
+    emit_metric(prefix, "ade", "Override-only ADE within " + tag + " horizon [m]", ade_vals);
+    emit_metric(prefix, "fde", "Override-only FDE at " + tag + " horizon [m]", fde_vals);
+    emit_metric(prefix, "ahe", "Override-only AHE within " + tag + " horizon [rad]", ahe_vals);
+    emit_metric(prefix, "fhe", "Override-only FHE at " + tag + " horizon [rad]", fhe_vals);
     emit_metric(
       prefix, "average_lateral_deviation",
       "Override-only average lateral deviation within " + tag + " horizon [m]", avg_lat_vals);
@@ -1852,14 +1848,12 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
       "Override-only max lateral deviation within " + tag + " horizon [m]", max_lat_vals);
     emit_metric(
       prefix, "average_longitudinal_deviation",
-      "Override-only average longitudinal deviation within " + tag + " horizon [m]",
-      avg_lon_vals);
+      "Override-only average longitudinal deviation within " + tag + " horizon [m]", avg_lon_vals);
     emit_metric(
       prefix, "max_longitudinal_deviation",
       "Override-only max longitudinal deviation within " + tag + " horizon [m]", max_lon_vals);
     emit_metric(
-      prefix, "min_ttc", "Override-only minimum TTC within " + tag + " horizon [s]",
-      min_ttc_vals);
+      prefix, "min_ttc", "Override-only minimum TTC within " + tag + " horizon [s]", min_ttc_vals);
   }
 
   return j;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -1390,43 +1390,6 @@ void OpenLoopEvaluator::calculate_summary()
   }
 }
 
-std::vector<std::pair<rclcpp::Time, rclcpp::Time>>
-OpenLoopEvaluator::compute_override_windows() const
-{
-  std::vector<std::pair<rclcpp::Time, rclcpp::Time>> windows;
-  if (override_window_sec_ <= 0.0 || control_mode_events_.size() < 2u) {
-    return windows;
-  }
-
-  const auto window_ns =
-    static_cast<rcutils_duration_value_t>(override_window_sec_ * 1e9);
-
-  auto previous_mode = control_mode_events_.front().second;
-  for (std::size_t i = 1; i < control_mode_events_.size(); ++i) {
-    const auto current_mode = control_mode_events_[i].second;
-    if (
-      previous_mode == ControlModeReport::AUTONOMOUS &&
-      current_mode == ControlModeReport::MANUAL) {
-      const auto start_ns = control_mode_events_[i].first;
-      windows.emplace_back(rclcpp::Time(start_ns), rclcpp::Time(start_ns + window_ns));
-    }
-    previous_mode = current_mode;
-  }
-  return windows;
-}
-
-bool OpenLoopEvaluator::is_within_any_window(
-  const rclcpp::Time & t,
-  const std::vector<std::pair<rclcpp::Time, rclcpp::Time>> & windows)
-{
-  for (const auto & [start, end] : windows) {
-    if (t >= start && t <= end) {
-      return true;
-    }
-  }
-  return false;
-}
-
 nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
 {
   nlohmann::json j;
@@ -1845,7 +1808,8 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
   // Re-aggregate per-horizon ADE/FDE (plus the rest of the horizon metrics for symmetry)
   // using only trajectory samples whose timestamp falls inside an override window derived
   // from AUTONOMOUS->MANUAL transitions in /vehicle/status/control_mode.
-  const auto override_windows = compute_override_windows();
+  const auto override_windows =
+    utils::compute_override_windows(control_mode_events_, override_window_sec_);
   j["override_only/num_windows"] = override_windows.size();
 
   for (const auto & tag : all_keys) {
@@ -1853,7 +1817,7 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
     std::vector<double> avg_lat_vals, max_lat_vals, avg_lon_vals, max_lon_vals;
     std::vector<double> min_ttc_vals;
     for (const auto & m : metrics_list_) {
-      if (!is_within_any_window(m.trajectory_timestamp, override_windows)) continue;
+      if (!utils::is_within_any_window(m.trajectory_timestamp, override_windows)) continue;
       const auto it = std::find_if(
         m.horizon_results.begin(), m.horizon_results.end(),
         [&tag](const auto & p) { return p.first == tag; });

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -23,6 +23,7 @@
 #include "metrics/epdms/subscores/extended_comfort.hpp"
 #include "metrics/epdms/subscores/lane_keeping.hpp"
 #include "metrics/trajectory_metrics.hpp"
+#include "utils/override_windows.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
@@ -201,8 +202,7 @@ public:
   /**
    * @brief Provide the timeline of ControlModeReport samples used to derive override windows.
    */
-  void set_control_mode_events(
-    std::vector<std::pair<rcutils_time_point_value_t, uint8_t>> events)
+  void set_control_mode_events(std::vector<utils::ControlModeEvent> events)
   {
     control_mode_events_ = std::move(events);
   }
@@ -362,25 +362,6 @@ private:
    */
   void calculate_summary();
 
-  /**
-   * @brief Derive override windows [start, end) from the ControlModeReport timeline.
-   *
-   * A window starts whenever the mode transitions from AUTONOMOUS to MANUAL and ends
-   * override_window_sec_ later. Returns an empty list when override_window_sec_ <= 0
-   * or no qualifying transition is found.
-   */
-  std::vector<std::pair<rclcpp::Time, rclcpp::Time>> compute_override_windows() const;
-
-  /**
-   * @brief Test whether a trajectory timestamp lies in any of the supplied windows.
-   *
-   * Assumes windows are sorted by start time. End time is inclusive to keep boundary
-   * samples (e.g. exactly window_sec after the transition).
-   */
-  static bool is_within_any_window(
-    const rclcpp::Time & t,
-    const std::vector<std::pair<rclcpp::Time, rclcpp::Time>> & windows);
-
   std::vector<OpenLoopTrajectoryMetrics> metrics_list_;
   std::vector<metrics::TrajectoryPointMetrics> trajectory_point_metrics_list_;
   std::vector<metrics::HumanFilterMetrics> human_filter_metrics_list_;
@@ -396,7 +377,7 @@ private:
   double gt_sync_tolerance_ms_;
   std::vector<double> evaluation_horizons_;
   double override_window_sec_{0.0};
-  std::vector<std::pair<rcutils_time_point_value_t, uint8_t>> control_mode_events_;
+  std::vector<utils::ControlModeEvent> control_mode_events_;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -191,6 +191,22 @@ public:
     extended_comfort_parameters_ = parameters;
   }
 
+  /**
+   * @brief Set the override window duration [s] applied after AUTONOMOUS->MANUAL transitions.
+   *
+   * A non-positive value disables override-only aggregation.
+   */
+  void set_override_window_sec(double window_sec) { override_window_sec_ = window_sec; }
+
+  /**
+   * @brief Provide the timeline of ControlModeReport samples used to derive override windows.
+   */
+  void set_control_mode_events(
+    std::vector<std::pair<rcutils_time_point_value_t, uint8_t>> events)
+  {
+    control_mode_events_ = std::move(events);
+  }
+
   nlohmann::json get_summary_as_json() const override;
 
   nlohmann::json get_detailed_results_as_json() const override;
@@ -346,6 +362,25 @@ private:
    */
   void calculate_summary();
 
+  /**
+   * @brief Derive override windows [start, end) from the ControlModeReport timeline.
+   *
+   * A window starts whenever the mode transitions from AUTONOMOUS to MANUAL and ends
+   * override_window_sec_ later. Returns an empty list when override_window_sec_ <= 0
+   * or no qualifying transition is found.
+   */
+  std::vector<std::pair<rclcpp::Time, rclcpp::Time>> compute_override_windows() const;
+
+  /**
+   * @brief Test whether a trajectory timestamp lies in any of the supplied windows.
+   *
+   * Assumes windows are sorted by start time. End time is inclusive to keep boundary
+   * samples (e.g. exactly window_sec after the transition).
+   */
+  static bool is_within_any_window(
+    const rclcpp::Time & t,
+    const std::vector<std::pair<rclcpp::Time, rclcpp::Time>> & windows);
+
   std::vector<OpenLoopTrajectoryMetrics> metrics_list_;
   std::vector<metrics::TrajectoryPointMetrics> trajectory_point_metrics_list_;
   std::vector<metrics::HumanFilterMetrics> human_filter_metrics_list_;
@@ -360,6 +395,8 @@ private:
   GTSourceMode gt_source_mode_;
   double gt_sync_tolerance_ms_;
   std::vector<double> evaluation_horizons_;
+  double override_window_sec_{0.0};
+  std::vector<std::pair<rcutils_time_point_value_t, uint8_t>> control_mode_events_;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
@@ -18,6 +18,8 @@
 
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 
+#include <vector>
+
 namespace autoware::planning_data_analyzer::utils
 {
 
@@ -35,8 +37,7 @@ std::vector<OverrideWindow> compute_override_windows(
   for (std::size_t i = 1; i < events.size(); ++i) {
     const auto current_mode = events[i].second;
     if (
-      previous_mode == ControlModeReport::AUTONOMOUS &&
-      current_mode == ControlModeReport::MANUAL) {
+      previous_mode == ControlModeReport::AUTONOMOUS && current_mode == ControlModeReport::MANUAL) {
       // Use RCL_ROS_TIME so windows can be compared against trajectory timestamps
       // produced from ROS message stamps (which default to RCL_ROS_TIME).
       const rclcpp::Time start_time(events[i].first, RCL_ROS_TIME);
@@ -47,8 +48,7 @@ std::vector<OverrideWindow> compute_override_windows(
   return windows;
 }
 
-bool is_within_any_window(
-  const rclcpp::Time & t, const std::vector<OverrideWindow> & windows)
+bool is_within_any_window(const rclcpp::Time & t, const std::vector<OverrideWindow> & windows)
 {
   for (const auto & [start, end] : windows) {
     if (t >= start && t <= end) {

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
@@ -37,7 +37,9 @@ std::vector<OverrideWindow> compute_override_windows(
     if (
       previous_mode == ControlModeReport::AUTONOMOUS &&
       current_mode == ControlModeReport::MANUAL) {
-      const rclcpp::Time start_time(events[i].first);
+      // Use RCL_ROS_TIME so windows can be compared against trajectory timestamps
+      // produced from ROS message stamps (which default to RCL_ROS_TIME).
+      const rclcpp::Time start_time(events[i].first, RCL_ROS_TIME);
       windows.emplace_back(start_time, start_time + window_duration);
     }
     previous_mode = current_mode;

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.cpp
@@ -1,0 +1,59 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils/override_windows.hpp"
+
+#include <rclcpp/duration.hpp>
+
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+
+namespace autoware::planning_data_analyzer::utils
+{
+
+std::vector<OverrideWindow> compute_override_windows(
+  const std::vector<ControlModeEvent> & events, const double window_sec)
+{
+  using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
+  std::vector<OverrideWindow> windows;
+  if (window_sec <= 0.0 || events.size() < 2u) {
+    return windows;
+  }
+
+  const auto window_duration = rclcpp::Duration::from_seconds(window_sec);
+  auto previous_mode = events.front().second;
+  for (std::size_t i = 1; i < events.size(); ++i) {
+    const auto current_mode = events[i].second;
+    if (
+      previous_mode == ControlModeReport::AUTONOMOUS &&
+      current_mode == ControlModeReport::MANUAL) {
+      const rclcpp::Time start_time(events[i].first);
+      windows.emplace_back(start_time, start_time + window_duration);
+    }
+    previous_mode = current_mode;
+  }
+  return windows;
+}
+
+bool is_within_any_window(
+  const rclcpp::Time & t, const std::vector<OverrideWindow> & windows)
+{
+  for (const auto & [start, end] : windows) {
+    if (t >= start && t <= end) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace autoware::planning_data_analyzer::utils

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.hpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.hpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.hpp
@@ -52,8 +52,7 @@ std::vector<OverrideWindow> compute_override_windows(
  * Both ends are inclusive so a sample exactly window_sec after the transition
  * still counts as inside the window.
  */
-bool is_within_any_window(
-  const rclcpp::Time & t, const std::vector<OverrideWindow> & windows);
+bool is_within_any_window(const rclcpp::Time & t, const std::vector<OverrideWindow> & windows);
 
 }  // namespace autoware::planning_data_analyzer::utils
 

--- a/planning/autoware_planning_data_analyzer/src/utils/override_windows.hpp
+++ b/planning/autoware_planning_data_analyzer/src/utils/override_windows.hpp
@@ -1,0 +1,60 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS__OVERRIDE_WINDOWS_HPP_
+#define UTILS__OVERRIDE_WINDOWS_HPP_
+
+#include <rclcpp/time.hpp>
+
+#include <rcutils/time.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::utils
+{
+
+using ControlModeEvent = std::pair<rcutils_time_point_value_t, uint8_t>;
+using OverrideWindow = std::pair<rclcpp::Time, rclcpp::Time>;
+
+/**
+ * @brief Derive [start, end] override windows from a sorted ControlModeReport timeline.
+ *
+ * A window is opened at every transition from AUTONOMOUS to MANUAL and closes
+ * window_sec seconds after the transition. Events must be sorted by timestamp
+ * ascending; ties are handled in input order (the predecessor sample defines
+ * the previous mode). Non-AUTONOMOUS->MANUAL transitions are ignored.
+ *
+ * @param events Sorted (timestamp_ns, mode) timeline.
+ * @param window_sec Window duration in seconds. A non-positive value returns an
+ *                   empty list.
+ * @return Override windows in event order. End time is start + window_sec and
+ *         treated as inclusive by is_within_any_window().
+ */
+std::vector<OverrideWindow> compute_override_windows(
+  const std::vector<ControlModeEvent> & events, double window_sec);
+
+/**
+ * @brief Test whether @p t lies within any of @p windows.
+ *
+ * Both ends are inclusive so a sample exactly window_sec after the transition
+ * still counts as inside the window.
+ */
+bool is_within_any_window(
+  const rclcpp::Time & t, const std::vector<OverrideWindow> & windows);
+
+}  // namespace autoware::planning_data_analyzer::utils
+
+#endif  // UTILS__OVERRIDE_WINDOWS_HPP_

--- a/planning/autoware_planning_data_analyzer/test/utils/test_override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/test/utils/test_override_windows.cpp
@@ -15,6 +15,7 @@
 #include "utils/override_windows.hpp"
 
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+
 #include <gtest/gtest.h>
 
 #include <cstdint>
@@ -23,10 +24,10 @@
 namespace
 {
 
-using autoware::planning_data_analyzer::utils::ControlModeEvent;
-using autoware::planning_data_analyzer::utils::OverrideWindow;
 using autoware::planning_data_analyzer::utils::compute_override_windows;
+using autoware::planning_data_analyzer::utils::ControlModeEvent;
 using autoware::planning_data_analyzer::utils::is_within_any_window;
+using autoware::planning_data_analyzer::utils::OverrideWindow;
 
 using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
 
@@ -105,9 +106,7 @@ TEST(OverrideWindowsTest, IsWithinAnyWindowHonoursBothEnds)
   const std::vector<OverrideWindow> windows{
     {rclcpp::Time(static_cast<int64_t>(1.0 * kNs), RCL_ROS_TIME),
      rclcpp::Time(static_cast<int64_t>(2.0 * kNs), RCL_ROS_TIME)}};
-  const auto t = [](double s) {
-    return rclcpp::Time(static_cast<int64_t>(s * kNs), RCL_ROS_TIME);
-  };
+  const auto t = [](double s) { return rclcpp::Time(static_cast<int64_t>(s * kNs), RCL_ROS_TIME); };
   // Inside
   EXPECT_TRUE(is_within_any_window(t(1.5), windows));
   // On boundaries (inclusive)

--- a/planning/autoware_planning_data_analyzer/test/utils/test_override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/test/utils/test_override_windows.cpp
@@ -103,19 +103,34 @@ TEST(OverrideWindowsTest, DetectsMultipleTransitions)
 TEST(OverrideWindowsTest, IsWithinAnyWindowHonoursBothEnds)
 {
   const std::vector<OverrideWindow> windows{
-    {rclcpp::Time(static_cast<int64_t>(1.0 * kNs)),
-     rclcpp::Time(static_cast<int64_t>(2.0 * kNs))}};
+    {rclcpp::Time(static_cast<int64_t>(1.0 * kNs), RCL_ROS_TIME),
+     rclcpp::Time(static_cast<int64_t>(2.0 * kNs), RCL_ROS_TIME)}};
+  const auto t = [](double s) {
+    return rclcpp::Time(static_cast<int64_t>(s * kNs), RCL_ROS_TIME);
+  };
   // Inside
-  EXPECT_TRUE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.5 * kNs)), windows));
+  EXPECT_TRUE(is_within_any_window(t(1.5), windows));
   // On boundaries (inclusive)
-  EXPECT_TRUE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.0 * kNs)), windows));
-  EXPECT_TRUE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(2.0 * kNs)), windows));
+  EXPECT_TRUE(is_within_any_window(t(1.0), windows));
+  EXPECT_TRUE(is_within_any_window(t(2.0), windows));
   // Outside
-  EXPECT_FALSE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(0.9 * kNs)), windows));
-  EXPECT_FALSE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(2.1 * kNs)), windows));
+  EXPECT_FALSE(is_within_any_window(t(0.9), windows));
+  EXPECT_FALSE(is_within_any_window(t(2.1), windows));
 }
 
 TEST(OverrideWindowsTest, IsWithinAnyWindowReturnsFalseWhenWindowsEmpty)
 {
-  EXPECT_FALSE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.0 * kNs)), {}));
+  EXPECT_FALSE(
+    is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.0 * kNs), RCL_ROS_TIME), {}));
+}
+
+TEST(OverrideWindowsTest, ComputedWindowsUseRosTimeClock)
+{
+  const std::vector<ControlModeEvent> events{
+    ev(0.0, ControlModeReport::AUTONOMOUS), ev(1.0, ControlModeReport::MANUAL)};
+  const auto windows = compute_override_windows(events, 0.5);
+  ASSERT_EQ(windows.size(), 1u);
+  // Windows must be comparable to timestamps derived from ROS message stamps.
+  EXPECT_EQ(windows[0].first.get_clock_type(), RCL_ROS_TIME);
+  EXPECT_EQ(windows[0].second.get_clock_type(), RCL_ROS_TIME);
 }

--- a/planning/autoware_planning_data_analyzer/test/utils/test_override_windows.cpp
+++ b/planning/autoware_planning_data_analyzer/test/utils/test_override_windows.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils/override_windows.hpp"
+
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+
+using autoware::planning_data_analyzer::utils::ControlModeEvent;
+using autoware::planning_data_analyzer::utils::OverrideWindow;
+using autoware::planning_data_analyzer::utils::compute_override_windows;
+using autoware::planning_data_analyzer::utils::is_within_any_window;
+
+using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
+
+constexpr rcutils_time_point_value_t kNs = 1'000'000'000LL;
+
+ControlModeEvent ev(const double seconds, const uint8_t mode)
+{
+  return {static_cast<rcutils_time_point_value_t>(seconds * kNs), mode};
+}
+
+}  // namespace
+
+TEST(OverrideWindowsTest, ReturnsEmptyForEmptyEvents)
+{
+  const auto windows = compute_override_windows({}, 1.0);
+  EXPECT_TRUE(windows.empty());
+}
+
+TEST(OverrideWindowsTest, ReturnsEmptyForSingleEvent)
+{
+  const std::vector<ControlModeEvent> events{ev(0.0, ControlModeReport::AUTONOMOUS)};
+  const auto windows = compute_override_windows(events, 1.0);
+  EXPECT_TRUE(windows.empty());
+}
+
+TEST(OverrideWindowsTest, ReturnsEmptyForNonPositiveWindow)
+{
+  const std::vector<ControlModeEvent> events{
+    ev(0.0, ControlModeReport::AUTONOMOUS), ev(1.0, ControlModeReport::MANUAL)};
+  EXPECT_TRUE(compute_override_windows(events, 0.0).empty());
+  EXPECT_TRUE(compute_override_windows(events, -1.0).empty());
+}
+
+TEST(OverrideWindowsTest, OpensWindowOnAutonomousToManualTransition)
+{
+  const std::vector<ControlModeEvent> events{
+    ev(0.0, ControlModeReport::AUTONOMOUS), ev(2.0, ControlModeReport::MANUAL)};
+  const auto windows = compute_override_windows(events, 0.5);
+  ASSERT_EQ(windows.size(), 1u);
+  EXPECT_EQ(windows[0].first.nanoseconds(), static_cast<int64_t>(2.0 * kNs));
+  EXPECT_EQ(windows[0].second.nanoseconds(), static_cast<int64_t>(2.5 * kNs));
+}
+
+TEST(OverrideWindowsTest, IgnoresManualToAutonomousTransition)
+{
+  const std::vector<ControlModeEvent> events{
+    ev(0.0, ControlModeReport::MANUAL), ev(1.0, ControlModeReport::AUTONOMOUS)};
+  EXPECT_TRUE(compute_override_windows(events, 1.0).empty());
+}
+
+TEST(OverrideWindowsTest, IgnoresAutonomousToNonManualTransition)
+{
+  const std::vector<ControlModeEvent> events{
+    ev(0.0, ControlModeReport::AUTONOMOUS), ev(1.0, ControlModeReport::DISENGAGED),
+    ev(2.0, ControlModeReport::AUTONOMOUS_STEER_ONLY)};
+  EXPECT_TRUE(compute_override_windows(events, 1.0).empty());
+}
+
+TEST(OverrideWindowsTest, DetectsMultipleTransitions)
+{
+  const std::vector<ControlModeEvent> events{
+    ev(0.0, ControlModeReport::AUTONOMOUS),  //
+    ev(1.0, ControlModeReport::MANUAL),      // -> window 1 at t=1
+    ev(2.0, ControlModeReport::AUTONOMOUS),  //
+    ev(3.0, ControlModeReport::MANUAL),      // -> window 2 at t=3
+    ev(4.0, ControlModeReport::MANUAL),      // no transition (MANUAL->MANUAL)
+  };
+  const auto windows = compute_override_windows(events, 0.5);
+  ASSERT_EQ(windows.size(), 2u);
+  EXPECT_EQ(windows[0].first.nanoseconds(), static_cast<int64_t>(1.0 * kNs));
+  EXPECT_EQ(windows[1].first.nanoseconds(), static_cast<int64_t>(3.0 * kNs));
+}
+
+TEST(OverrideWindowsTest, IsWithinAnyWindowHonoursBothEnds)
+{
+  const std::vector<OverrideWindow> windows{
+    {rclcpp::Time(static_cast<int64_t>(1.0 * kNs)),
+     rclcpp::Time(static_cast<int64_t>(2.0 * kNs))}};
+  // Inside
+  EXPECT_TRUE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.5 * kNs)), windows));
+  // On boundaries (inclusive)
+  EXPECT_TRUE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.0 * kNs)), windows));
+  EXPECT_TRUE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(2.0 * kNs)), windows));
+  // Outside
+  EXPECT_FALSE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(0.9 * kNs)), windows));
+  EXPECT_FALSE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(2.1 * kNs)), windows));
+}
+
+TEST(OverrideWindowsTest, IsWithinAnyWindowReturnsFalseWhenWindowsEmpty)
+{
+  EXPECT_FALSE(is_within_any_window(rclcpp::Time(static_cast<int64_t>(1.0 * kNs)), {}));
+}


### PR DESCRIPTION
## Description

Add a framework to compute ADE/FDE (and the other per-horizon trajectory metrics) restricted to scenes around override events. The analyzer now:

- Subscribes to `/vehicle/status/control_mode` (`autoware_vehicle_msgs/msg/ControlModeReport`) from the input bag (topic name configurable via `control_mode_topic`).
- Detects every `AUTONOMOUS -> MANUAL` transition and opens an override window of `open_loop.override.window_sec` seconds (default `0.5`) starting at the transition timestamp.
- Emits an additional `override_only/*` block in `time_step_based_trajectory_metric.json` containing the same per-horizon statistics as the existing aggregation, computed only over trajectory samples whose timestamp falls inside an override window.
- Reports `override_only/num_windows` so consumers can detect when no overrides were present (statistics are then empty).

The override window logic is implemented as pure free functions in `utils/override_windows.{hpp,cpp}` and covered by unit tests, so it can be exercised without instantiating `OpenLoopEvaluator`.

## How was this PR tested?

- `colcon build --packages-select autoware_planning_data_analyzer` (clean rebuild).
- `colcon test --packages-select autoware_planning_data_analyzer`: 51/51 gtest cases pass, including 10 new `OverrideWindowsTest` cases covering empty/single-event inputs, AUTONOMOUS->MANUAL filtering, multiple transitions, boundary inclusivity, and the RCL_ROS_TIME clock contract.
- Run on a real override scenario bag ([TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/2ba1da83-a9ee-5728-aef6-693bb3a94923/tests/dc0c9cdb-4988-5c05-b16e-8f6231d50cb7/9a39c00f-3eb3-5a91-a64e-3067d4f9e5d4/ea0f7447-3fcf-5ef6-9b13-4da46b796e69?project_id=x2_dev)). 
- Part of the json file 
```
  "override_only/full/min_ttc/description": "Override-only minimum TTC within full horizon [s]",
  "override_only/full/min_ttc/max": 1.7976931348623157e+308,
  "override_only/full/min_ttc/mean": null,
  "override_only/full/min_ttc/min": 1.7976931348623157e+308,
  "override_only/full/min_ttc/percentile_95": 1.7976931348623157e+308,
  "override_only/full/min_ttc/percentile_99": 1.7976931348623157e+308,
  "override_only/full/min_ttc/std": null,
  "override_only/num_windows": 1
```

## Notes for reviewers
- Override aggregation is keyed off the same horizon tags as the existing aggregation, so the diff in the summary JSON is purely additive (a new `override_only/*` namespace).

## Effects on system behavior
None