### PR TITLE
feat(planning_data_analyzer): migrate NC metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/CMakeLists.txt
+++ b/planning/autoware_planning_data_analyzer/CMakeLists.txt
@@ -13,6 +13,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/metrics/geometry/ego_footprint.cpp
   src/metrics/geometry/lanelet_geometry.cpp
   src/metrics/geometry/lanelet_queries.cpp
+  src/metrics/geometry/object_tracks.cpp
   src/metrics/epdms/aggregation/epdms_aggregation.cpp
   src/metrics/epdms/subscores/ego_progress.cpp
   src/metrics/epdms/subscores/driving_direction_compliance.cpp

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -25,6 +25,7 @@
     trajectory_topic: "/planning/trajectory"
     candidate_trajectories_topic: "/diffusion_planner/output/trajectories"
     objects_topic: "/perception/object_recognition/objects"
+    tracked_objects_topic: "/perception/object_recognition/tracking/objects"
     traffic_signals_topic: "/perception/traffic_light_recognition/traffic_signals"
     tf_topic: "/tf"
     acceleration_topic: "/localization/acceleration"
@@ -44,6 +45,9 @@
       # Debug visualization topics are expensive and disabled by default.
       # This switch is reserved for the follow-up debug-topic PR.
       debug_topics_enabled: false
+      # Maximum planned trajectory duration to evaluate [s].
+      # 0.0 means use the full trajectory from the bag.
+      trajectory_evaluation_horizon: 4.0
       hc:
         # NAVSIM-aligned default thresholds for the History Comfort (HC) subscore.
         finite_difference_epsilon: 0.001

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -124,6 +124,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   enabled_metric_names_ =
     get_or_declare_parameter<std::vector<std::string>>(*this, "open_loop.enabled_metrics");
   debug_topics_enabled_ = get_or_declare_parameter<bool>(*this, "open_loop.debug_topics_enabled");
+  trajectory_evaluation_horizon_s_ =
+    get_or_declare_parameter<double>(*this, "open_loop.trajectory_evaluation_horizon");
   history_comfort_params_.finite_difference_epsilon =
     get_or_declare_parameter<double>(*this, "open_loop.hc.finite_difference_epsilon");
   history_comfort_params_.max_longitudinal_acceleration =
@@ -155,6 +157,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   lane_keeping_params_.max_continuous_violation_time =
     get_or_declare_parameter<double>(*this, "open_loop.lane_keep.max_continuous_violation_time");
   objects_topic_name_ = get_or_declare_parameter<std::string>(*this, "objects_topic");
+  tracked_objects_topic_name_ =
+    get_or_declare_parameter<std::string>(*this, "tracked_objects_topic");
   traffic_signals_topic_name_ =
     get_or_declare_parameter<std::string>(*this, "traffic_signals_topic");
   tf_topic_name_ = get_or_declare_parameter<std::string>(*this, "tf_topic");
@@ -176,6 +180,11 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
     throw std::runtime_error(
       "Invalid open_loop.gt_sync_tolerance_ms: " + std::to_string(gt_sync_tolerance_ms_) +
       ". Expected >= 0.");
+  }
+  if (trajectory_evaluation_horizon_s_ < 0.0) {
+    throw std::runtime_error(
+      "Invalid open_loop.trajectory_evaluation_horizon: " +
+      std::to_string(trajectory_evaluation_horizon_s_) + ". Expected >= 0.");
   }
 
   // Read evaluation mode
@@ -469,6 +478,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   topic_names.candidate_trajectories_topic = candidate_trajectories_topic_name_;
   topic_names.gt_trajectory_topic = gt_trajectory_topic_name_;
   topic_names.objects_topic = objects_topic_name_;
+  topic_names.tracked_objects_topic = tracked_objects_topic_name_;
   topic_names.traffic_signals_topic = traffic_signals_topic_name_;
   topic_names.tf_topic = tf_topic_name_;
   topic_names.acceleration_topic = acceleration_topic_name_;
@@ -476,6 +486,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   topic_names.control_mode_topic = control_mode_topic_name_;
   topic_names.evaluation_interval_ms = evaluation_interval_ms_;
   topic_names.sync_tolerance_ms = sync_tolerance_ms_;
+  topic_names.trajectory_evaluation_horizon_s = trajectory_evaluation_horizon_s_;
   auto output_dir = get_or_declare_parameter<std::string>(*this, "output_dir");
   const std::filesystem::path output_dir_path(output_dir);
   if (output_dir.empty() || !output_dir_path.is_absolute()) {
@@ -503,6 +514,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       evaluator.set_metric_variant(open_loop_metric_variant);
       evaluator.set_enabled_metrics(enabled_metric_names_);
       evaluator.set_debug_topics_enabled(debug_topics_enabled_);
+      evaluator.set_trajectory_evaluation_horizon(trajectory_evaluation_horizon_s_);
       evaluator.set_evaluation_horizons(evaluation_horizons);
       evaluator.set_extended_comfort_parameters(extended_comfort_parameters_);
       evaluator.set_override_window_sec(override_window_sec_);

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -90,7 +90,7 @@ private:
   double gt_sync_tolerance_ms_ = 200.0;
   std::vector<std::string> enabled_metric_names_;
   bool debug_topics_enabled_ = false;
-  double trajectory_evaluation_horizon_s_ = 0.0;
+  double trajectory_evaluation_horizon_s_ = 4.0;
   metrics::HistoryComfortParameters history_comfort_params_;
   metrics::ExtendedComfortParameters extended_comfort_parameters_;
   metrics::LaneKeepingParameters lane_keeping_params_;

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -90,11 +90,13 @@ private:
   double gt_sync_tolerance_ms_ = 200.0;
   std::vector<std::string> enabled_metric_names_;
   bool debug_topics_enabled_ = false;
+  double trajectory_evaluation_horizon_s_ = 0.0;
   metrics::HistoryComfortParameters history_comfort_params_;
   metrics::ExtendedComfortParameters extended_comfort_parameters_;
   metrics::LaneKeepingParameters lane_keeping_params_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
   std::string objects_topic_name_;
+  std::string tracked_objects_topic_name_;
   std::string traffic_signals_topic_name_;
   std::string tf_topic_name_;
   std::string acceleration_topic_name_;

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -65,6 +65,8 @@ struct BagData
       candidate_trajectories_topic_key, buffer_duration_sec, max_buffer_msgs);
     create_buffer<PredictedObjects>(
       "/perception/object_recognition/objects", buffer_duration_sec, max_buffer_msgs);
+    create_buffer<TrackedObjects>(
+      "/perception/object_recognition/tracking/objects", buffer_duration_sec, max_buffer_msgs);
     create_buffer<TrafficLightGroupArray>(
       "/perception/traffic_light_recognition/traffic_signals", buffer_duration_sec,
       max_buffer_msgs);
@@ -97,6 +99,10 @@ struct BagData
     }
     create_buffer<PredictedObjects>(
       topic_names.objects_topic, buffer_duration_sec, max_buffer_msgs);
+    if (!topic_names.tracked_objects_topic.empty()) {
+      create_buffer<TrackedObjects>(
+        topic_names.tracked_objects_topic, buffer_duration_sec, max_buffer_msgs);
+    }
     if (!topic_names.traffic_signals_topic.empty()) {
       create_buffer<TrafficLightGroupArray>(
         topic_names.traffic_signals_topic, buffer_duration_sec, max_buffer_msgs);
@@ -243,6 +249,23 @@ struct BagData
       synchronized_data->objects = obj_buffer->get_closest(traj_stamp_ns, tolerance_ms);
     } else if (obj_buffer) {
       synchronized_data->objects = obj_buffer->get_closest(target_time, tolerance_ms);
+    }
+
+    std::shared_ptr<Buffer<TrackedObjects>> tracked_obj_buffer;
+    for (const auto & [topic, buffer] : buffers) {
+      if (auto ob = std::dynamic_pointer_cast<Buffer<TrackedObjects>>(buffer)) {
+        tracked_obj_buffer = ob;
+        break;
+      }
+    }
+    if (tracked_obj_buffer && synchronized_data->trajectory) {
+      const auto traj_stamp_ns =
+        rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
+      synchronized_data->tracked_objects =
+        tracked_obj_buffer->get_closest(traj_stamp_ns, tolerance_ms);
+    } else if (tracked_obj_buffer) {
+      synchronized_data->tracked_objects =
+        tracked_obj_buffer->get_closest(target_time, tolerance_ms);
     }
 
     // Get traffic signals

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -94,6 +94,12 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
       process_and_append_message<PredictedObjects>(
         serialized_message, bag_data, topic_names.objects_topic, use_bag_timestamp, logger_);
     } else if (
+      !topic_names.tracked_objects_topic.empty() &&
+      topic_name == topic_names.tracked_objects_topic) {
+      process_and_append_message<TrackedObjects>(
+        serialized_message, bag_data, topic_names.tracked_objects_topic, use_bag_timestamp,
+        logger_);
+    } else if (
       topic_name == topic_names.traffic_signals_topic &&
       !topic_names.traffic_signals_topic.empty()) {
       process_and_append_message<TrafficLightGroupArray>(
@@ -124,6 +130,19 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
   std::sort(
     result.control_mode_events.begin(), result.control_mode_events.end(),
     [](const auto & a, const auto & b) { return a.first < b.first; });
+
+  if (const auto object_itr = bag_data->buffers.find(topic_names.tracked_objects_topic);
+      object_itr != bag_data->buffers.end()) {
+    if (
+      const auto object_buffer =
+        std::dynamic_pointer_cast<Buffer<TrackedObjects>>(object_itr->second)) {
+      result.tracked_object_timeline.reserve(object_buffer->msgs.size());
+      for (const auto & objects : object_buffer->msgs) {
+        result.tracked_object_timeline.push_back(
+          TimedTrackedObjects{message_stamp(objects), std::make_shared<TrackedObjects>(objects)});
+      }
+    }
+  }
 
   // Get kinematic states at regular intervals
   auto kinematic_states =

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -146,6 +146,7 @@ protected:
   struct BagProcessingResult
   {
     std::vector<std::shared_ptr<SynchronizedData>> synchronized_data_list;
+    std::vector<TimedTrackedObjects> tracked_object_timeline;
     rclcpp::Time evaluation_start_time;
     rclcpp::Time evaluation_end_time;
     tf2_msgs::msg::TFMessage tf_static_msgs;

--- a/planning/autoware_planning_data_analyzer/src/data_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/data_types.hpp
@@ -87,7 +87,7 @@ struct TopicNames
   std::string control_mode_topic;
   double evaluation_interval_ms = 100.0;
   double sync_tolerance_ms = 100.0;
-  double trajectory_evaluation_horizon_s = 0.0;
+  double trajectory_evaluation_horizon_s = 4.0;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/src/data_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/data_types.hpp
@@ -19,6 +19,7 @@
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
@@ -29,6 +30,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer
 {
@@ -39,10 +41,17 @@ using CandidateTrajectories = autoware_internal_planning_msgs::msg::CandidateTra
 using TFMessage = tf2_msgs::msg::TFMessage;
 using Odometry = nav_msgs::msg::Odometry;
 using PredictedObjects = autoware_perception_msgs::msg::PredictedObjects;
+using TrackedObjects = autoware_perception_msgs::msg::TrackedObjects;
 using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
 using AccelWithCovarianceStamped = geometry_msgs::msg::AccelWithCovarianceStamped;
 using SteeringReport = autoware_vehicle_msgs::msg::SteeringReport;
 using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
+
+struct TimedTrackedObjects
+{
+  rclcpp::Time stamp;
+  std::shared_ptr<const TrackedObjects> objects;
+};
 
 // Synchronized data from multiple topics at a specific timestamp
 struct SynchronizedData
@@ -54,6 +63,8 @@ struct SynchronizedData
   std::shared_ptr<AccelWithCovarianceStamped> acceleration;
   std::shared_ptr<SteeringReport> steering_status;
   std::shared_ptr<PredictedObjects> objects;
+  std::shared_ptr<TrackedObjects> tracked_objects;
+  std::vector<TimedTrackedObjects> future_tracked_objects;
   std::shared_ptr<TrafficLightGroupArray> traffic_signals;
   rclcpp::Time timestamp;
   rclcpp::Time bag_timestamp;
@@ -68,6 +79,7 @@ struct TopicNames
   std::string candidate_trajectories_topic;
   std::string gt_trajectory_topic;
   std::string objects_topic;
+  std::string tracked_objects_topic;
   std::string traffic_signals_topic;
   std::string tf_topic;
   std::string acceleration_topic;
@@ -75,6 +87,7 @@ struct TopicNames
   std::string control_mode_topic;
   double evaluation_interval_ms = 100.0;
   double sync_tolerance_ms = 100.0;
+  double trajectory_evaluation_horizon_s = 0.0;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
@@ -24,12 +24,10 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
-#include <cstdint>
 #include <memory>
-#include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -44,7 +42,9 @@ using autoware_utils_geometry::Point2d;
 using autoware_utils_geometry::Polygon2d;
 namespace bg = boost::geometry;
 
-constexpr double kStoppedSpeedThreshold = 5.0e-2;
+// Strict NAVSIM-style physical-stop threshold for NC classification; this is intentionally
+// tighter than general perception stopped-vehicle thresholds to keep creeping objects active.
+constexpr double kStoppedVelocityThresholdMps = 5.0e-2;
 
 enum class CollisionType {
   StoppedEgo,
@@ -89,7 +89,7 @@ bool front_bumper_intersects(
 bool is_track_stopped(const InterpolatedLoggedObject & object_state)
 {
   return !is_agent_classification(object_state.classification) ||
-         object_state.speed_mps <= kStoppedSpeedThreshold;
+         object_state.speed_mps <= kStoppedVelocityThresholdMps;
 }
 
 CollisionType classify_collision(
@@ -97,7 +97,7 @@ CollisionType classify_collision(
   const InterpolatedLoggedObject & object_state,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
-  if (ego_speed(ego_point) <= kStoppedSpeedThreshold) {
+  if (ego_speed(ego_point) <= kStoppedVelocityThresholdMps) {
     return CollisionType::StoppedEgo;
   }
   if (is_track_stopped(object_state)) {
@@ -158,7 +158,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
     return result;
   }
 
-  std::set<std::array<uint8_t, 16>> collided_object_ids;
+  std::unordered_set<unique_identifier_msgs::msg::UUID, UuidHash> collided_object_ids;
   const auto trajectory_start_time = rclcpp::Time(trajectory.header.stamp);
 
   auto record_at_fault_collision = [&](

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
@@ -24,6 +24,7 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -54,10 +55,10 @@ enum class CollisionType {
   ActiveLateral,
 };
 
-struct EgoAreaFlags
+struct AtFaultCollision
 {
-  bool multiple_lanes{false};
-  bool non_drivable_area{false};
+  double score{1.0};
+  std::string reason{"available"};
 };
 
 double ego_speed(const autoware_planning_msgs::msg::TrajectoryPoint & point)
@@ -112,49 +113,15 @@ CollisionType classify_collision(
   return CollisionType::ActiveLateral;
 }
 
-bool footprint_intersects_lanelet(
-  const Polygon2d & footprint, const lanelet::ConstLanelet & lanelet)
-{
-  return !bg::disjoint(footprint, lanelet.polygon2d().basicPolygon());
-}
-
-std::optional<EgoAreaFlags> compute_ego_area_flags(
-  const geometry_msgs::msg::Pose & pose, const Polygon2d & ego_polygon,
-  const std::shared_ptr<RouteHandler> & route_handler)
-{
-  if (!route_handler || !route_handler->isHandlerReady()) {
-    return std::nullopt;
-  }
-
-  std::size_t intersecting_route_lanelets = 0;
-  for (const auto & lanelet : route_handler->getRoadLaneletsAtPose(pose)) {
-    if (!route_handler->isRouteLanelet(lanelet)) {
-      continue;
-    }
-    if (footprint_intersects_lanelet(ego_polygon, lanelet)) {
-      ++intersecting_route_lanelets;
-    }
-  }
-
-  EgoAreaFlags flags;
-  flags.non_drivable_area = intersecting_route_lanelets == 0U;
-  flags.multiple_lanes = intersecting_route_lanelets > 1U;
-  return flags;
-}
-
-NoAtFaultCollisionResult make_at_fault_result(
-  const InterpolatedLoggedObject & object, const double time_s, const bool lateral_collision)
+AtFaultCollision make_at_fault_collision(
+  const InterpolatedLoggedObject & object, const bool lateral_collision)
 {
   const bool agent = is_agent_classification(object.classification);
-  NoAtFaultCollisionResult result;
-  result.available = true;
-  result.score = agent ? 0.0 : 0.5;
-  result.infraction_time_s = time_s;
-  result.reason = lateral_collision ? (agent ? "at_fault_lateral_collision_with_agent"
-                                             : "at_fault_lateral_collision_with_non_agent")
-                                    : (agent ? "at_fault_collision_with_agent"
-                                             : "at_fault_collision_with_non_agent");
-  return result;
+  return AtFaultCollision{
+    agent ? 0.0 : 0.5, lateral_collision ? (agent ? "at_fault_lateral_collision_with_agent"
+                                                  : "at_fault_lateral_collision_with_non_agent")
+                                         : (agent ? "at_fault_collision_with_agent"
+                                                  : "at_fault_collision_with_non_agent")};
 }
 
 }  // namespace
@@ -164,6 +131,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler,
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations,
   const std::vector<LoggedObjectTrack> * object_tracks)
 {
   NoAtFaultCollisionResult result;
@@ -172,7 +140,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
     result.reason = "unavailable_empty_trajectory";
     return result;
   }
-  if (future_objects.empty() && !object_tracks) {
+  if (future_objects.empty()) {
     result.reason = "unavailable_no_future_objects";
     return result;
   }
@@ -192,14 +160,25 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
     return result;
   }
 
-  const auto local_footprint = vehicle_info.createFootprint(0.0);
+  const auto local_evaluations =
+    footprint_evaluations ? std::vector<TrajectoryFootprintEvaluation>{}
+                          : evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
+  const auto & evaluations = footprint_evaluations ? *footprint_evaluations : local_evaluations;
+  if (evaluations.size() != trajectory.points.size()) {
+    result.available = false;
+    result.reason = "unavailable_invalid_footprint";
+    result.score = 0.0;
+    return result;
+  }
+
   std::set<std::array<uint8_t, 16>> collided_object_ids;
   const auto trajectory_start_time = rclcpp::Time(trajectory.header.stamp);
 
-  for (const auto & point : trajectory.points) {
+  for (size_t index = 0; index < trajectory.points.size(); ++index) {
+    const auto & point = trajectory.points.at(index);
     const auto query_time = trajectory_start_time + rclcpp::Duration(point.time_from_start);
     const auto query_time_s = rclcpp::Duration(point.time_from_start).seconds();
-    const auto ego_polygon = create_pose_footprint(point.pose, local_footprint);
+    const auto & ego_polygon = evaluations.at(index).ego_polygon;
 
     for (const auto & object_track : tracks) {
       if (
@@ -225,12 +204,18 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
       const bool lateral_collision = collision_type == CollisionType::ActiveLateral;
 
       if (front_or_stopped_track) {
-        return make_at_fault_result(*object_state, query_time_s, false);
+        const auto at_fault_collision = make_at_fault_collision(*object_state, false);
+        if (at_fault_collision.score < result.score) {
+          result.score = at_fault_collision.score;
+          result.reason = at_fault_collision.reason;
+          result.infraction_time_s = query_time_s;
+        }
+        continue;
       }
 
       if (lateral_collision) {
-        const auto ego_area_flags = compute_ego_area_flags(point.pose, ego_polygon, route_handler);
-        if (!ego_area_flags.has_value()) {
+        const auto & ego_area_evaluation = evaluations.at(index).ego_area_evaluation;
+        if (!ego_area_evaluation.has_value()) {
           result.available = false;
           result.score = 0.0;
           result.reason = !route_handler
@@ -239,9 +224,17 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
           return result;
         }
 
-        if (ego_area_flags->multiple_lanes || ego_area_flags->non_drivable_area) {
-          return make_at_fault_result(*object_state, query_time_s, true);
+        if (
+          ego_area_evaluation->flags.multiple_lanes ||
+          ego_area_evaluation->flags.non_drivable_area) {
+          const auto at_fault_collision = make_at_fault_collision(*object_state, true);
+          if (at_fault_collision.score < result.score) {
+            result.score = at_fault_collision.score;
+            result.reason = at_fault_collision.reason;
+            result.infraction_time_s = query_time_s;
+          }
         }
+        continue;
       }
     }
   }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
@@ -17,20 +17,18 @@
 #include "metrics/geometry/ego_footprint.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 
-#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
 
 #include <boost/geometry.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -42,7 +40,6 @@ using autoware::route_handler::RouteHandler;
 namespace
 {
 
-using autoware_utils_geometry::LinearRing2d;
 using autoware_utils_geometry::Point2d;
 using autoware_utils_geometry::Polygon2d;
 namespace bg = boost::geometry;
@@ -57,21 +54,6 @@ enum class CollisionType {
   ActiveLateral,
 };
 
-struct ObjectState
-{
-  geometry_msgs::msg::Pose pose;
-  double speed_mps{0.0};
-  Polygon2d polygon;
-};
-
-struct PredictedObjectCache
-{
-  const autoware_perception_msgs::msg::PredictedObject * object{};
-  const autoware_perception_msgs::msg::PredictedPath * path{};
-  double dt{0.0};
-  double max_time{0.0};
-};
-
 struct EgoAreaFlags
 {
   bool multiple_lanes{false};
@@ -81,65 +63,6 @@ struct EgoAreaFlags
 double ego_speed(const autoware_planning_msgs::msg::TrajectoryPoint & point)
 {
   return std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps);
-}
-
-std::vector<PredictedObjectCache> build_object_caches(const PredictedObjects & objects)
-{
-  std::vector<PredictedObjectCache> caches;
-  caches.reserve(objects.objects.size());
-
-  for (const auto & object : objects.objects) {
-    PredictedObjectCache cache;
-    cache.object = &object;
-    cache.path = highest_confidence_path(object);
-    if (cache.path && cache.path->path.size() >= 2) {
-      cache.dt = rclcpp::Duration(cache.path->time_step).seconds();
-      if (cache.dt > 0.0) {
-        cache.max_time = cache.dt * static_cast<double>(cache.path->path.size() - 1);
-      } else {
-        cache.path = nullptr;
-        cache.dt = 0.0;
-      }
-    } else {
-      cache.path = nullptr;
-    }
-    caches.push_back(cache);
-  }
-
-  return caches;
-}
-
-std::optional<ObjectState> interpolate_object_state(
-  const PredictedObjectCache & cache, const double query_time_s)
-{
-  if (!cache.object) {
-    return std::nullopt;
-  }
-  ObjectState state;
-
-  if (query_time_s <= 0.0) {
-    state.pose = cache.object->kinematics.initial_pose_with_covariance.pose;
-    const auto & twist = cache.object->kinematics.initial_twist_with_covariance.twist.linear;
-    state.speed_mps = std::hypot(twist.x, twist.y);
-    state.polygon = autoware_utils_geometry::to_polygon2d(state.pose, cache.object->shape);
-    return state;
-  }
-  if (!cache.path || query_time_s > cache.max_time) {
-    return std::nullopt;
-  }
-
-  const std::size_t index =
-    std::min(static_cast<std::size_t>(query_time_s / cache.dt), cache.path->path.size() - 2);
-  const double t_i = static_cast<double>(index) * cache.dt;
-  const double ratio = std::clamp((query_time_s - t_i) / cache.dt, 0.0, 1.0);
-  state.pose = autoware_utils_geometry::calc_interpolated_pose(
-    cache.path->path.at(index), cache.path->path.at(index + 1), ratio);
-
-  const auto & p0 = cache.path->path.at(index).position;
-  const auto & p1 = cache.path->path.at(index + 1).position;
-  state.speed_mps = std::hypot(p1.x - p0.x, p1.y - p0.y) / cache.dt;
-  state.polygon = autoware_utils_geometry::to_polygon2d(state.pose, cache.object->shape);
-  return state;
 }
 
 bool front_bumper_intersects(
@@ -163,14 +86,21 @@ bool front_bumper_intersects(
   return bg::intersects(front_bumper, object_polygon);
 }
 
+bool is_track_stopped(const InterpolatedLoggedObject & object_state)
+{
+  return !is_agent_classification(object_state.classification) ||
+         object_state.speed_mps <= kStoppedSpeedThreshold;
+}
+
 CollisionType classify_collision(
-  const autoware_planning_msgs::msg::TrajectoryPoint & ego_point, const ObjectState & object_state,
+  const autoware_planning_msgs::msg::TrajectoryPoint & ego_point,
+  const InterpolatedLoggedObject & object_state,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
   if (ego_speed(ego_point) <= kStoppedSpeedThreshold) {
     return CollisionType::StoppedEgo;
   }
-  if (object_state.speed_mps <= kStoppedSpeedThreshold) {
+  if (is_track_stopped(object_state)) {
     return CollisionType::StoppedTrack;
   }
   if (is_agent_behind(ego_point.pose, object_state.pose)) {
@@ -192,10 +122,7 @@ std::optional<EgoAreaFlags> compute_ego_area_flags(
   const geometry_msgs::msg::Pose & pose, const Polygon2d & ego_polygon,
   const std::shared_ptr<RouteHandler> & route_handler)
 {
-  if (!route_handler) {
-    return std::nullopt;
-  }
-  if (!route_handler->isHandlerReady()) {
+  if (!route_handler || !route_handler->isHandlerReady()) {
     return std::nullopt;
   }
 
@@ -215,21 +142,29 @@ std::optional<EgoAreaFlags> compute_ego_area_flags(
   return flags;
 }
 
-bool is_agent_type(const autoware_perception_msgs::msg::PredictedObject & object)
+NoAtFaultCollisionResult make_at_fault_result(
+  const InterpolatedLoggedObject & object, const double time_s, const bool lateral_collision)
 {
-  using autoware_perception_msgs::msg::ObjectClassification;
-  const auto label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
-  return autoware::object_recognition_utils::isVehicle(label) ||
-         label == ObjectClassification::PEDESTRIAN || label == ObjectClassification::ANIMAL;
+  const bool agent = is_agent_classification(object.classification);
+  NoAtFaultCollisionResult result;
+  result.available = true;
+  result.score = agent ? 0.0 : 0.5;
+  result.infraction_time_s = time_s;
+  result.reason = lateral_collision ? (agent ? "at_fault_lateral_collision_with_agent"
+                                             : "at_fault_lateral_collision_with_non_agent")
+                                    : (agent ? "at_fault_collision_with_agent"
+                                             : "at_fault_collision_with_non_agent");
+  return result;
 }
 
 }  // namespace
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::shared_ptr<PredictedObjects> & objects,
+  const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::vector<LoggedObjectTrack> * object_tracks)
 {
   NoAtFaultCollisionResult result;
 
@@ -237,8 +172,8 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
     result.reason = "unavailable_empty_trajectory";
     return result;
   }
-  if (!objects) {
-    result.reason = "unavailable_no_objects_message";
+  if (future_objects.empty() && !object_tracks) {
+    result.reason = "unavailable_no_future_objects";
     return result;
   }
   if (!is_vehicle_info_valid(vehicle_info)) {
@@ -250,38 +185,47 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   result.score = 1.0;
   result.reason = "available";
 
-  if (objects->objects.empty()) {
+  const auto local_object_tracks =
+    object_tracks ? std::vector<LoggedObjectTrack>{} : build_logged_object_tracks(future_objects);
+  const auto & tracks = object_tracks ? *object_tracks : local_object_tracks;
+  if (tracks.empty()) {
     return result;
   }
 
   const auto local_footprint = vehicle_info.createFootprint(0.0);
-  const auto object_caches = build_object_caches(*objects);
+  std::set<std::array<uint8_t, 16>> collided_object_ids;
+  const auto trajectory_start_time = rclcpp::Time(trajectory.header.stamp);
 
   for (const auto & point : trajectory.points) {
+    const auto query_time = trajectory_start_time + rclcpp::Duration(point.time_from_start);
     const auto query_time_s = rclcpp::Duration(point.time_from_start).seconds();
     const auto ego_polygon = create_pose_footprint(point.pose, local_footprint);
 
-    for (const auto & object_cache : object_caches) {
-      const auto object_state = interpolate_object_state(object_cache, query_time_s);
-      if (!object_state.has_value()) {
+    for (const auto & object_track : tracks) {
+      if (
+        object_track.has_valid_object_id &&
+        collided_object_ids.count(object_track.object_id) > 0U) {
+        continue;
+      }
+
+      const auto object_state = interpolate_logged_object_state(object_track, query_time);
+      if (!object_state.has_value() || is_unknown_classification(object_state->classification)) {
         continue;
       }
       if (!bg::intersects(ego_polygon, object_state->polygon)) {
         continue;
       }
+      if (object_state->has_valid_object_id) {
+        collided_object_ids.insert(object_state->object_id);
+      }
 
       const auto collision_type = classify_collision(point, *object_state, vehicle_info);
-
       const bool front_or_stopped_track = collision_type == CollisionType::ActiveFront ||
                                           collision_type == CollisionType::StoppedTrack;
       const bool lateral_collision = collision_type == CollisionType::ActiveLateral;
 
       if (front_or_stopped_track) {
-        result.score = is_agent_type(*object_cache.object) ? 0.0 : 0.5;
-        result.reason = is_agent_type(*object_cache.object) ? "at_fault_collision_with_agent"
-                                                            : "at_fault_collision_with_non_agent";
-        result.infraction_time_s = query_time_s;
-        return result;
+        return make_at_fault_result(*object_state, query_time_s, false);
       }
 
       if (lateral_collision) {
@@ -296,12 +240,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
         }
 
         if (ego_area_flags->multiple_lanes || ego_area_flags->non_drivable_area) {
-          result.score = is_agent_type(*object_cache.object) ? 0.0 : 0.5;
-          result.reason = is_agent_type(*object_cache.object)
-                            ? "at_fault_lateral_collision_with_agent"
-                            : "at_fault_lateral_collision_with_non_agent";
-          result.infraction_time_s = query_time_s;
-          return result;
+          return make_at_fault_result(*object_state, query_time_s, true);
         }
       }
     }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.cpp
@@ -28,7 +28,6 @@
 #include <cmath>
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -117,31 +116,26 @@ AtFaultCollision make_at_fault_collision(
   const InterpolatedLoggedObject & object, const bool lateral_collision)
 {
   const bool agent = is_agent_classification(object.classification);
-  return AtFaultCollision{
-    agent ? 0.0 : 0.5, lateral_collision ? (agent ? "at_fault_lateral_collision_with_agent"
-                                                  : "at_fault_lateral_collision_with_non_agent")
-                                         : (agent ? "at_fault_collision_with_agent"
-                                                  : "at_fault_collision_with_non_agent")};
+  const double score = agent ? 0.0 : 0.5;
+  const std::string collision_scope =
+    lateral_collision ? "at_fault_lateral_collision" : "at_fault_collision";
+  const std::string object_kind = agent ? "with_agent" : "with_non_agent";
+  return AtFaultCollision{score, collision_scope + "_" + object_kind};
 }
 
 }  // namespace
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::vector<TimedTrackedObjects> & future_objects,
+  const std::vector<LoggedObjectTrack> & object_tracks,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler,
-  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations,
-  const std::vector<LoggedObjectTrack> * object_tracks)
+  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations)
 {
   NoAtFaultCollisionResult result;
 
   if (trajectory.points.empty()) {
     result.reason = "unavailable_empty_trajectory";
-    return result;
-  }
-  if (future_objects.empty()) {
-    result.reason = "unavailable_no_future_objects";
     return result;
   }
   if (!is_vehicle_info_valid(vehicle_info)) {
@@ -153,18 +147,11 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   result.score = 1.0;
   result.reason = "available";
 
-  const auto local_object_tracks =
-    object_tracks ? std::vector<LoggedObjectTrack>{} : build_logged_object_tracks(future_objects);
-  const auto & tracks = object_tracks ? *object_tracks : local_object_tracks;
-  if (tracks.empty()) {
+  if (object_tracks.empty()) {
     return result;
   }
 
-  const auto local_evaluations =
-    footprint_evaluations ? std::vector<TrajectoryFootprintEvaluation>{}
-                          : evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
-  const auto & evaluations = footprint_evaluations ? *footprint_evaluations : local_evaluations;
-  if (evaluations.size() != trajectory.points.size()) {
+  if (footprint_evaluations.size() != trajectory.points.size()) {
     result.available = false;
     result.reason = "unavailable_invalid_footprint";
     result.score = 0.0;
@@ -174,13 +161,27 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   std::set<std::array<uint8_t, 16>> collided_object_ids;
   const auto trajectory_start_time = rclcpp::Time(trajectory.header.stamp);
 
+  auto record_at_fault_collision = [&](
+                                     const InterpolatedLoggedObject & object_state,
+                                     const AtFaultCollision & at_fault_collision,
+                                     const double query_time_s) {
+    if (object_state.has_valid_object_id) {
+      collided_object_ids.insert(object_state.object_id);
+    }
+    if (at_fault_collision.score < result.score) {
+      result.score = at_fault_collision.score;
+      result.reason = at_fault_collision.reason;
+      result.infraction_time_s = query_time_s;
+    }
+  };
+
   for (size_t index = 0; index < trajectory.points.size(); ++index) {
     const auto & point = trajectory.points.at(index);
     const auto query_time = trajectory_start_time + rclcpp::Duration(point.time_from_start);
     const auto query_time_s = rclcpp::Duration(point.time_from_start).seconds();
-    const auto & ego_polygon = evaluations.at(index).ego_polygon;
+    const auto & ego_polygon = footprint_evaluations.at(index).ego_polygon;
 
-    for (const auto & object_track : tracks) {
+    for (const auto & object_track : object_tracks) {
       if (
         object_track.has_valid_object_id &&
         collided_object_ids.count(object_track.object_id) > 0U) {
@@ -194,9 +195,6 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
       if (!bg::intersects(ego_polygon, object_state->polygon)) {
         continue;
       }
-      if (object_state->has_valid_object_id) {
-        collided_object_ids.insert(object_state->object_id);
-      }
 
       const auto collision_type = classify_collision(point, *object_state, vehicle_info);
       const bool front_or_stopped_track = collision_type == CollisionType::ActiveFront ||
@@ -205,16 +203,12 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
 
       if (front_or_stopped_track) {
         const auto at_fault_collision = make_at_fault_collision(*object_state, false);
-        if (at_fault_collision.score < result.score) {
-          result.score = at_fault_collision.score;
-          result.reason = at_fault_collision.reason;
-          result.infraction_time_s = query_time_s;
-        }
+        record_at_fault_collision(*object_state, at_fault_collision, query_time_s);
         continue;
       }
 
       if (lateral_collision) {
-        const auto & ego_area_evaluation = evaluations.at(index).ego_area_evaluation;
+        const auto & ego_area_evaluation = footprint_evaluations.at(index).ego_area_evaluation;
         if (!ego_area_evaluation.has_value()) {
           result.available = false;
           result.score = 0.0;
@@ -228,11 +222,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
           ego_area_evaluation->flags.multiple_lanes ||
           ego_area_evaluation->flags.non_drivable_area) {
           const auto at_fault_collision = make_at_fault_collision(*object_state, true);
-          if (at_fault_collision.score < result.score) {
-            result.score = at_fault_collision.score;
-            result.reason = at_fault_collision.reason;
-            result.infraction_time_s = query_time_s;
-          }
+          record_at_fault_collision(*object_state, at_fault_collision, query_time_s);
         }
         continue;
       }
@@ -240,6 +230,24 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   }
 
   return result;
+}
+
+NoAtFaultCollisionResult calculate_no_at_fault_collision(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<TimedTrackedObjects> & future_objects,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::shared_ptr<RouteHandler> & route_handler)
+{
+  if (future_objects.empty()) {
+    NoAtFaultCollisionResult result;
+    result.reason = "unavailable_no_future_objects";
+    return result;
+  }
+  const auto object_tracks = build_logged_object_tracks(future_objects);
+  const auto footprint_evaluations =
+    evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
+  return calculate_no_at_fault_collision(
+    trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations);
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
@@ -16,6 +16,7 @@
 #define METRICS__EPDMS__SUBSCORES__NO_AT_FAULT_COLLISION_HPP_
 
 #include "data_types.hpp"
+#include "metrics/geometry/ego_footprint.hpp"
 #include "metrics/geometry/object_tracks.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
@@ -44,6 +45,7 @@ NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const std::shared_ptr<RouteHandler> & route_handler = nullptr,
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr,
   const std::vector<LoggedObjectTrack> * object_tracks = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
@@ -16,6 +16,7 @@
 #define METRICS__EPDMS__SUBSCORES__NO_AT_FAULT_COLLISION_HPP_
 
 #include "data_types.hpp"
+#include "metrics/geometry/object_tracks.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
@@ -23,6 +24,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
@@ -39,9 +41,10 @@ struct NoAtFaultCollisionResult
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::shared_ptr<PredictedObjects> & objects,
+  const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr);
+  const std::shared_ptr<RouteHandler> & route_handler = nullptr,
+  const std::vector<LoggedObjectTrack> * object_tracks = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/no_at_fault_collision.hpp
@@ -42,11 +42,16 @@ struct NoAtFaultCollisionResult
 
 NoAtFaultCollisionResult calculate_no_at_fault_collision(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<LoggedObjectTrack> & object_tracks,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::vector<TrajectoryFootprintEvaluation> & footprint_evaluations);
+
+NoAtFaultCollisionResult calculate_no_at_fault_collision(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr,
-  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr,
-  const std::vector<LoggedObjectTrack> * object_tracks = nullptr);
+  const std::shared_ptr<RouteHandler> & route_handler = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.cpp
@@ -44,8 +44,9 @@ double forward_offset_in_ego_frame(
 bool is_agent_behind(
   const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & object_pose)
 {
-  constexpr double kPi = 3.14159265358979323846;
-  constexpr double kBehindAngleThresholdRad = 5.0 * kPi / 6.0;
+  // NAVSIM-style rear check: treat an object as behind only when it is more than
+  // 150 degrees away from the ego forward axis.
+  constexpr double kBehindAngleThresholdRad = 5.0 * M_PI / 6.0;
 
   const double yaw = get_yaw(ego_pose.orientation);
   const double dx = object_pose.position.x - ego_pose.position.x;

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/metric_utils.cpp
@@ -44,7 +44,20 @@ double forward_offset_in_ego_frame(
 bool is_agent_behind(
   const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & object_pose)
 {
-  return forward_offset_in_ego_frame(ego_pose, object_pose) < 0.0;
+  constexpr double kPi = 3.14159265358979323846;
+  constexpr double kBehindAngleThresholdRad = 5.0 * kPi / 6.0;
+
+  const double yaw = get_yaw(ego_pose.orientation);
+  const double dx = object_pose.position.x - ego_pose.position.x;
+  const double dy = object_pose.position.y - ego_pose.position.y;
+  const double distance = std::hypot(dx, dy);
+  if (distance <= 1.0e-6) {
+    return false;
+  }
+
+  const double cos_angle =
+    std::clamp((std::cos(yaw) * dx + std::sin(yaw) * dy) / distance, -1.0, 1.0);
+  return std::acos(cos_angle) > kBehindAngleThresholdRad;
 }
 
 const autoware_perception_msgs::msg::PredictedPath * highest_confidence_path(

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
@@ -206,6 +206,43 @@ std::vector<LoggedObjectTrack> build_logged_object_tracks(
   return tracks;
 }
 
+std::vector<TimedTrackedObjects> get_future_objects_for_trajectory(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<TimedTrackedObjects> & object_timeline, const double horizon_s)
+{
+  std::vector<TimedTrackedObjects> future_objects;
+  if (trajectory.points.empty() || object_timeline.empty()) {
+    return future_objects;
+  }
+
+  const auto trajectory_start_ns = rclcpp::Time(trajectory.header.stamp).nanoseconds();
+  auto trajectory_horizon_ns =
+    rclcpp::Duration(trajectory.points.back().time_from_start).nanoseconds();
+  if (horizon_s > 0.0) {
+    trajectory_horizon_ns =
+      std::min(trajectory_horizon_ns, rclcpp::Duration::from_seconds(horizon_s).nanoseconds());
+  }
+
+  constexpr rcutils_time_point_value_t kFutureObjectRangeMarginNs =
+    static_cast<rcutils_time_point_value_t>(200'000'000);
+  const auto range_end_ns =
+    trajectory_start_ns + trajectory_horizon_ns + kFutureObjectRangeMarginNs;
+
+  const auto first = std::lower_bound(
+    object_timeline.begin(), object_timeline.end(), trajectory_start_ns,
+    [](const TimedTrackedObjects & timed_objects, const rcutils_time_point_value_t stamp_ns) {
+      return timed_objects.stamp.nanoseconds() < stamp_ns;
+    });
+
+  for (auto itr = first; itr != object_timeline.end(); ++itr) {
+    if (itr->stamp.nanoseconds() > range_end_ns) {
+      break;
+    }
+    future_objects.push_back(*itr);
+  }
+  return future_objects;
+}
+
 std::optional<InterpolatedLoggedObject> interpolate_logged_object_state(
   const LoggedObjectTrack & track, const rclcpp::Time & query_time)
 {

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
@@ -23,8 +23,10 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdlib>
-#include <map>
+#include <functional>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -34,11 +36,23 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
+struct ObjectIdHash
+{
+  std::size_t operator()(const std::array<uint8_t, 16> & object_id) const
+  {
+    std::size_t seed = 0U;
+    for (const auto byte : object_id) {
+      seed ^= std::hash<uint8_t>{}(byte) + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
+    }
+    return seed;
+  }
+};
+
 double closest_pi_symmetric_yaw(const double reference_yaw, const double yaw)
 {
   double best_yaw = yaw;
   double best_error = std::abs(yaw - reference_yaw);
-  for (int multiplier = -2; multiplier <= 2; ++multiplier) {
+  for (int multiplier = -1; multiplier <= 1; ++multiplier) {
     const double candidate_yaw = yaw + static_cast<double>(multiplier) * M_PI;
     const double candidate_error = std::abs(candidate_yaw - reference_yaw);
     if (candidate_error < best_error) {
@@ -69,6 +83,8 @@ bool should_hold_long_object_yaw(
   const LoggedObjectState & previous_state, const LoggedObjectState & current_state,
   const double previous_yaw, const double current_yaw)
 {
+  // These thresholds suppress tracker yaw flips for long slow/stationary objects, where
+  // a bounding box can jump by about pi without the object physically turning.
   constexpr double kLongObjectLengthThresholdM = 8.0;
   constexpr double kSlowObjectSpeedThresholdMps = 2.0;
   constexpr double kSmallDisplacementThresholdM = 0.75;
@@ -159,7 +175,7 @@ bool is_unknown_classification(
 std::vector<LoggedObjectTrack> build_logged_object_tracks(
   const std::vector<TimedTrackedObjects> & future_objects)
 {
-  std::map<std::array<uint8_t, 16>, LoggedObjectTrack> keyed_tracks;
+  std::unordered_map<std::array<uint8_t, 16>, LoggedObjectTrack, ObjectIdHash> keyed_tracks;
   std::vector<LoggedObjectTrack> invalid_id_tracks;
 
   for (const auto & timed_objects : future_objects) {
@@ -200,6 +216,9 @@ std::vector<LoggedObjectTrack> build_logged_object_tracks(
     canonicalize_bounding_box_yaws(track);
     tracks.push_back(std::move(track));
   }
+  std::sort(tracks.begin(), tracks.end(), [](const auto & lhs, const auto & rhs) {
+    return lhs.object_id < rhs.object_id;
+  });
   for (auto & track : invalid_id_tracks) {
     tracks.push_back(std::move(track));
   }
@@ -223,6 +242,8 @@ std::vector<TimedTrackedObjects> get_future_objects_for_trajectory(
       std::min(trajectory_horizon_ns, rclcpp::Duration::from_seconds(horizon_s).nanoseconds());
   }
 
+  // This is not message sync tolerance. Keep one extra tracker sample beyond the trajectory
+  // horizon so interpolation at the last trajectory point can still use a following object state.
   constexpr rcutils_time_point_value_t kFutureObjectRangeMarginNs =
     static_cast<rcutils_time_point_value_t>(200'000'000);
   const auto range_end_ns =

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
@@ -19,13 +19,11 @@
 #include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
-#include <cstddef>
 #include <cstdlib>
-#include <functional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -36,23 +34,11 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
-struct ObjectIdHash
-{
-  std::size_t operator()(const std::array<uint8_t, 16> & object_id) const
-  {
-    std::size_t seed = 0U;
-    for (const auto byte : object_id) {
-      seed ^= std::hash<uint8_t>{}(byte) + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
-    }
-    return seed;
-  }
-};
-
 double closest_pi_symmetric_yaw(const double reference_yaw, const double yaw)
 {
   double best_yaw = yaw;
   double best_error = std::abs(yaw - reference_yaw);
-  for (int multiplier = -1; multiplier <= 1; ++multiplier) {
+  for (const int multiplier : {-1, 0, 1}) {
     const double candidate_yaw = yaw + static_cast<double>(multiplier) * M_PI;
     const double candidate_error = std::abs(candidate_yaw - reference_yaw);
     if (candidate_error < best_error) {
@@ -63,20 +49,9 @@ double closest_pi_symmetric_yaw(const double reference_yaw, const double yaw)
   return best_yaw;
 }
 
-double normalize_angle(const double angle)
-{
-  return std::atan2(std::sin(angle), std::cos(angle));
-}
-
 double planar_speed_mps(const geometry_msgs::msg::Twist & twist)
 {
   return std::hypot(twist.linear.x, twist.linear.y);
-}
-
-double planar_displacement_m(
-  const geometry_msgs::msg::Pose & lhs, const geometry_msgs::msg::Pose & rhs)
-{
-  return autoware_utils_geometry::calc_distance2d(lhs.position, rhs.position);
 }
 
 bool should_hold_long_object_yaw(
@@ -102,12 +77,14 @@ bool should_hold_long_object_yaw(
     return false;
   }
 
-  const double displacement = planar_displacement_m(previous_state.pose, current_state.pose);
+  const double displacement = autoware_utils_geometry::calc_distance2d(
+    previous_state.pose.position, current_state.pose.position);
   if (displacement > kSmallDisplacementThresholdM) {
     return false;
   }
 
-  const double yaw_delta = std::abs(normalize_angle(current_yaw - previous_yaw));
+  const double yaw_delta =
+    std::abs(autoware_utils_math::normalize_radian(current_yaw - previous_yaw));
   return yaw_delta > kLargeYawJumpThresholdRad;
 }
 
@@ -150,11 +127,6 @@ bool has_valid_object_id(const unique_identifier_msgs::msg::UUID & object_id)
     object_id.uuid.begin(), object_id.uuid.end(), [](const auto byte) { return byte != 0U; });
 }
 
-std::array<uint8_t, 16> object_id_key(const unique_identifier_msgs::msg::UUID & object_id)
-{
-  return object_id.uuid;
-}
-
 bool is_agent_classification(
   const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
 {
@@ -175,7 +147,7 @@ bool is_unknown_classification(
 std::vector<LoggedObjectTrack> build_logged_object_tracks(
   const std::vector<TimedTrackedObjects> & future_objects)
 {
-  std::unordered_map<std::array<uint8_t, 16>, LoggedObjectTrack, ObjectIdHash> keyed_tracks;
+  std::unordered_map<unique_identifier_msgs::msg::UUID, LoggedObjectTrack, UuidHash> keyed_tracks;
   std::vector<LoggedObjectTrack> invalid_id_tracks;
 
   for (const auto & timed_objects : future_objects) {
@@ -199,9 +171,8 @@ std::vector<LoggedObjectTrack> build_logged_object_tracks(
         continue;
       }
 
-      const auto key = object_id_key(object.object_id);
-      auto & track = keyed_tracks[key];
-      track.object_id = key;
+      auto & track = keyed_tracks[object.object_id];
+      track.object_id = object.object_id;
       track.has_valid_object_id = true;
       track.states.push_back(state);
     }
@@ -217,7 +188,7 @@ std::vector<LoggedObjectTrack> build_logged_object_tracks(
     tracks.push_back(std::move(track));
   }
   std::sort(tracks.begin(), tracks.end(), [](const auto & lhs, const auto & rhs) {
-    return lhs.object_id < rhs.object_id;
+    return lhs.object_id.uuid < rhs.object_id.uuid;
   });
   for (auto & track : invalid_id_tracks) {
     tracks.push_back(std::move(track));
@@ -255,12 +226,12 @@ std::vector<TimedTrackedObjects> get_future_objects_for_trajectory(
       return timed_objects.stamp.nanoseconds() < stamp_ns;
     });
 
-  for (auto itr = first; itr != object_timeline.end(); ++itr) {
-    if (itr->stamp.nanoseconds() > range_end_ns) {
-      break;
-    }
-    future_objects.push_back(*itr);
-  }
+  const auto last = std::upper_bound(
+    first, object_timeline.end(), range_end_ns,
+    [](const rcutils_time_point_value_t stamp_ns, const TimedTrackedObjects & timed_objects) {
+      return stamp_ns < timed_objects.stamp.nanoseconds();
+    });
+  future_objects.assign(first, last);
   return future_objects;
 }
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.cpp
@@ -1,0 +1,283 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "object_tracks.hpp"
+
+#include "metric_utils.hpp"
+
+#include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware_utils_geometry/boost_polygon_utils.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics
+{
+
+namespace
+{
+
+double closest_pi_symmetric_yaw(const double reference_yaw, const double yaw)
+{
+  double best_yaw = yaw;
+  double best_error = std::abs(yaw - reference_yaw);
+  for (int multiplier = -2; multiplier <= 2; ++multiplier) {
+    const double candidate_yaw = yaw + static_cast<double>(multiplier) * M_PI;
+    const double candidate_error = std::abs(candidate_yaw - reference_yaw);
+    if (candidate_error < best_error) {
+      best_yaw = candidate_yaw;
+      best_error = candidate_error;
+    }
+  }
+  return best_yaw;
+}
+
+double normalize_angle(const double angle)
+{
+  return std::atan2(std::sin(angle), std::cos(angle));
+}
+
+double planar_speed_mps(const geometry_msgs::msg::Twist & twist)
+{
+  return std::hypot(twist.linear.x, twist.linear.y);
+}
+
+double planar_displacement_m(
+  const geometry_msgs::msg::Pose & lhs, const geometry_msgs::msg::Pose & rhs)
+{
+  return autoware_utils_geometry::calc_distance2d(lhs.position, rhs.position);
+}
+
+bool should_hold_long_object_yaw(
+  const LoggedObjectState & previous_state, const LoggedObjectState & current_state,
+  const double previous_yaw, const double current_yaw)
+{
+  constexpr double kLongObjectLengthThresholdM = 8.0;
+  constexpr double kSlowObjectSpeedThresholdMps = 2.0;
+  constexpr double kSmallDisplacementThresholdM = 0.75;
+  constexpr double kLargeYawJumpThresholdRad = 10.0 * M_PI / 180.0;
+
+  const double object_length =
+    std::max(previous_state.shape.dimensions.x, current_state.shape.dimensions.x);
+  if (object_length < kLongObjectLengthThresholdM) {
+    return false;
+  }
+
+  const double max_speed =
+    std::max(planar_speed_mps(previous_state.twist), planar_speed_mps(current_state.twist));
+  if (max_speed > kSlowObjectSpeedThresholdMps) {
+    return false;
+  }
+
+  const double displacement = planar_displacement_m(previous_state.pose, current_state.pose);
+  if (displacement > kSmallDisplacementThresholdM) {
+    return false;
+  }
+
+  const double yaw_delta = std::abs(normalize_angle(current_yaw - previous_yaw));
+  return yaw_delta > kLargeYawJumpThresholdRad;
+}
+
+void canonicalize_bounding_box_yaws(LoggedObjectTrack & track)
+{
+  if (track.states.size() < 2U) {
+    return;
+  }
+
+  bool has_reference_yaw = false;
+  double reference_yaw = 0.0;
+  const LoggedObjectState * previous_state = nullptr;
+  for (auto & state : track.states) {
+    if (state.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+      has_reference_yaw = false;
+      previous_state = nullptr;
+      continue;
+    }
+
+    const double raw_yaw = get_yaw(state.pose.orientation);
+    double canonical_yaw =
+      has_reference_yaw ? closest_pi_symmetric_yaw(reference_yaw, raw_yaw) : raw_yaw;
+    if (
+      has_reference_yaw && previous_state &&
+      should_hold_long_object_yaw(*previous_state, state, reference_yaw, canonical_yaw)) {
+      canonical_yaw = reference_yaw;
+    }
+    state.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(canonical_yaw);
+    reference_yaw = canonical_yaw;
+    has_reference_yaw = true;
+    previous_state = &state;
+  }
+}
+
+}  // namespace
+
+bool has_valid_object_id(const unique_identifier_msgs::msg::UUID & object_id)
+{
+  return std::any_of(
+    object_id.uuid.begin(), object_id.uuid.end(), [](const auto byte) { return byte != 0U; });
+}
+
+std::array<uint8_t, 16> object_id_key(const unique_identifier_msgs::msg::UUID & object_id)
+{
+  return object_id.uuid;
+}
+
+bool is_agent_classification(
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
+{
+  using autoware_perception_msgs::msg::ObjectClassification;
+  const auto label = autoware::object_recognition_utils::getHighestProbLabel(classification);
+  return autoware::object_recognition_utils::isVehicle(label) ||
+         label == ObjectClassification::PEDESTRIAN || label == ObjectClassification::ANIMAL;
+}
+
+bool is_unknown_classification(
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification)
+{
+  using autoware_perception_msgs::msg::ObjectClassification;
+  return autoware::object_recognition_utils::getHighestProbLabel(classification) ==
+         ObjectClassification::UNKNOWN;
+}
+
+std::vector<LoggedObjectTrack> build_logged_object_tracks(
+  const std::vector<TimedTrackedObjects> & future_objects)
+{
+  std::map<std::array<uint8_t, 16>, LoggedObjectTrack> keyed_tracks;
+  std::vector<LoggedObjectTrack> invalid_id_tracks;
+
+  for (const auto & timed_objects : future_objects) {
+    if (!timed_objects.objects) {
+      continue;
+    }
+    for (const auto & object : timed_objects.objects->objects) {
+      LoggedObjectState state;
+      state.stamp = timed_objects.stamp;
+      state.pose = object.kinematics.pose_with_covariance.pose;
+      state.twist = object.kinematics.twist_with_covariance.twist;
+      state.shape = object.shape;
+      state.classification = object.classification;
+
+      const bool valid_id = has_valid_object_id(object.object_id);
+      if (!valid_id) {
+        LoggedObjectTrack track;
+        track.has_valid_object_id = false;
+        track.states.push_back(state);
+        invalid_id_tracks.push_back(track);
+        continue;
+      }
+
+      const auto key = object_id_key(object.object_id);
+      auto & track = keyed_tracks[key];
+      track.object_id = key;
+      track.has_valid_object_id = true;
+      track.states.push_back(state);
+    }
+  }
+
+  std::vector<LoggedObjectTrack> tracks;
+  tracks.reserve(keyed_tracks.size() + invalid_id_tracks.size());
+  for (auto & [_, track] : keyed_tracks) {
+    std::sort(track.states.begin(), track.states.end(), [](const auto & lhs, const auto & rhs) {
+      return lhs.stamp.nanoseconds() < rhs.stamp.nanoseconds();
+    });
+    canonicalize_bounding_box_yaws(track);
+    tracks.push_back(std::move(track));
+  }
+  for (auto & track : invalid_id_tracks) {
+    tracks.push_back(std::move(track));
+  }
+  return tracks;
+}
+
+std::optional<InterpolatedLoggedObject> interpolate_logged_object_state(
+  const LoggedObjectTrack & track, const rclcpp::Time & query_time)
+{
+  if (track.states.empty()) {
+    return std::nullopt;
+  }
+
+  auto make_object = [&](const LoggedObjectState & state, const double speed_mps) {
+    InterpolatedLoggedObject object;
+    object.object_id = track.object_id;
+    object.has_valid_object_id = track.has_valid_object_id;
+    object.pose = state.pose;
+    object.speed_mps = speed_mps;
+    object.shape = state.shape;
+    object.classification = state.classification;
+    object.polygon = autoware_utils_geometry::to_polygon2d(object.pose, object.shape);
+    return object;
+  };
+
+  if (track.states.size() == 1U) {
+    const auto & state = track.states.front();
+    constexpr int64_t kSingleStateToleranceNs = 50'000'000;
+    if (
+      std::llabs(query_time.nanoseconds() - state.stamp.nanoseconds()) > kSingleStateToleranceNs) {
+      return std::nullopt;
+    }
+    return make_object(state, std::hypot(state.twist.linear.x, state.twist.linear.y));
+  }
+
+  if (
+    query_time.nanoseconds() < track.states.front().stamp.nanoseconds() ||
+    query_time.nanoseconds() > track.states.back().stamp.nanoseconds()) {
+    return std::nullopt;
+  }
+
+  auto after = std::lower_bound(
+    track.states.begin(), track.states.end(), query_time,
+    [](const auto & state, const auto & time) {
+      return state.stamp.nanoseconds() < time.nanoseconds();
+    });
+  if (after == track.states.begin()) {
+    return make_object(*after, std::hypot(after->twist.linear.x, after->twist.linear.y));
+  }
+  if (after == track.states.end()) {
+    const auto & state = track.states.back();
+    return make_object(state, std::hypot(state.twist.linear.x, state.twist.linear.y));
+  }
+
+  const auto & previous = *(after - 1);
+  const auto & next = *after;
+  const double dt = (next.stamp - previous.stamp).seconds();
+  if (dt <= 0.0) {
+    return make_object(next, std::hypot(next.twist.linear.x, next.twist.linear.y));
+  }
+
+  const double ratio = std::clamp((query_time - previous.stamp).seconds() / dt, 0.0, 1.0);
+  InterpolatedLoggedObject object;
+  object.object_id = track.object_id;
+  object.has_valid_object_id = track.has_valid_object_id;
+  object.pose =
+    autoware_utils_geometry::calc_interpolated_pose(previous.pose, next.pose, ratio, false);
+  const double logged_speed = std::hypot(previous.twist.linear.x, previous.twist.linear.y);
+  if (std::isfinite(logged_speed) && logged_speed > 1.0e-6) {
+    object.speed_mps = logged_speed;
+  } else {
+    object.speed_mps =
+      autoware_utils_geometry::calc_distance2d(previous.pose.position, next.pose.position) / dt;
+  }
+  object.shape = previous.shape;
+  object.classification = previous.classification;
+  object.polygon = autoware_utils_geometry::to_polygon2d(object.pose, object.shape);
+  return object;
+}
+
+}  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.hpp
@@ -73,6 +73,10 @@ bool is_unknown_classification(
 std::vector<LoggedObjectTrack> build_logged_object_tracks(
   const std::vector<TimedTrackedObjects> & future_objects);
 
+std::vector<TimedTrackedObjects> get_future_objects_for_trajectory(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<TimedTrackedObjects> & object_timeline, double horizon_s);
+
 std::optional<InterpolatedLoggedObject> interpolate_logged_object_state(
   const LoggedObjectTrack & track, const rclcpp::Time & query_time);
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.hpp
@@ -17,6 +17,7 @@
 
 #include "data_types.hpp"
 
+#include <autoware_utils/ros/uuid_helper.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
@@ -25,13 +26,22 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
-#include <array>
-#include <cstdint>
+#include <boost/uuid/uuid_hash.hpp>
+
+#include <cstddef>
 #include <optional>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
+
+struct UuidHash
+{
+  std::size_t operator()(const unique_identifier_msgs::msg::UUID & object_id) const
+  {
+    return boost::hash<boost::uuids::uuid>{}(autoware_utils::to_boost_uuid(object_id));
+  }
+};
 
 struct LoggedObjectState
 {
@@ -44,14 +54,14 @@ struct LoggedObjectState
 
 struct LoggedObjectTrack
 {
-  std::array<uint8_t, 16> object_id{};
+  unique_identifier_msgs::msg::UUID object_id{};
   bool has_valid_object_id{false};
   std::vector<LoggedObjectState> states;
 };
 
 struct InterpolatedLoggedObject
 {
-  std::array<uint8_t, 16> object_id{};
+  unique_identifier_msgs::msg::UUID object_id{};
   bool has_valid_object_id{false};
   geometry_msgs::msg::Pose pose;
   double speed_mps{0.0};
@@ -61,8 +71,6 @@ struct InterpolatedLoggedObject
 };
 
 bool has_valid_object_id(const unique_identifier_msgs::msg::UUID & object_id);
-
-std::array<uint8_t, 16> object_id_key(const unique_identifier_msgs::msg::UUID & object_id);
 
 bool is_agent_classification(
   const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification);

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/object_tracks.hpp
@@ -1,0 +1,81 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef METRICS__GEOMETRY__OBJECT_TRACKS_HPP_
+#define METRICS__GEOMETRY__OBJECT_TRACKS_HPP_
+
+#include "data_types.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics
+{
+
+struct LoggedObjectState
+{
+  rclcpp::Time stamp;
+  geometry_msgs::msg::Pose pose;
+  geometry_msgs::msg::Twist twist;
+  autoware_perception_msgs::msg::Shape shape;
+  std::vector<autoware_perception_msgs::msg::ObjectClassification> classification;
+};
+
+struct LoggedObjectTrack
+{
+  std::array<uint8_t, 16> object_id{};
+  bool has_valid_object_id{false};
+  std::vector<LoggedObjectState> states;
+};
+
+struct InterpolatedLoggedObject
+{
+  std::array<uint8_t, 16> object_id{};
+  bool has_valid_object_id{false};
+  geometry_msgs::msg::Pose pose;
+  double speed_mps{0.0};
+  autoware_perception_msgs::msg::Shape shape;
+  std::vector<autoware_perception_msgs::msg::ObjectClassification> classification;
+  autoware_utils_geometry::Polygon2d polygon;
+};
+
+bool has_valid_object_id(const unique_identifier_msgs::msg::UUID & object_id);
+
+std::array<uint8_t, 16> object_id_key(const unique_identifier_msgs::msg::UUID & object_id);
+
+bool is_agent_classification(
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification);
+
+bool is_unknown_classification(
+  const std::vector<autoware_perception_msgs::msg::ObjectClassification> & classification);
+
+std::vector<LoggedObjectTrack> build_logged_object_tracks(
+  const std::vector<TimedTrackedObjects> & future_objects);
+
+std::optional<InterpolatedLoggedObject> interpolate_logged_object_state(
+  const LoggedObjectTrack & track, const rclcpp::Time & query_time);
+
+}  // namespace autoware::planning_data_analyzer::metrics
+
+#endif  // METRICS__GEOMETRY__OBJECT_TRACKS_HPP_

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -26,7 +26,6 @@
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/intersection.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <tf2/LinearMath/Vector3.hpp>
 
@@ -256,8 +255,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   metrics.time_to_collision_within_bound_available = ttc_within_bound.available;
   metrics.time_to_collision_within_bound_reason = ttc_within_bound.reason;
   metrics.time_to_collision_infraction_time_s = ttc_within_bound.infraction_time_s;
-  const auto no_at_fault_collision =
-    calculate_no_at_fault_collision(trajectory, sync_data->objects, vehicle_info, route_handler);
+  const auto no_at_fault_collision = calculate_no_at_fault_collision(
+    trajectory, sync_data->future_tracked_objects, vehicle_info, route_handler);
   metrics.no_at_fault_collision = no_at_fault_collision.score;
   metrics.no_at_fault_collision_available = no_at_fault_collision.available;
   metrics.no_at_fault_collision_reason = no_at_fault_collision.reason;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -261,8 +261,14 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   metrics.time_to_collision_infraction_time_s = ttc_within_bound.infraction_time_s;
   const auto footprint_evaluations =
     evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
-  const auto no_at_fault_collision = calculate_no_at_fault_collision(
-    trajectory, logged_future_objects, vehicle_info, route_handler, &footprint_evaluations);
+  NoAtFaultCollisionResult no_at_fault_collision;
+  if (logged_future_objects.empty()) {
+    no_at_fault_collision.reason = "unavailable_no_future_objects";
+  } else {
+    const auto object_tracks = build_logged_object_tracks(logged_future_objects);
+    no_at_fault_collision = calculate_no_at_fault_collision(
+      trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations);
+  }
   metrics.no_at_fault_collision = no_at_fault_collision.score;
   metrics.no_at_fault_collision_available = no_at_fault_collision.available;
   metrics.no_at_fault_collision_reason = no_at_fault_collision.reason;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -20,6 +20,7 @@
 #include "metrics/epdms/subscores/no_at_fault_collision.hpp"
 #include "metrics/epdms/subscores/traffic_light_compliance.hpp"
 #include "metrics/epdms/subscores/ttc_within_bound.hpp"
+#include "metrics/geometry/ego_footprint.hpp"
 #include "metrics/geometry/lanelet_queries.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 
@@ -227,7 +228,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   const HistoryComfortParameters & history_comfort_params,
   const LaneKeepingParameters & lane_keeping_params,
   const DrivingDirectionComplianceParameters & driving_direction_params,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::vector<TimedTrackedObjects> & future_objects)
 {
   TrajectoryPointMetrics metrics;
 
@@ -236,6 +238,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   }
 
   const auto & trajectory = *sync_data->trajectory;
+  const auto & logged_future_objects =
+    future_objects.empty() ? sync_data->future_tracked_objects : future_objects;
   const size_t num_points = trajectory.points.size();
 
   // Initialize vectors
@@ -255,8 +259,10 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   metrics.time_to_collision_within_bound_available = ttc_within_bound.available;
   metrics.time_to_collision_within_bound_reason = ttc_within_bound.reason;
   metrics.time_to_collision_infraction_time_s = ttc_within_bound.infraction_time_s;
+  const auto footprint_evaluations =
+    evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
   const auto no_at_fault_collision = calculate_no_at_fault_collision(
-    trajectory, sync_data->future_tracked_objects, vehicle_info, route_handler);
+    trajectory, logged_future_objects, vehicle_info, route_handler, &footprint_evaluations);
   metrics.no_at_fault_collision = no_at_fault_collision.score;
   metrics.no_at_fault_collision_available = no_at_fault_collision.available;
   metrics.no_at_fault_collision_reason = no_at_fault_collision.reason;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
@@ -96,7 +96,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   const DrivingDirectionComplianceParameters & driving_direction_params =
     DrivingDirectionComplianceParameters{},
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info =
-    autoware::vehicle_info_utils::VehicleInfo{});
+    autoware::vehicle_info_utils::VehicleInfo{},
+  const std::vector<TimedTrackedObjects> & future_objects = {});
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -2427,39 +2427,6 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
 
   // Pass the control_mode timeline to enable override-only aggregation in the summary.
   set_control_mode_events(std::move(bag_result.control_mode_events));
-  for (auto & sync_data : bag_result.synchronized_data_list) {
-    if (!sync_data || !sync_data->trajectory || bag_result.tracked_object_timeline.empty()) {
-      continue;
-    }
-
-    const auto trajectory_start = rclcpp::Time(sync_data->trajectory->header.stamp);
-    auto trajectory_duration =
-      rclcpp::Duration(sync_data->trajectory->points.back().time_from_start);
-    if (topic_names.trajectory_evaluation_horizon_s > 0.0) {
-      trajectory_duration = std::min(
-        trajectory_duration,
-        rclcpp::Duration::from_seconds(topic_names.trajectory_evaluation_horizon_s));
-    }
-    const auto trajectory_end = trajectory_start + trajectory_duration;
-    constexpr int64_t kObjectTimelineMarginNs = 200'000'000;
-    const int64_t start_ns = trajectory_start.nanoseconds();
-    const int64_t end_ns = trajectory_end.nanoseconds() + kObjectTimelineMarginNs;
-
-    const auto first = std::lower_bound(
-      bag_result.tracked_object_timeline.begin(), bag_result.tracked_object_timeline.end(),
-      start_ns, [](const TimedTrackedObjects & timed_objects, const int64_t stamp_ns) {
-        return timed_objects.stamp.nanoseconds() < stamp_ns;
-      });
-
-    sync_data->future_tracked_objects.reserve(
-      std::distance(first, bag_result.tracked_object_timeline.end()));
-    for (auto itr = first; itr != bag_result.tracked_object_timeline.end(); ++itr) {
-      if (itr->stamp.nanoseconds() > end_ns) {
-        break;
-      }
-      sync_data->future_tracked_objects.push_back(*itr);
-    }
-  }
 
   if (gt_source_mode_ == GTSourceMode::GT_TRAJECTORY) {
     if (!bag_result.gt_trajectory_topic_seen || bag_result.gt_trajectory_message_count == 0) {

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -16,6 +16,7 @@
 
 #include "metrics/epdms/aggregation/epdms_aggregation.hpp"
 #include "metrics/geometry/metric_utils.hpp"
+#include "metrics/geometry/object_tracks.hpp"
 #include "metrics/trajectory_metrics.hpp"
 
 #include <autoware/motion_utils/trajectory/conversion.hpp>
@@ -212,43 +213,6 @@ autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
   }
 
   return truncated;
-}
-
-std::vector<TimedTrackedObjects> get_future_objects_for_trajectory(
-  const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::vector<TimedTrackedObjects> & object_timeline, const double horizon_s)
-{
-  std::vector<TimedTrackedObjects> future_objects;
-  if (trajectory.points.empty() || object_timeline.empty()) {
-    return future_objects;
-  }
-
-  const auto trajectory_start_ns = rclcpp::Time(trajectory.header.stamp).nanoseconds();
-  auto trajectory_horizon_ns =
-    rclcpp::Duration(trajectory.points.back().time_from_start).nanoseconds();
-  if (horizon_s > 0.0) {
-    trajectory_horizon_ns =
-      std::min(trajectory_horizon_ns, rclcpp::Duration::from_seconds(horizon_s).nanoseconds());
-  }
-
-  constexpr rcutils_time_point_value_t kFutureObjectRangeMarginNs =
-    static_cast<rcutils_time_point_value_t>(200'000'000);
-  const auto range_end_ns =
-    trajectory_start_ns + trajectory_horizon_ns + kFutureObjectRangeMarginNs;
-
-  const auto first = std::lower_bound(
-    object_timeline.begin(), object_timeline.end(), trajectory_start_ns,
-    [](const TimedTrackedObjects & timed_objects, const rcutils_time_point_value_t stamp_ns) {
-      return timed_objects.stamp.nanoseconds() < stamp_ns;
-    });
-
-  for (auto itr = first; itr != object_timeline.end(); ++itr) {
-    if (itr->stamp.nanoseconds() > range_end_ns) {
-      break;
-    }
-    future_objects.push_back(*itr);
-  }
-  return future_objects;
 }
 
 metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetrics & metrics)
@@ -567,7 +531,7 @@ void OpenLoopEvaluator::evaluate(
         const auto & eval_data = evaluation_data_list[i];
         const auto future_objects =
           eval_data.synchronized_data && eval_data.synchronized_data->trajectory
-            ? get_future_objects_for_trajectory(
+            ? metrics::get_future_objects_for_trajectory(
                 *eval_data.synchronized_data->trajectory, object_timeline_,
                 trajectory_evaluation_horizon_s_)
             : std::vector<TimedTrackedObjects>{};

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -209,6 +209,9 @@ autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
           interpolate_trajectory_point(truncated.points.back(), point, horizon_s));
       }
     }
+    if (truncated.points.empty()) {
+      truncated.points.push_back(point);
+    }
     return truncated;
   }
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -145,6 +145,75 @@ std::shared_ptr<SynchronizedData> clone_with_trajectory(
   return cloned;
 }
 
+double point_time_s(const autoware_planning_msgs::msg::TrajectoryPoint & point)
+{
+  return rclcpp::Duration(point.time_from_start).seconds();
+}
+
+double lerp(const double lhs, const double rhs, const double ratio)
+{
+  return lhs + (rhs - lhs) * ratio;
+}
+
+autoware_planning_msgs::msg::TrajectoryPoint interpolate_trajectory_point(
+  const autoware_planning_msgs::msg::TrajectoryPoint & previous,
+  const autoware_planning_msgs::msg::TrajectoryPoint & next, const double horizon_s)
+{
+  const double previous_t = point_time_s(previous);
+  const double next_t = point_time_s(next);
+  const double ratio = next_t > previous_t
+                         ? std::clamp((horizon_s - previous_t) / (next_t - previous_t), 0.0, 1.0)
+                         : 0.0;
+
+  auto interpolated = previous;
+  interpolated.pose =
+    autoware_utils_geometry::calc_interpolated_pose(previous.pose, next.pose, ratio);
+  interpolated.longitudinal_velocity_mps =
+    lerp(previous.longitudinal_velocity_mps, next.longitudinal_velocity_mps, ratio);
+  interpolated.lateral_velocity_mps =
+    lerp(previous.lateral_velocity_mps, next.lateral_velocity_mps, ratio);
+  interpolated.acceleration_mps2 = lerp(previous.acceleration_mps2, next.acceleration_mps2, ratio);
+  interpolated.heading_rate_rps = lerp(previous.heading_rate_rps, next.heading_rate_rps, ratio);
+  interpolated.front_wheel_angle_rad =
+    lerp(previous.front_wheel_angle_rad, next.front_wheel_angle_rad, ratio);
+  interpolated.rear_wheel_angle_rad =
+    lerp(previous.rear_wheel_angle_rad, next.rear_wheel_angle_rad, ratio);
+  interpolated.time_from_start = rclcpp::Duration::from_seconds(horizon_s);
+  return interpolated;
+}
+
+autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const double horizon_s)
+{
+  constexpr double kTimeEpsilon = 1.0e-6;
+  if (horizon_s <= 0.0 || trajectory.points.empty()) {
+    return trajectory;
+  }
+
+  autoware_planning_msgs::msg::Trajectory truncated;
+  truncated.header = trajectory.header;
+  truncated.points.reserve(trajectory.points.size());
+
+  for (const auto & point : trajectory.points) {
+    const double t = point_time_s(point);
+    if (t <= horizon_s + kTimeEpsilon) {
+      truncated.points.push_back(point);
+      continue;
+    }
+
+    if (!truncated.points.empty()) {
+      const double previous_t = point_time_s(truncated.points.back());
+      if (previous_t < horizon_s - kTimeEpsilon) {
+        truncated.points.push_back(
+          interpolate_trajectory_point(truncated.points.back(), point, horizon_s));
+      }
+    }
+    return truncated;
+  }
+
+  return truncated;
+}
+
 metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetrics & metrics)
 {
   metrics::EpdmsMetricSnapshot snapshot;
@@ -668,10 +737,14 @@ std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evalua
       continue;
     }
 
-    const size_t num_pts = data->trajectory->points.size();
+    const auto truncated_trajectory =
+      truncate_trajectory_by_horizon(*data->trajectory, trajectory_evaluation_horizon_s_);
+    const auto truncated_data = clone_with_trajectory(data, truncated_trajectory);
+
+    const size_t num_pts = truncated_data->trajectory->points.size();
     if (num_pts <= 1u) {
       // Include frame in output as failure (no metrics); do not skip.
-      result.push_back({data, autoware_planning_msgs::msg::Trajectory{}});
+      result.push_back({truncated_data, autoware_planning_msgs::msg::Trajectory{}});
       continue;
     }
 
@@ -679,15 +752,17 @@ std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evalua
     if (gt_source_mode_ == GTSourceMode::GT_TRAJECTORY) {
       // In gt_trajectory mode, tolerate short startup timing gaps by skipping frames
       // where GT topic is missing/empty, instead of aborting the whole evaluation.
-      if (!data->ground_truth_trajectory_msg || data->ground_truth_trajectory_msg->points.empty()) {
+      if (
+        !truncated_data->ground_truth_trajectory_msg ||
+        truncated_data->ground_truth_trajectory_msg->points.empty()) {
         RCLCPP_WARN(
           logger_,
           "Skipping trajectory at time %f in gt_trajectory mode - GT topic message was "
           "missing or empty.",
-          data->timestamp.seconds());
+          truncated_data->timestamp.seconds());
         continue;
       }
-      ground_truth_opt = generate_ground_truth_trajectory_from_topic(data);
+      ground_truth_opt = generate_ground_truth_trajectory_from_topic(truncated_data);
       if (!ground_truth_opt.has_value()) {
         // For per-trajectory prediction issues (e.g., too few predicted points, invalid timing,
         // out-of-tolerance alignment), skip this frame and continue evaluating others.
@@ -695,22 +770,22 @@ std::vector<OpenLoopEvaluator::EvaluationData> OpenLoopEvaluator::prepare_evalua
           logger_,
           "Skipping trajectory at time %f in gt_trajectory mode - predicted trajectory was "
           "invalid for evaluation (GT topic exists).",
-          data->timestamp.seconds());
+          truncated_data->timestamp.seconds());
         continue;
       }
     } else {
-      ground_truth_opt = generate_ground_truth_trajectory(data, synchronized_data_list);
+      ground_truth_opt = generate_ground_truth_trajectory(truncated_data, synchronized_data_list);
     }
 
     if (!ground_truth_opt.has_value()) {
       RCLCPP_WARN(
         logger_, "Skipping trajectory at time %f - ground truth generation failed",
-        data->timestamp.seconds());
+        truncated_data->timestamp.seconds());
       continue;
     }
 
     // Add valid evaluation data
-    result.push_back({data, ground_truth_opt.value()});
+    result.push_back({truncated_data, ground_truth_opt.value()});
   }
 
   return result;
@@ -2344,6 +2419,36 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
 
   // Pass the control_mode timeline to enable override-only aggregation in the summary.
   set_control_mode_events(std::move(bag_result.control_mode_events));
+  for (auto & sync_data : bag_result.synchronized_data_list) {
+    if (!sync_data || !sync_data->trajectory || bag_result.tracked_object_timeline.empty()) {
+      continue;
+    }
+
+    const auto trajectory_start = rclcpp::Time(sync_data->trajectory->header.stamp);
+    auto trajectory_duration =
+      rclcpp::Duration(sync_data->trajectory->points.back().time_from_start);
+    if (topic_names.trajectory_evaluation_horizon_s > 0.0) {
+      trajectory_duration = std::min(
+        trajectory_duration,
+        rclcpp::Duration::from_seconds(topic_names.trajectory_evaluation_horizon_s));
+    }
+    const auto trajectory_end = trajectory_start + trajectory_duration;
+    constexpr int64_t kObjectTimelineMarginNs = 100'000'000;
+    const int64_t start_ns = trajectory_start.nanoseconds() - kObjectTimelineMarginNs;
+    const int64_t end_ns = trajectory_end.nanoseconds() + kObjectTimelineMarginNs;
+
+    sync_data->future_tracked_objects.reserve(bag_result.tracked_object_timeline.size());
+    for (const auto & timed_objects : bag_result.tracked_object_timeline) {
+      const int64_t stamp_ns = timed_objects.stamp.nanoseconds();
+      if (stamp_ns < start_ns) {
+        continue;
+      }
+      if (stamp_ns > end_ns) {
+        break;
+      }
+      sync_data->future_tracked_objects.push_back(timed_objects);
+    }
+  }
 
   if (gt_source_mode_ == GTSourceMode::GT_TRAJECTORY) {
     if (!bag_result.gt_trajectory_topic_seen || bag_result.gt_trajectory_message_count == 0) {

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -214,6 +214,43 @@ autoware_planning_msgs::msg::Trajectory truncate_trajectory_by_horizon(
   return truncated;
 }
 
+std::vector<TimedTrackedObjects> get_future_objects_for_trajectory(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<TimedTrackedObjects> & object_timeline, const double horizon_s)
+{
+  std::vector<TimedTrackedObjects> future_objects;
+  if (trajectory.points.empty() || object_timeline.empty()) {
+    return future_objects;
+  }
+
+  const auto trajectory_start_ns = rclcpp::Time(trajectory.header.stamp).nanoseconds();
+  auto trajectory_horizon_ns =
+    rclcpp::Duration(trajectory.points.back().time_from_start).nanoseconds();
+  if (horizon_s > 0.0) {
+    trajectory_horizon_ns =
+      std::min(trajectory_horizon_ns, rclcpp::Duration::from_seconds(horizon_s).nanoseconds());
+  }
+
+  constexpr rcutils_time_point_value_t kFutureObjectRangeMarginNs =
+    static_cast<rcutils_time_point_value_t>(200'000'000);
+  const auto range_end_ns =
+    trajectory_start_ns + trajectory_horizon_ns + kFutureObjectRangeMarginNs;
+
+  const auto first = std::lower_bound(
+    object_timeline.begin(), object_timeline.end(), trajectory_start_ns,
+    [](const TimedTrackedObjects & timed_objects, const rcutils_time_point_value_t stamp_ns) {
+      return timed_objects.stamp.nanoseconds() < stamp_ns;
+    });
+
+  for (auto itr = first; itr != object_timeline.end(); ++itr) {
+    if (itr->stamp.nanoseconds() > range_end_ns) {
+      break;
+    }
+    future_objects.push_back(*itr);
+  }
+  return future_objects;
+}
+
 metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetrics & metrics)
 {
   metrics::EpdmsMetricSnapshot snapshot;
@@ -528,9 +565,15 @@ void OpenLoopEvaluator::evaluate(
 
       try {
         const auto & eval_data = evaluation_data_list[i];
+        const auto future_objects =
+          eval_data.synchronized_data && eval_data.synchronized_data->trajectory
+            ? get_future_objects_for_trajectory(
+                *eval_data.synchronized_data->trajectory, object_timeline_,
+                trajectory_evaluation_horizon_s_)
+            : std::vector<TimedTrackedObjects>{};
         auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
           eval_data.synchronized_data, route_handler_, history_comfort_params_,
-          lane_keeping_params_, driving_direction_params_, vehicle_info_);
+          lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects);
         auto metrics = evaluate_trajectory(eval_data);
         metrics.history_comfort = trajectory_metrics.history_comfort;
         metrics.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
@@ -2416,6 +2459,7 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
 
   // Use base class method to process bag and get synchronized data
   auto bag_result = process_bag_common(bag_path, evaluation_bag_writer, topic_names);
+  object_timeline_ = bag_result.tracked_object_timeline;
 
   // Pass the control_mode timeline to enable override-only aggregation in the summary.
   set_control_mode_events(std::move(bag_result.control_mode_events));
@@ -2433,20 +2477,23 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
         rclcpp::Duration::from_seconds(topic_names.trajectory_evaluation_horizon_s));
     }
     const auto trajectory_end = trajectory_start + trajectory_duration;
-    constexpr int64_t kObjectTimelineMarginNs = 100'000'000;
-    const int64_t start_ns = trajectory_start.nanoseconds() - kObjectTimelineMarginNs;
+    constexpr int64_t kObjectTimelineMarginNs = 200'000'000;
+    const int64_t start_ns = trajectory_start.nanoseconds();
     const int64_t end_ns = trajectory_end.nanoseconds() + kObjectTimelineMarginNs;
 
-    sync_data->future_tracked_objects.reserve(bag_result.tracked_object_timeline.size());
-    for (const auto & timed_objects : bag_result.tracked_object_timeline) {
-      const int64_t stamp_ns = timed_objects.stamp.nanoseconds();
-      if (stamp_ns < start_ns) {
-        continue;
-      }
-      if (stamp_ns > end_ns) {
+    const auto first = std::lower_bound(
+      bag_result.tracked_object_timeline.begin(), bag_result.tracked_object_timeline.end(),
+      start_ns, [](const TimedTrackedObjects & timed_objects, const int64_t stamp_ns) {
+        return timed_objects.stamp.nanoseconds() < stamp_ns;
+      });
+
+    sync_data->future_tracked_objects.reserve(
+      std::distance(first, bag_result.tracked_object_timeline.end()));
+    for (auto itr = first; itr != bag_result.tracked_object_timeline.end(); ++itr) {
+      if (itr->stamp.nanoseconds() > end_ns) {
         break;
       }
-      sync_data->future_tracked_objects.push_back(timed_objects);
+      sync_data->future_tracked_objects.push_back(*itr);
     }
   }
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -201,6 +201,11 @@ public:
 
   void set_debug_topics_enabled(bool enabled) { debug_topics_enabled_ = enabled; }
 
+  void set_trajectory_evaluation_horizon(double horizon_s)
+  {
+    trajectory_evaluation_horizon_s_ = horizon_s;
+  }
+
   void set_evaluation_horizons(const std::vector<double> & horizons)
   {
     evaluation_horizons_ = horizons;
@@ -398,6 +403,7 @@ private:
   std::string metric_variant_;
   GTSourceMode gt_source_mode_;
   double gt_sync_tolerance_ms_;
+  double trajectory_evaluation_horizon_s_{0.0};
   std::vector<double> evaluation_horizons_;
   double override_window_sec_{0.0};
   std::vector<utils::ControlModeEvent> control_mode_events_;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -408,6 +408,7 @@ private:
   double override_window_sec_{0.0};
   std::vector<utils::ControlModeEvent> control_mode_events_;
   // Reserved for the follow-up debug-topic PR. PR 425 only stores the runtime switch.
+  std::vector<TimedTrackedObjects> object_timeline_;
   bool debug_topics_enabled_{false};
 };
 

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -37,6 +37,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -203,6 +204,9 @@ public:
 
   void set_trajectory_evaluation_horizon(double horizon_s)
   {
+    if (horizon_s < 0.0) {
+      throw std::invalid_argument("trajectory evaluation horizon must be non-negative");
+    }
     trajectory_evaluation_horizon_s_ = horizon_s;
   }
 
@@ -403,7 +407,7 @@ private:
   std::string metric_variant_;
   GTSourceMode gt_source_mode_;
   double gt_sync_tolerance_ms_;
-  double trajectory_evaluation_horizon_s_{0.0};
+  double trajectory_evaluation_horizon_s_{4.0};
   std::vector<double> evaluation_horizons_;
   double override_window_sec_{0.0};
   std::vector<utils::ControlModeEvent> control_mode_events_;

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_no_at_fault_collision.cpp
@@ -77,12 +77,21 @@ autoware_planning_msgs::msg::Trajectory make_straight_trajectory(const double sp
   return trajectory;
 }
 
+autoware_planning_msgs::msg::Trajectory make_stopped_then_moving_trajectory()
+{
+  auto trajectory = make_straight_trajectory(5.0);
+  trajectory.points[0].longitudinal_velocity_mps = 0.0;
+  return trajectory;
+}
+
 autoware_perception_msgs::msg::TrackedObject make_object(
-  const double x, const double y, const std::uint8_t label, const std::array<uint8_t, 16> & uuid)
+  const double x, const double y, const std::uint8_t label, const std::array<uint8_t, 16> & uuid,
+  const double speed_mps = 1.0)
 {
   autoware_perception_msgs::msg::TrackedObject object;
   object.object_id.uuid = uuid;
   object.kinematics.pose_with_covariance.pose = make_pose(x, y);
+  object.kinematics.twist_with_covariance.twist.linear.x = speed_mps;
   object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   object.shape.dimensions.x = 2.0;
   object.shape.dimensions.y = 1.0;
@@ -193,6 +202,27 @@ TEST(NoAtFaultCollision, UsesLoggedFutureObjectAtMatchingTime)
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
   EXPECT_EQ(result.reason, "at_fault_collision_with_agent");
+}
+
+TEST(NoAtFaultCollision, IgnoredCollisionDoesNotMaskLaterAtFaultCollisionWithSameObject)
+{
+  const auto trajectory = make_stopped_then_moving_trajectory();
+  constexpr std::array<uint8_t, 16> uuid{6};
+  const auto future_objects = std::vector<TimedTrackedObjects>{
+    make_timed_objects(
+      rclcpp::Time(10, 0, RCL_ROS_TIME),
+      {make_object(4.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR, uuid)}),
+    make_timed_objects(
+      rclcpp::Time(11, 0, RCL_ROS_TIME),
+      {make_object(8.8, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR, uuid)})};
+
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "at_fault_collision_with_agent");
+  EXPECT_DOUBLE_EQ(result.infraction_time_s, 1.0);
 }
 
 TEST(NoAtFaultCollision, UnknownObjectsAreIgnored)

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_no_at_fault_collision.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_no_at_fault_collision.cpp
@@ -18,14 +18,15 @@
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
-#include <autoware_perception_msgs/msg/predicted_object.hpp>
-#include <autoware_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_perception_msgs/msg/predicted_path.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
@@ -65,6 +66,7 @@ geometry_msgs::msg::Pose make_pose(const double x, const double y, const double 
 autoware_planning_msgs::msg::Trajectory make_straight_trajectory(const double speed_mps)
 {
   autoware_planning_msgs::msg::Trajectory trajectory;
+  trajectory.header.stamp.sec = 10;
   trajectory.points.resize(2);
   trajectory.points[0].pose = make_pose(0.0, 0.0);
   trajectory.points[0].longitudinal_velocity_mps = speed_mps;
@@ -75,11 +77,12 @@ autoware_planning_msgs::msg::Trajectory make_straight_trajectory(const double sp
   return trajectory;
 }
 
-autoware_perception_msgs::msg::PredictedObject make_object(
-  const double x, const double y, const std::uint8_t label)
+autoware_perception_msgs::msg::TrackedObject make_object(
+  const double x, const double y, const std::uint8_t label, const std::array<uint8_t, 16> & uuid)
 {
-  autoware_perception_msgs::msg::PredictedObject object;
-  object.kinematics.initial_pose_with_covariance.pose = make_pose(x, y);
+  autoware_perception_msgs::msg::TrackedObject object;
+  object.object_id.uuid = uuid;
+  object.kinematics.pose_with_covariance.pose = make_pose(x, y);
   object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   object.shape.dimensions.x = 2.0;
   object.shape.dimensions.y = 1.0;
@@ -89,15 +92,23 @@ autoware_perception_msgs::msg::PredictedObject make_object(
   classification.label = label;
   classification.probability = 1.0f;
   object.classification.push_back(classification);
-
-  autoware_perception_msgs::msg::PredictedPath path;
-  path.time_step = rclcpp::Duration::from_seconds(0.5);
-  path.confidence = 1.0;
-  path.path.push_back(make_pose(x, y));
-  path.path.push_back(make_pose(x, y));
-  path.path.push_back(make_pose(x, y));
-  object.kinematics.predicted_paths.push_back(path);
   return object;
+}
+
+TimedTrackedObjects make_timed_objects(
+  const rclcpp::Time & stamp,
+  const std::vector<autoware_perception_msgs::msg::TrackedObject> & objects)
+{
+  auto tracked_objects = std::make_shared<TrackedObjects>();
+  tracked_objects->header.stamp = stamp;
+  tracked_objects->objects = objects;
+  return TimedTrackedObjects{stamp, tracked_objects};
+}
+
+std::vector<TimedTrackedObjects> make_future_objects(
+  const std::vector<autoware_perception_msgs::msg::TrackedObject> & objects)
+{
+  return {make_timed_objects(rclcpp::Time(10, 0, RCL_ROS_TIME), objects)};
 }
 
 }  // namespace
@@ -105,8 +116,10 @@ autoware_perception_msgs::msg::PredictedObject make_object(
 TEST(NoAtFaultCollision, EmptyObjectsPasses)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
-  const auto result = calculate_no_at_fault_collision(trajectory, objects, make_vehicle_info());
+  const std::vector<TimedTrackedObjects> future_objects{
+    make_timed_objects(rclcpp::Time(10, 0, RCL_ROS_TIME), {})};
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);
@@ -116,11 +129,12 @@ TEST(NoAtFaultCollision, EmptyObjectsPasses)
 TEST(NoAtFaultCollision, FrontCollisionWithAgentFails)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
-  objects->objects.push_back(
-    make_object(4.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR));
+  const auto future_objects = make_future_objects({make_object(
+    4.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR,
+    std::array<uint8_t, 16>{1})});
 
-  const auto result = calculate_no_at_fault_collision(trajectory, objects, make_vehicle_info());
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
@@ -131,11 +145,12 @@ TEST(NoAtFaultCollision, FrontCollisionWithAgentFails)
 TEST(NoAtFaultCollision, FrontCollisionWithNonAgentGetsHalfPenalty)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
-  objects->objects.push_back(
-    make_object(4.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::HAZARD));
+  const auto future_objects = make_future_objects({make_object(
+    4.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::HAZARD,
+    std::array<uint8_t, 16>{2})});
 
-  const auto result = calculate_no_at_fault_collision(trajectory, objects, make_vehicle_info());
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.5);
@@ -145,52 +160,50 @@ TEST(NoAtFaultCollision, FrontCollisionWithNonAgentGetsHalfPenalty)
 TEST(NoAtFaultCollision, RearCollisionDoesNotFail)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
-  objects->objects.push_back(
-    make_object(-3.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR));
+  const auto future_objects = make_future_objects({make_object(
+    -3.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR,
+    std::array<uint8_t, 16>{3})});
 
-  const auto result = calculate_no_at_fault_collision(trajectory, objects, make_vehicle_info());
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);
   EXPECT_EQ(result.reason, "available");
 }
 
-TEST(NoAtFaultCollision, UsesHighestConfidencePredictedPath)
+TEST(NoAtFaultCollision, UsesLoggedFutureObjectAtMatchingTime)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
+  const auto future_objects = std::vector<TimedTrackedObjects>{
+    make_timed_objects(
+      rclcpp::Time(10, 0, RCL_ROS_TIME),
+      {make_object(
+        20.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR,
+        std::array<uint8_t, 16>{4})}),
+    make_timed_objects(
+      rclcpp::Time(11, 0, RCL_ROS_TIME),
+      {make_object(
+        8.8, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR,
+        std::array<uint8_t, 16>{4})})};
 
-  autoware_perception_msgs::msg::PredictedObject object;
-  object.kinematics.initial_pose_with_covariance.pose = make_pose(20.0, 0.0);
-  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
-  object.shape.dimensions.x = 2.0;
-  object.shape.dimensions.y = 1.0;
-  object.shape.dimensions.z = 1.5;
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
 
-  autoware_perception_msgs::msg::ObjectClassification classification;
-  classification.label = autoware_perception_msgs::msg::ObjectClassification::CAR;
-  classification.probability = 1.0f;
-  object.classification.push_back(classification);
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "at_fault_collision_with_agent");
+}
 
-  autoware_perception_msgs::msg::PredictedPath colliding_path;
-  colliding_path.time_step = rclcpp::Duration::from_seconds(0.5);
-  colliding_path.confidence = 0.1;
-  colliding_path.path.push_back(make_pose(4.0, 0.0));
-  colliding_path.path.push_back(make_pose(4.0, 0.0));
-  colliding_path.path.push_back(make_pose(4.0, 0.0));
+TEST(NoAtFaultCollision, UnknownObjectsAreIgnored)
+{
+  const auto trajectory = make_straight_trajectory(5.0);
+  const auto future_objects = make_future_objects({make_object(
+    4.0, 0.0, autoware_perception_msgs::msg::ObjectClassification::UNKNOWN,
+    std::array<uint8_t, 16>{5})});
 
-  autoware_perception_msgs::msg::PredictedPath safe_path;
-  safe_path.time_step = rclcpp::Duration::from_seconds(0.5);
-  safe_path.confidence = 0.9;
-  safe_path.path.push_back(make_pose(20.0, 0.0));
-  safe_path.path.push_back(make_pose(20.0, 0.0));
-  safe_path.path.push_back(make_pose(20.0, 0.0));
-
-  object.kinematics.predicted_paths = {colliding_path, safe_path};
-  objects->objects.push_back(object);
-
-  const auto result = calculate_no_at_fault_collision(trajectory, objects, make_vehicle_info());
+  const auto result =
+    calculate_no_at_fault_collision(trajectory, future_objects, make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);

--- a/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
@@ -42,7 +42,7 @@ TEST_F(BagHandlerTest, BagDataConstruction)
   auto bag_data = std::make_shared<BagData>(timestamp_);
 
   EXPECT_EQ(bag_data->timestamp, timestamp_);
-  EXPECT_EQ(bag_data->buffers.size(), 8u);
+  EXPECT_EQ(bag_data->buffers.size(), 9u);
   // Check default topic names
   EXPECT_TRUE(bag_data->buffers.count("/tf"));
   EXPECT_TRUE(bag_data->buffers.count("/localization/kinematic_state"));
@@ -50,6 +50,7 @@ TEST_F(BagHandlerTest, BagDataConstruction)
   EXPECT_TRUE(bag_data->buffers.count("/planning/trajectory"));
   EXPECT_TRUE(bag_data->buffers.count("/diffusion_planner/output/trajectories"));
   EXPECT_TRUE(bag_data->buffers.count("/perception/object_recognition/objects"));
+  EXPECT_TRUE(bag_data->buffers.count("/perception/object_recognition/tracking/objects"));
   EXPECT_TRUE(bag_data->buffers.count("/perception/traffic_light_recognition/traffic_signals"));
   EXPECT_TRUE(bag_data->buffers.count("/vehicle/status/steering_status"));
 }

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -322,7 +322,7 @@ TEST_F(OpenLoopGTSourceModeTest, MissingInputsUnavailableReasonsAreReported)
     "unavailable_no_route_handler");
   EXPECT_EQ(
     full_json["trajectories"][0]["no_at_fault_collision_reason"].get<std::string>(),
-    "unavailable_no_objects_message");
+    "unavailable_no_future_objects");
 }
 
 TEST_F(OpenLoopGTSourceModeTest, ExtendedComfortAvailabilityIsReportedAcrossConsecutivePlans)

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -34,7 +34,9 @@ using autoware::planning_data_analyzer::Trajectory;
 namespace
 {
 
-Trajectory make_trajectory(const rclcpp::Time & start_time, const std::vector<double> & xs)
+Trajectory make_timed_trajectory(
+  const rclcpp::Time & start_time, const std::vector<double> & xs,
+  const std::vector<double> & times_s)
 {
   Trajectory trajectory;
   trajectory.header.frame_id = "map";
@@ -42,13 +44,17 @@ Trajectory make_trajectory(const rclcpp::Time & start_time, const std::vector<do
   trajectory.header.stamp.nanosec =
     static_cast<uint32_t>(start_time.nanoseconds() - trajectory.header.stamp.sec * 1000000000LL);
 
+  if (xs.size() != times_s.size()) {
+    return trajectory;
+  }
+
   for (size_t i = 0; i < xs.size(); ++i) {
     autoware_planning_msgs::msg::TrajectoryPoint point;
     point.pose.position.x = xs[i];
     point.pose.position.y = 0.0;
     point.pose.position.z = 0.0;
     point.pose.orientation.w = 1.0;
-    const double time_from_start_s = 0.1 * static_cast<double>(i);
+    const double time_from_start_s = times_s.at(i);
     const int32_t sec = static_cast<int32_t>(time_from_start_s);
     const uint32_t nanosec = static_cast<uint32_t>((time_from_start_s - sec) * 1e9);
     point.time_from_start.sec = sec;
@@ -58,6 +64,16 @@ Trajectory make_trajectory(const rclcpp::Time & start_time, const std::vector<do
   }
 
   return trajectory;
+}
+
+Trajectory make_trajectory(const rclcpp::Time & start_time, const std::vector<double> & xs)
+{
+  std::vector<double> times_s;
+  times_s.reserve(xs.size());
+  for (size_t i = 0; i < xs.size(); ++i) {
+    times_s.push_back(0.1 * static_cast<double>(i));
+  }
+  return make_timed_trajectory(start_time, xs, times_s);
 }
 
 std::shared_ptr<SynchronizedData> make_sync_data(
@@ -130,6 +146,64 @@ TEST_F(OpenLoopGTSourceModeTest, GTTrajectoryModeUsesSyncToleranceForBoundaryInt
     OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 120.0);
   EXPECT_NO_THROW(tolerant_evaluator.evaluate(sync_data_list, nullptr));
   EXPECT_EQ(tolerant_evaluator.get_metrics().size(), 1u);
+}
+
+TEST_F(OpenLoopGTSourceModeTest, TrajectoryHorizonTruncationKeepsFirstPointBeyondHorizon)
+{
+  const rclcpp::Time start_time(35, 0);
+  const auto prediction = make_timed_trajectory(start_time, {1.0, 2.0}, {1.0, 1.1});
+  std::vector<std::shared_ptr<SynchronizedData>> sync_data_list{make_sync_data(prediction)};
+
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+  evaluator.set_trajectory_evaluation_horizon(0.5);
+
+  const auto evaluation_data = evaluator.prepare_evaluation_data(sync_data_list);
+  ASSERT_EQ(evaluation_data.size(), 1u);
+  ASSERT_EQ(evaluation_data.front().synchronized_data->trajectory->points.size(), 1u);
+  EXPECT_DOUBLE_EQ(
+    rclcpp::Duration(
+      evaluation_data.front().synchronized_data->trajectory->points.front().time_from_start)
+      .seconds(),
+    1.0);
+}
+
+TEST_F(OpenLoopGTSourceModeTest, TrajectoryHorizonTruncationKeepsSinglePointTrajectory)
+{
+  const rclcpp::Time start_time(36, 0);
+  const auto prediction = make_timed_trajectory(start_time, {1.0}, {0.0});
+  std::vector<std::shared_ptr<SynchronizedData>> sync_data_list{make_sync_data(prediction)};
+
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+  evaluator.set_trajectory_evaluation_horizon(4.0);
+
+  const auto evaluation_data = evaluator.prepare_evaluation_data(sync_data_list);
+  ASSERT_EQ(evaluation_data.size(), 1u);
+  ASSERT_EQ(evaluation_data.front().synchronized_data->trajectory->points.size(), 1u);
+}
+
+TEST_F(OpenLoopGTSourceModeTest, TrajectoryHorizonTruncationKeepsPointExactlyAtHorizon)
+{
+  const rclcpp::Time start_time(37, 0);
+  const auto prediction =
+    make_timed_trajectory(start_time, {0.0, 1.0, 2.0, 3.0}, {0.0, 0.5, 1.0, 1.5});
+  const auto gt = std::make_shared<Trajectory>(
+    make_timed_trajectory(start_time, {0.0, 1.0, 2.0, 3.0}, {0.0, 0.5, 1.0, 1.5}));
+  std::vector<std::shared_ptr<SynchronizedData>> sync_data_list{make_sync_data(prediction, gt)};
+
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+  evaluator.set_trajectory_evaluation_horizon(1.0);
+
+  const auto evaluation_data = evaluator.prepare_evaluation_data(sync_data_list);
+  ASSERT_EQ(evaluation_data.size(), 1u);
+  const auto & points = evaluation_data.front().synchronized_data->trajectory->points;
+  ASSERT_EQ(points.size(), 3u);
+  EXPECT_DOUBLE_EQ(rclcpp::Duration(points.back().time_from_start).seconds(), 1.0);
 }
 
 TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)


### PR DESCRIPTION
## Description

First subscore migration PR in the EPDMS patch series.

This migrates no-at-fault collision (NC) to use logged tracked objects and shared EPDMS helper utilities for object tracks and future-object slicing.

## Logic Change

As-is pipeline:

1. Read one synchronized predicted-object message.
2. Use predicted object states/paths from that single frame.
3. Compare ego trajectory footprints with those predicted objects.
4. Classify NC collision result from that predicted-object overlap.

To-be pipeline:

1. Read the tracked-object timeline from the rosbag.
2. Slice the future tracked-object messages for each evaluated trajectory horizon.
3. Build reusable logged-object tracks by object ID.
4. Interpolate each tracked object to every trajectory sample time.
5. Reuse shared ego footprint polygons for the same trajectory samples.
6. Check ego/object polygon overlap.
7. Classify at-fault NC result using ego motion, object motion, collision side, and lateral-assessment context.

The PR adds more lines because it introduces the reusable tracked-object helper layer, object_tracks, that later EPDMS migrations can reuse instead of duplicating timeline slicing/interpolation logic.

## Validation

### One Takanawa route run against baseline
- NC exact match, 0 changed records