### PR TITLE
feat(planning_data_analyzer): add NAVSIM-style DAC metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
@@ -54,7 +54,7 @@ std::vector<geometry_msgs::msg::Point> lanelet_polygon_to_points(
   const auto polygon = lanelet.polygon2d().basicPolygon();
   points.reserve(polygon.size());
   for (const auto & point : polygon) {
-    points.push_back(autoware::lanelet2_utils::to_ros(point, z));
+    points.push_back(autoware::experimental::lanelet2_utils::to_ros(point, z));
   }
   return points;
 }
@@ -65,7 +65,8 @@ std::vector<geometry_msgs::msg::Point> map_polygon_to_points(
   std::vector<geometry_msgs::msg::Point> points;
   points.reserve(polygon.size());
   for (const auto & point : polygon) {
-    points.push_back(autoware::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
+    points.push_back(
+      autoware::experimental::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
   }
   return points;
 }
@@ -76,7 +77,8 @@ std::vector<geometry_msgs::msg::Point> line_string_to_points(
   std::vector<geometry_msgs::msg::Point> points;
   points.reserve(line_string.size());
   for (const auto & point : line_string) {
-    points.push_back(autoware::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
+    points.push_back(
+      autoware::experimental::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
   }
   return points;
 }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
@@ -14,9 +14,9 @@
 
 #include "drivable_area_compliance.hpp"
 
-#include "../../geometry/lanelet_geometry.hpp"
-#include "../../geometry/metric_utils.hpp"
+#include "metrics/geometry/metric_utils.hpp"
 
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <rclcpp/duration.hpp>
 
@@ -35,23 +35,13 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
-geometry_msgs::msg::Point to_msg_point(
-  const autoware_utils_geometry::Point2d & point, const double z = 0.0)
-{
-  geometry_msgs::msg::Point msg;
-  msg.x = point.x();
-  msg.y = point.y();
-  msg.z = z;
-  return msg;
-}
-
 std::vector<geometry_msgs::msg::Point> polygon_to_points(
   const autoware_utils_geometry::Polygon2d & polygon, const double z)
 {
   std::vector<geometry_msgs::msg::Point> points;
   points.reserve(polygon.outer().size());
   for (const auto & point : polygon.outer()) {
-    points.push_back(to_msg_point(point, z));
+    points.push_back(autoware_utils_geometry::create_point(point.x(), point.y(), z));
   }
   return points;
 }
@@ -59,21 +49,33 @@ std::vector<geometry_msgs::msg::Point> polygon_to_points(
 std::vector<geometry_msgs::msg::Point> lanelet_polygon_to_points(
   const lanelet::ConstLanelet & lanelet, const double z)
 {
-  return polygon_to_points(to_polygon_2d(lanelet.polygon2d().basicPolygon()), z);
+  std::vector<geometry_msgs::msg::Point> points;
+  const auto polygon = lanelet.polygon2d().basicPolygon();
+  points.reserve(polygon.size());
+  for (const auto & point : polygon) {
+    points.push_back(autoware::lanelet2_utils::to_ros(point, z));
+  }
+  return points;
 }
 
 std::vector<geometry_msgs::msg::Point> map_polygon_to_points(
   const lanelet::ConstPolygon3d & polygon, const double z)
 {
-  return polygon_to_points(to_polygon_2d(lanelet::utils::to2D(polygon).basicPolygon()), z);
+  std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(polygon.size());
+  for (const auto & point : polygon) {
+    points.push_back(autoware::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
+  }
+  return points;
 }
 
 std::vector<geometry_msgs::msg::Point> line_string_to_points(
   const lanelet::ConstLineString3d & line_string, const double z)
 {
   std::vector<geometry_msgs::msg::Point> points;
-  for (const auto & point : lanelet::utils::to2D(line_string)) {
-    points.push_back(to_msg_point({point.x(), point.y()}, z));
+  points.reserve(line_string.size());
+  for (const auto & point : line_string) {
+    points.push_back(autoware::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
   }
   return points;
 }
@@ -98,20 +100,24 @@ void append_first_failure_debug_info(
   debug_info.corner_count_inside =
     std::count(area.corner_drivable.begin(), area.corner_drivable.end(), true);
   if (!area.footprint_points.empty()) {
-    debug_info.label_anchor = to_msg_point(area.footprint_points.front(), z);
+    const auto & point = area.footprint_points.front();
+    debug_info.label_anchor = autoware_utils_geometry::create_point(point.x(), point.y(), z);
   }
 
   for (std::size_t corner_index = 0; corner_index < area.footprint_points.size(); ++corner_index) {
     if (!area.corner_drivable.at(corner_index)) {
       debug_info.failing_corner_indices.push_back(corner_index);
+      const auto & point = area.footprint_points.at(corner_index);
       debug_info.failing_corners.push_back(
-        {time_s, corner_index, to_msg_point(area.footprint_points.at(corner_index), z)});
+        {time_s, corner_index, autoware_utils_geometry::create_point(point.x(), point.y(), z)});
     }
     if (
       corner_index < area.corner_drivable_by_road_border.size() &&
       area.corner_drivable_by_road_border.at(corner_index)) {
+      const auto & point = area.footprint_points.at(corner_index);
       debug_info.road_border_fallback_corners.push_back(
-        {time_s, corner_index, to_msg_point(area.footprint_points.at(corner_index), z + 0.01)});
+        {time_s, corner_index,
+         autoware_utils_geometry::create_point(point.x(), point.y(), z + 0.01)});
     }
   }
 
@@ -143,16 +149,24 @@ void append_first_failure_debug_info(
   for (const auto & side_test : area.road_border_side_tests) {
     debug_info.road_border_side_test_segments.push_back(
       {time_s,
-       {to_msg_point(side_test.segment_start, z + 0.09),
-        to_msg_point(side_test.segment_end, z + 0.09)}});
+       {autoware_utils_geometry::create_point(
+          side_test.segment_start.x(), side_test.segment_start.y(), z + 0.09),
+        autoware_utils_geometry::create_point(
+          side_test.segment_end.x(), side_test.segment_end.y(), z + 0.09)}});
     debug_info.road_border_gap_segments.push_back(
       {time_s,
-       {to_msg_point(side_test.semantic_closest_point, z + 0.10),
-        to_msg_point(side_test.closest_point, z + 0.10)}});
+       {autoware_utils_geometry::create_point(
+          side_test.semantic_closest_point.x(), side_test.semantic_closest_point.y(), z + 0.10),
+        autoware_utils_geometry::create_point(
+          side_test.closest_point.x(), side_test.closest_point.y(), z + 0.10)}});
     debug_info.semantic_boundary_points.push_back(
-      {time_s, side_test.corner_index, to_msg_point(side_test.semantic_closest_point, z + 0.11)});
+      {time_s, side_test.corner_index,
+       autoware_utils_geometry::create_point(
+         side_test.semantic_closest_point.x(), side_test.semantic_closest_point.y(), z + 0.11)});
     debug_info.road_border_closest_points.push_back(
-      {time_s, side_test.corner_index, to_msg_point(side_test.closest_point, z + 0.12)});
+      {time_s, side_test.corner_index,
+       autoware_utils_geometry::create_point(
+         side_test.closest_point.x(), side_test.closest_point.y(), z + 0.12)});
 
     if (std::isfinite(side_test.corner_between_ratio)) {
       const auto projection_point = autoware_utils_geometry::Point2d{
@@ -163,13 +177,19 @@ void append_first_failure_debug_info(
           side_test.corner_between_ratio *
             (side_test.closest_point.y() - side_test.semantic_closest_point.y())};
       debug_info.corner_projection_points.push_back(
-        {time_s, side_test.corner_index, to_msg_point(projection_point, z + 0.13)});
+        {time_s, side_test.corner_index,
+         autoware_utils_geometry::create_point(
+           projection_point.x(), projection_point.y(), z + 0.13)});
     }
 
     debug_info.road_border_plus_samples.push_back(
-      {time_s, side_test.corner_index, to_msg_point(side_test.plus_sample, z + 0.14)});
+      {time_s, side_test.corner_index,
+       autoware_utils_geometry::create_point(
+         side_test.plus_sample.x(), side_test.plus_sample.y(), z + 0.14)});
     debug_info.road_border_minus_samples.push_back(
-      {time_s, side_test.corner_index, to_msg_point(side_test.minus_sample, z + 0.15)});
+      {time_s, side_test.corner_index,
+       autoware_utils_geometry::create_point(
+         side_test.minus_sample.x(), side_test.minus_sample.y(), z + 0.15)});
   }
 }
 
@@ -235,11 +255,10 @@ DrivableAreaComplianceResult calculate_drivable_area_compliance(
   const auto & evaluations =
     footprint_evaluations != nullptr ? *footprint_evaluations : local_evaluations;
   if (evaluations.size() != trajectory.points.size()) {
-    result.reason = "unavailable_invalid_footprint";
+    result.reason = "unavailable_footprint_evaluation_size_mismatch";
     return result;
   }
 
-  fill_debug_info(result.debug_info, trajectory, evaluations);
   result.available = true;
   result.reason = "compliant";
 
@@ -249,6 +268,11 @@ DrivableAreaComplianceResult calculate_drivable_area_compliance(
       result.reason = "unavailable_drivable_area_query_failed";
       return result;
     }
+  }
+
+  fill_debug_info(result.debug_info, trajectory, evaluations);
+
+  for (const auto & evaluation : evaluations) {
     if (evaluation.ego_area_evaluation->flags.non_drivable_area) {
       result.reason = "non_compliant_corner_outside_drivable_area";
       return result;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
@@ -18,6 +18,7 @@
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
 
 #include <boost/geometry.hpp>

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
@@ -16,7 +16,6 @@
 
 #include "metrics/geometry/metric_utils.hpp"
 
-#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
@@ -54,7 +53,7 @@ std::vector<geometry_msgs::msg::Point> lanelet_polygon_to_points(
   const auto polygon = lanelet.polygon2d().basicPolygon();
   points.reserve(polygon.size());
   for (const auto & point : polygon) {
-    points.push_back(autoware::experimental::lanelet2_utils::to_ros(point, z));
+    points.push_back(autoware_utils_geometry::create_point(point.x(), point.y(), z));
   }
   return points;
 }
@@ -65,8 +64,7 @@ std::vector<geometry_msgs::msg::Point> map_polygon_to_points(
   std::vector<geometry_msgs::msg::Point> points;
   points.reserve(polygon.size());
   for (const auto & point : polygon) {
-    points.push_back(
-      autoware::experimental::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
+    points.push_back(autoware_utils_geometry::create_point(point.x(), point.y(), z));
   }
   return points;
 }
@@ -77,8 +75,7 @@ std::vector<geometry_msgs::msg::Point> line_string_to_points(
   std::vector<geometry_msgs::msg::Point> points;
   points.reserve(line_string.size());
   for (const auto & point : line_string) {
-    points.push_back(
-      autoware::experimental::lanelet2_utils::to_ros(lanelet::utils::to2D(point), z));
+    points.push_back(autoware_utils_geometry::create_point(point.x(), point.y(), z));
   }
   return points;
 }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.cpp
@@ -14,17 +14,19 @@
 
 #include "drivable_area_compliance.hpp"
 
-#include "metrics/geometry/metric_utils.hpp"
+#include "../../geometry/lanelet_geometry.hpp"
+#include "../../geometry/metric_utils.hpp"
 
 #include <autoware_utils_geometry/boost_geometry.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
+#include <rclcpp/duration.hpp>
 
 #include <boost/geometry.hpp>
 
-#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/utility/Utilities.h>
 
-#include <cstddef>
-#include <optional>
+#include <algorithm>
+#include <cmath>
+#include <memory>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -33,120 +35,192 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
-using autoware_utils_geometry::LinearRing2d;
-using autoware_utils_geometry::MultiPolygon2d;
-using autoware_utils_geometry::Point2d;
-using autoware_utils_geometry::Polygon2d;
+geometry_msgs::msg::Point to_msg_point(
+  const autoware_utils_geometry::Point2d & point, const double z = 0.0)
+{
+  geometry_msgs::msg::Point msg;
+  msg.x = point.x();
+  msg.y = point.y();
+  msg.z = z;
+  return msg;
+}
 
-std::vector<LinearRing2d> create_vehicle_footprints(
+std::vector<geometry_msgs::msg::Point> polygon_to_points(
+  const autoware_utils_geometry::Polygon2d & polygon, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(polygon.outer().size());
+  for (const auto & point : polygon.outer()) {
+    points.push_back(to_msg_point(point, z));
+  }
+  return points;
+}
+
+std::vector<geometry_msgs::msg::Point> lanelet_polygon_to_points(
+  const lanelet::ConstLanelet & lanelet, const double z)
+{
+  return polygon_to_points(to_polygon_2d(lanelet.polygon2d().basicPolygon()), z);
+}
+
+std::vector<geometry_msgs::msg::Point> map_polygon_to_points(
+  const lanelet::ConstPolygon3d & polygon, const double z)
+{
+  return polygon_to_points(to_polygon_2d(lanelet::utils::to2D(polygon).basicPolygon()), z);
+}
+
+std::vector<geometry_msgs::msg::Point> line_string_to_points(
+  const lanelet::ConstLineString3d & line_string, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  for (const auto & point : lanelet::utils::to2D(line_string)) {
+    points.push_back(to_msg_point({point.x(), point.y()}, z));
+  }
+  return points;
+}
+
+void append_first_failure_debug_info(
+  DrivableAreaComplianceDebugInfo & debug_info, const double time_s, const double z,
+  const EgoAreaEvaluation & area)
+{
+  debug_info.first_failure_time_s = time_s;
+  debug_info.route_candidate_count = area.designated_lanelet_count;
+  debug_info.road_candidate_count = area.road_lanelets.size();
+  debug_info.shoulder_candidate_count = area.shoulder_lanelets.size();
+  debug_info.intersection_candidate_count = area.intersection_areas.size();
+  debug_info.hatched_road_marking_candidate_count = area.hatched_road_markings.size();
+  debug_info.parking_candidate_count = area.parking_lots.size();
+  debug_info.road_border_line_count = area.road_border_lines.size();
+  debug_info.road_border_fallback_used = area.flags.road_border_fallback_used;
+  debug_info.road_border_side_test_count = area.road_border_side_tests.size();
+  debug_info.road_border_side_accept_count = std::count_if(
+    area.road_border_side_tests.begin(), area.road_border_side_tests.end(),
+    [](const auto & test) { return test.accepted; });
+  debug_info.corner_count_inside =
+    std::count(area.corner_drivable.begin(), area.corner_drivable.end(), true);
+  if (!area.footprint_points.empty()) {
+    debug_info.label_anchor = to_msg_point(area.footprint_points.front(), z);
+  }
+
+  for (std::size_t corner_index = 0; corner_index < area.footprint_points.size(); ++corner_index) {
+    if (!area.corner_drivable.at(corner_index)) {
+      debug_info.failing_corner_indices.push_back(corner_index);
+      debug_info.failing_corners.push_back(
+        {time_s, corner_index, to_msg_point(area.footprint_points.at(corner_index), z)});
+    }
+    if (
+      corner_index < area.corner_drivable_by_road_border.size() &&
+      area.corner_drivable_by_road_border.at(corner_index)) {
+      debug_info.road_border_fallback_corners.push_back(
+        {time_s, corner_index, to_msg_point(area.footprint_points.at(corner_index), z + 0.01)});
+    }
+  }
+
+  for (const auto & road_lanelet : area.road_lanelets) {
+    debug_info.admissible_road_areas.push_back(
+      {time_s, lanelet_polygon_to_points(road_lanelet, z + 0.02)});
+  }
+  for (const auto & shoulder_lanelet : area.shoulder_lanelets) {
+    debug_info.admissible_shoulder_areas.push_back(
+      {time_s, lanelet_polygon_to_points(shoulder_lanelet, z + 0.03)});
+  }
+  for (const auto & intersection_area : area.intersection_areas) {
+    debug_info.admissible_intersection_areas.push_back(
+      {time_s, map_polygon_to_points(intersection_area, z + 0.04)});
+  }
+  for (const auto & hatched_road_marking : area.hatched_road_markings) {
+    debug_info.admissible_hatched_road_markings.push_back(
+      {time_s, map_polygon_to_points(hatched_road_marking, z + 0.05)});
+  }
+  for (const auto & parking_lot : area.parking_lots) {
+    debug_info.admissible_parking_areas.push_back(
+      {time_s, map_polygon_to_points(parking_lot, z + 0.06)});
+  }
+  for (const auto & road_border_line : area.road_border_lines) {
+    debug_info.road_border_lines.push_back(
+      {time_s, line_string_to_points(road_border_line, z + 0.08)});
+  }
+
+  for (const auto & side_test : area.road_border_side_tests) {
+    debug_info.road_border_side_test_segments.push_back(
+      {time_s,
+       {to_msg_point(side_test.segment_start, z + 0.09),
+        to_msg_point(side_test.segment_end, z + 0.09)}});
+    debug_info.road_border_gap_segments.push_back(
+      {time_s,
+       {to_msg_point(side_test.semantic_closest_point, z + 0.10),
+        to_msg_point(side_test.closest_point, z + 0.10)}});
+    debug_info.semantic_boundary_points.push_back(
+      {time_s, side_test.corner_index, to_msg_point(side_test.semantic_closest_point, z + 0.11)});
+    debug_info.road_border_closest_points.push_back(
+      {time_s, side_test.corner_index, to_msg_point(side_test.closest_point, z + 0.12)});
+
+    if (std::isfinite(side_test.corner_between_ratio)) {
+      const auto projection_point = autoware_utils_geometry::Point2d{
+        side_test.semantic_closest_point.x() +
+          side_test.corner_between_ratio *
+            (side_test.closest_point.x() - side_test.semantic_closest_point.x()),
+        side_test.semantic_closest_point.y() +
+          side_test.corner_between_ratio *
+            (side_test.closest_point.y() - side_test.semantic_closest_point.y())};
+      debug_info.corner_projection_points.push_back(
+        {time_s, side_test.corner_index, to_msg_point(projection_point, z + 0.13)});
+    }
+
+    debug_info.road_border_plus_samples.push_back(
+      {time_s, side_test.corner_index, to_msg_point(side_test.plus_sample, z + 0.14)});
+    debug_info.road_border_minus_samples.push_back(
+      {time_s, side_test.corner_index, to_msg_point(side_test.minus_sample, z + 0.15)});
+  }
+}
+
+void fill_debug_info(
+  DrivableAreaComplianceDebugInfo & debug_info,
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+  const std::vector<TrajectoryFootprintEvaluation> & evaluations)
 {
-  const auto base_footprint = vehicle_info.createFootprint(0.0);
-
-  std::vector<LinearRing2d> vehicle_footprints;
-  vehicle_footprints.reserve(trajectory.points.size());
-  for (const auto & point : trajectory.points) {
-    vehicle_footprints.push_back(
-      autoware_utils_geometry::transform_vector(
-        base_footprint, autoware_utils_geometry::pose2transform(point.pose)));
-  }
-
-  return vehicle_footprints;
-}
-
-LinearRing2d create_hull_from_footprints(const std::vector<LinearRing2d> & footprints)
-{
-  boost::geometry::model::multi_point<Point2d> combined;
-  for (const auto & footprint : footprints) {
-    for (const auto & point : footprint) {
-      combined.push_back(point);
+  for (std::size_t index = 0; index < trajectory.points.size(); ++index) {
+    const auto & point = trajectory.points.at(index);
+    const auto & evaluation = evaluations.at(index);
+    if (!evaluation.ego_area_evaluation.has_value()) {
+      continue;
     }
-  }
 
-  LinearRing2d hull;
-  boost::geometry::convex_hull(combined, hull);
-  boost::geometry::correct(hull);
-  return hull;
-}
+    const auto & area = *evaluation.ego_area_evaluation;
+    const auto time_s = rclcpp::Duration(point.time_from_start).seconds();
+    debug_info.ego_horizon_footprints.push_back(
+      {time_s, area.flags.non_drivable_area,
+       polygon_to_points(evaluation.ego_polygon, point.pose.position.z)});
 
-lanelet::ConstLanelets collect_candidate_lanelets(
-  const lanelet::ConstLanelets & drivable_lanelets,
-  const std::vector<LinearRing2d> & vehicle_footprints)
-{
-  const auto footprint_hull = create_hull_from_footprints(vehicle_footprints);
-
-  lanelet::ConstLanelets candidate_lanelets;
-  for (const auto & lanelet : drivable_lanelets) {
-    if (!boost::geometry::disjoint(lanelet.polygon2d().basicPolygon(), footprint_hull)) {
-      candidate_lanelets.push_back(lanelet);
+    if (!area.flags.non_drivable_area || std::isfinite(debug_info.first_failure_time_s)) {
+      continue;
     }
+    append_first_failure_debug_info(debug_info, time_s, point.pose.position.z, area);
   }
-
-  return candidate_lanelets;
-}
-
-Polygon2d to_polygon_2d(const lanelet::BasicPolygon2d & polygon)
-{
-  Polygon2d converted;
-  for (const auto & point : polygon) {
-    converted.outer().push_back(Point2d(point.x(), point.y()));
-  }
-  boost::geometry::correct(converted);
-  return converted;
-}
-
-std::optional<MultiPolygon2d> fuse_lanelet_polygons(
-  const lanelet::ConstLanelets & candidate_lanelets)
-{
-  if (candidate_lanelets.empty()) {
-    return std::nullopt;
-  }
-
-  MultiPolygon2d lanelet_unions;
-  MultiPolygon2d result;
-
-  for (const auto & lanelet : candidate_lanelets) {
-    const auto polygon = to_polygon_2d(lanelet.polygon2d().basicPolygon());
-    boost::geometry::union_(lanelet_unions, polygon, result);
-    lanelet_unions = result;
-    result.clear();
-  }
-
-  if (lanelet_unions.empty()) {
-    return std::nullopt;
-  }
-
-  for (auto & polygon : lanelet_unions) {
-    boost::geometry::correct(polygon);
-  }
-
-  return lanelet_unions;
-}
-
-bool is_footprint_inside_any_polygon(
-  const LinearRing2d & vehicle_footprint, const MultiPolygon2d & fused_polygons)
-{
-  return std::any_of(
-    fused_polygons.begin(), fused_polygons.end(), [&vehicle_footprint](const auto & polygon) {
-      return boost::geometry::within(vehicle_footprint, polygon);
-    });
 }
 
 }  // namespace
 
 DrivableAreaComplianceResult calculate_drivable_area_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const lanelet::ConstLanelets & drivable_lanelets,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations)
 {
   DrivableAreaComplianceResult result;
   if (trajectory.points.empty()) {
     result.reason = "unavailable_empty_trajectory";
     return result;
   }
-  if (drivable_lanelets.empty()) {
-    result.reason = "unavailable_no_drivable_lanelets";
+  if (!route_handler) {
+    result.reason = "unavailable_no_route_handler";
+    return result;
+  }
+  if (!route_handler->isMapMsgReady()) {
+    result.reason = "unavailable_route_handler_map_not_ready";
+    return result;
+  }
+  if (!route_handler->isHandlerReady()) {
+    result.reason = "unavailable_route_handler_not_ready";
     return result;
   }
   if (!is_vehicle_info_valid(vehicle_info)) {
@@ -154,30 +228,29 @@ DrivableAreaComplianceResult calculate_drivable_area_compliance(
     return result;
   }
 
-  const auto vehicle_footprints = create_vehicle_footprints(trajectory, vehicle_info);
-  if (vehicle_footprints.empty() || vehicle_footprints.front().empty()) {
+  const auto local_evaluations =
+    footprint_evaluations != nullptr
+      ? std::vector<TrajectoryFootprintEvaluation>{}
+      : evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
+  const auto & evaluations =
+    footprint_evaluations != nullptr ? *footprint_evaluations : local_evaluations;
+  if (evaluations.size() != trajectory.points.size()) {
     result.reason = "unavailable_invalid_footprint";
     return result;
   }
 
-  const auto candidate_lanelets = collect_candidate_lanelets(drivable_lanelets, vehicle_footprints);
-  if (candidate_lanelets.empty()) {
-    result.reason = "unavailable_no_candidate_lanelets";
-    return result;
-  }
-
-  const auto fused_lanelet_polygons = fuse_lanelet_polygons(candidate_lanelets);
-  if (!fused_lanelet_polygons) {
-    result.reason = "unavailable_invalid_drivable_area_polygon";
-    return result;
-  }
-
+  fill_debug_info(result.debug_info, trajectory, evaluations);
   result.available = true;
   result.reason = "compliant";
 
-  for (const auto & footprint : vehicle_footprints) {
-    if (!is_footprint_inside_any_polygon(footprint, *fused_lanelet_polygons)) {
-      result.reason = "non_compliant_footprint_outside_drivable_area";
+  for (const auto & evaluation : evaluations) {
+    if (!evaluation.ego_area_evaluation.has_value()) {
+      result.available = false;
+      result.reason = "unavailable_drivable_area_query_failed";
+      return result;
+    }
+    if (evaluation.ego_area_evaluation->flags.non_drivable_area) {
+      result.reason = "non_compliant_corner_outside_drivable_area";
       return result;
     }
   }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.hpp
@@ -15,7 +15,7 @@
 #ifndef METRICS__EPDMS__SUBSCORES__DRIVABLE_AREA_COMPLIANCE_HPP_
 #define METRICS__EPDMS__SUBSCORES__DRIVABLE_AREA_COMPLIANCE_HPP_
 
-#include "../../geometry/ego_footprint.hpp"
+#include "metrics/geometry/ego_footprint.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/drivable_area_compliance.hpp
@@ -15,28 +15,90 @@
 #ifndef METRICS__EPDMS__SUBSCORES__DRIVABLE_AREA_COMPLIANCE_HPP_
 #define METRICS__EPDMS__SUBSCORES__DRIVABLE_AREA_COMPLIANCE_HPP_
 
+#include "../../geometry/ego_footprint.hpp"
+
+#include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <geometry_msgs/msg/point.hpp>
 
-#include <lanelet2_core/primitives/Lanelet.h>
-
+#include <cstddef>
+#include <limits>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
+
+struct DrivableAreaComplianceHorizonFootprint
+{
+  double time_s{0.0};
+  bool non_drivable_area{false};
+  std::vector<geometry_msgs::msg::Point> footprint;
+};
+
+struct DrivableAreaComplianceDebugPolygon
+{
+  double time_s{0.0};
+  std::vector<geometry_msgs::msg::Point> polygon;
+};
+
+struct DrivableAreaComplianceDebugCorner
+{
+  double time_s{0.0};
+  std::size_t corner_index{0};
+  geometry_msgs::msg::Point point;
+};
+
+struct DrivableAreaComplianceDebugInfo
+{
+  double first_failure_time_s{std::numeric_limits<double>::infinity()};
+  std::size_t corner_count_inside{0};
+  std::vector<std::size_t> failing_corner_indices;
+  std::size_t route_candidate_count{0};
+  std::size_t road_candidate_count{0};
+  std::size_t shoulder_candidate_count{0};
+  std::size_t intersection_candidate_count{0};
+  std::size_t hatched_road_marking_candidate_count{0};
+  std::size_t parking_candidate_count{0};
+  std::size_t road_border_line_count{0};
+  bool road_border_fallback_used{false};
+  std::size_t road_border_side_test_count{0};
+  std::size_t road_border_side_accept_count{0};
+  geometry_msgs::msg::Point label_anchor;
+  std::vector<DrivableAreaComplianceHorizonFootprint> ego_horizon_footprints;
+  std::vector<DrivableAreaComplianceDebugPolygon> admissible_road_areas;
+  std::vector<DrivableAreaComplianceDebugPolygon> admissible_shoulder_areas;
+  std::vector<DrivableAreaComplianceDebugPolygon> admissible_intersection_areas;
+  std::vector<DrivableAreaComplianceDebugPolygon> admissible_hatched_road_markings;
+  std::vector<DrivableAreaComplianceDebugPolygon> admissible_parking_areas;
+  std::vector<DrivableAreaComplianceDebugPolygon> road_border_lines;
+  std::vector<DrivableAreaComplianceDebugPolygon> road_border_side_test_segments;
+  std::vector<DrivableAreaComplianceDebugPolygon> road_border_gap_segments;
+  std::vector<DrivableAreaComplianceDebugCorner> semantic_boundary_points;
+  std::vector<DrivableAreaComplianceDebugCorner> road_border_closest_points;
+  std::vector<DrivableAreaComplianceDebugCorner> corner_projection_points;
+  std::vector<DrivableAreaComplianceDebugCorner> road_border_plus_samples;
+  std::vector<DrivableAreaComplianceDebugCorner> road_border_minus_samples;
+  std::vector<DrivableAreaComplianceDebugCorner> road_border_fallback_corners;
+  std::vector<DrivableAreaComplianceDebugCorner> failing_corners;
+};
 
 struct DrivableAreaComplianceResult
 {
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
+  DrivableAreaComplianceDebugInfo debug_info;
 };
 
 DrivableAreaComplianceResult calculate_drivable_area_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const lanelet::ConstLanelets & drivable_lanelets,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -309,9 +309,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.drivable_area_compliance_reason = "unavailable_route_handler_not_ready";
     metrics.traffic_light_compliance_reason = "unavailable_route_handler_not_ready";
   } else {
-    const auto drivable_lanelets = collect_route_relevant_lanelets(trajectory, route_handler);
-    const auto drivable_area_compliance =
-      calculate_drivable_area_compliance(trajectory, drivable_lanelets, vehicle_info);
+    const auto drivable_area_compliance = calculate_drivable_area_compliance(
+      trajectory, route_handler, vehicle_info, &footprint_evaluations);
     metrics.drivable_area_compliance = drivable_area_compliance.score;
     metrics.drivable_area_compliance_available = drivable_area_compliance.available;
     metrics.drivable_area_compliance_reason = drivable_area_compliance.reason;

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
@@ -126,7 +126,10 @@ std::shared_ptr<RouteHandler> make_route_handler(
   }
 
   autoware_map_msgs::msg::LaneletMapBin map_msg;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   lanelet::utils::conversion::toBinMsg(map, &map_msg);
+#pragma GCC diagnostic pop
 
   auto route_handler = std::make_shared<RouteHandler>();
   route_handler->setMap(map_msg);

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
@@ -15,16 +15,37 @@
 #include "metrics/epdms/subscores/drivable_area_compliance.hpp"
 
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Point.h>
+#include <lanelet2_core/primitives/Polygon.h>
 
+#include <cmath>
+#include <memory>
 #include <vector>
 
+namespace autoware::planning_data_analyzer::metrics
+{
 namespace
 {
+
+using autoware::route_handler::RouteHandler;
+
+geometry_msgs::msg::Pose make_pose(const double x, const double y)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.orientation.w = 1.0;
+  return pose;
+}
 
 autoware_planning_msgs::msg::Trajectory make_trajectory(const double lateral_offset)
 {
@@ -33,9 +54,7 @@ autoware_planning_msgs::msg::Trajectory make_trajectory(const double lateral_off
 
   for (std::size_t i = 0; i < 3; ++i) {
     autoware_planning_msgs::msg::TrajectoryPoint point;
-    point.pose.position.x = 3.0 + static_cast<double>(i) * 2.0;
-    point.pose.position.y = lateral_offset;
-    point.pose.orientation.w = 1.0;
+    point.pose = make_pose(3.0 + static_cast<double>(i) * 2.0, lateral_offset);
     point.longitudinal_velocity_mps = 2.0;
     point.time_from_start.nanosec = static_cast<uint32_t>(i * 100000000UL);
     trajectory.points.push_back(point);
@@ -44,17 +63,80 @@ autoware_planning_msgs::msg::Trajectory make_trajectory(const double lateral_off
   return trajectory;
 }
 
-lanelet::ConstLanelets make_drivable_lanelets()
+lanelet::Lanelet make_road_lanelet(const lanelet::Id id, const double y_min, const double y_max)
 {
   lanelet::LineString3d left_bound{
-    lanelet::InvalId,
-    {lanelet::Point3d{lanelet::InvalId, -5.0, 2.0, 0.0},
-     lanelet::Point3d{lanelet::InvalId, 12.0, 2.0, 0.0}}};
+    id * 10 + 1,
+    {lanelet::Point3d{id * 100 + 1, -5.0, y_max, 0.0},
+     lanelet::Point3d{id * 100 + 2, 12.0, y_max, 0.0}}};
   lanelet::LineString3d right_bound{
-    lanelet::InvalId,
-    {lanelet::Point3d{lanelet::InvalId, -5.0, -2.0, 0.0},
-     lanelet::Point3d{lanelet::InvalId, 12.0, -2.0, 0.0}}};
-  return lanelet::ConstLanelets{lanelet::ConstLanelet{lanelet::InvalId, left_bound, right_bound}};
+    id * 10 + 2,
+    {lanelet::Point3d{id * 100 + 3, -5.0, y_min, 0.0},
+     lanelet::Point3d{id * 100 + 4, 12.0, y_min, 0.0}}};
+  lanelet::Lanelet lanelet{id, left_bound, right_bound};
+  lanelet.setAttribute(lanelet::AttributeName::Subtype, lanelet::AttributeValueString::Road);
+  return lanelet;
+}
+
+lanelet::Lanelet make_shoulder_lanelet(const lanelet::Id id, const double y_min, const double y_max)
+{
+  auto lanelet = make_road_lanelet(id, y_min, y_max);
+  lanelet.setAttribute(lanelet::AttributeName::Subtype, "road_shoulder");
+  return lanelet;
+}
+
+lanelet::Polygon3d make_hatched_road_marking(
+  const lanelet::Id id, const double y_min, const double y_max)
+{
+  lanelet::Polygon3d polygon{
+    id,
+    {lanelet::Point3d{id * 100 + 1, -5.0, y_min, 0.0},
+     lanelet::Point3d{id * 100 + 2, 12.0, y_min, 0.0},
+     lanelet::Point3d{id * 100 + 3, 12.0, y_max, 0.0},
+     lanelet::Point3d{id * 100 + 4, -5.0, y_max, 0.0}}};
+  polygon.setAttribute(lanelet::AttributeName::Type, "hatched_road_markings");
+  polygon.setAttribute("area", "yes");
+  return polygon;
+}
+
+lanelet::LineString3d make_road_border_line(const lanelet::Id id, const double y)
+{
+  lanelet::LineString3d line_string{
+    id,
+    {lanelet::Point3d{id * 100 + 1, -5.0, y, 0.0}, lanelet::Point3d{id * 100 + 2, 12.0, y, 0.0}}};
+  line_string.setAttribute(lanelet::AttributeName::Type, "road_border");
+  return line_string;
+}
+
+std::shared_ptr<RouteHandler> make_route_handler(
+  const lanelet::Lanelets & lanelets, const std::vector<lanelet::Polygon3d> & polygons = {},
+  const std::vector<lanelet::LineString3d> & line_strings = {})
+{
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  lanelet::ConstLanelets const_lanelets;
+  for (const auto & lanelet : lanelets) {
+    map->add(lanelet);
+    const_lanelets.push_back(lanelet);
+  }
+  for (const auto & polygon : polygons) {
+    map->add(polygon);
+  }
+  for (const auto & line_string : line_strings) {
+    map->add(line_string);
+  }
+
+  autoware_map_msgs::msg::LaneletMapBin map_msg;
+  lanelet::utils::conversion::toBinMsg(map, &map_msg);
+
+  auto route_handler = std::make_shared<RouteHandler>();
+  route_handler->setMap(map_msg);
+
+  autoware_planning_msgs::msg::LaneletRoute route;
+  route.start_pose = make_pose(-4.0, 0.0);
+  route.goal_pose = make_pose(11.0, 0.0);
+  route.segments = route_handler->createMapSegments(const_lanelets);
+  route_handler->setRoute(route);
+  return route_handler;
 }
 
 autoware::vehicle_info_utils::VehicleInfo make_vehicle_info()
@@ -65,32 +147,77 @@ autoware::vehicle_info_utils::VehicleInfo make_vehicle_info()
 
 }  // namespace
 
-TEST(DrivableAreaComplianceTest, ReturnsOneWhenFullFootprintStaysInsideFusedDrivableArea)
+TEST(DrivableAreaComplianceTest, ReturnsOneWhenAllCornersStayInsideDrivableArea)
 {
-  const auto result = autoware::planning_data_analyzer::metrics::calculate_drivable_area_compliance(
-    make_trajectory(0.0), make_drivable_lanelets(), make_vehicle_info());
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(0.0), make_route_handler({make_road_lanelet(1, -2.0, 2.0)}),
+    make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);
   EXPECT_EQ(result.reason, "compliant");
 }
 
-TEST(DrivableAreaComplianceTest, ReturnsZeroWhenAnyFootprintLeavesFusedDrivableArea)
+TEST(DrivableAreaComplianceTest, CountsRoadShoulderAsDrivableArea)
 {
-  const auto result = autoware::planning_data_analyzer::metrics::calculate_drivable_area_compliance(
-    make_trajectory(1.5), make_drivable_lanelets(), make_vehicle_info());
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(2.2),
+    make_route_handler({make_road_lanelet(1, -2.0, 2.0), make_shoulder_lanelet(2, 2.0, 4.0)}),
+    make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "compliant");
+}
+
+TEST(DrivableAreaComplianceTest, CountsHatchedRoadMarkingAsDrivableArea)
+{
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(2.2),
+    make_route_handler({make_road_lanelet(1, -2.0, 2.0)}, {make_hatched_road_marking(2, 2.0, 4.0)}),
+    make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "compliant");
+}
+
+TEST(DrivableAreaComplianceTest, CountsRoadBorderSideTestAsFallbackDrivableArea)
+{
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(3.15),
+    make_route_handler({make_road_lanelet(1, -2.0, 4.35)}, {}, {make_road_border_line(2, 4.55)}),
+    make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "compliant");
+}
+
+TEST(DrivableAreaComplianceTest, ReturnsZeroWhenAnyCornerLeavesDrivableArea)
+{
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(1.5), make_route_handler({make_road_lanelet(1, -2.0, 2.0)}),
+    make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
-  EXPECT_EQ(result.reason, "non_compliant_footprint_outside_drivable_area");
+  EXPECT_EQ(result.reason, "non_compliant_corner_outside_drivable_area");
+  EXPECT_TRUE(std::isfinite(result.debug_info.first_failure_time_s));
+  EXPECT_FALSE(result.debug_info.failing_corners.empty());
+  EXPECT_FALSE(result.debug_info.ego_horizon_footprints.empty());
+  EXPECT_FALSE(result.debug_info.admissible_road_areas.empty());
 }
 
 TEST(DrivableAreaComplianceTest, ReturnsUnavailableWhenRequiredInputsAreMissing)
 {
-  const auto result = autoware::planning_data_analyzer::metrics::calculate_drivable_area_compliance(
-    make_trajectory(0.0), {}, autoware::vehicle_info_utils::VehicleInfo{});
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(0.0), std::shared_ptr<RouteHandler>{},
+    autoware::vehicle_info_utils::VehicleInfo{});
 
   EXPECT_FALSE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
-  EXPECT_EQ(result.reason, "unavailable_no_drivable_lanelets");
+  EXPECT_EQ(result.reason, "unavailable_no_route_handler");
 }
+
+}  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_drivable_area_compliance.cpp
@@ -85,8 +85,8 @@ lanelet::Lanelet make_shoulder_lanelet(const lanelet::Id id, const double y_min,
   return lanelet;
 }
 
-lanelet::Polygon3d make_hatched_road_marking(
-  const lanelet::Id id, const double y_min, const double y_max)
+lanelet::Polygon3d make_map_polygon(
+  const lanelet::Id id, const double y_min, const double y_max, const char * type)
 {
   lanelet::Polygon3d polygon{
     id,
@@ -94,9 +94,15 @@ lanelet::Polygon3d make_hatched_road_marking(
      lanelet::Point3d{id * 100 + 2, 12.0, y_min, 0.0},
      lanelet::Point3d{id * 100 + 3, 12.0, y_max, 0.0},
      lanelet::Point3d{id * 100 + 4, -5.0, y_max, 0.0}}};
-  polygon.setAttribute(lanelet::AttributeName::Type, "hatched_road_markings");
+  polygon.setAttribute(lanelet::AttributeName::Type, type);
   polygon.setAttribute("area", "yes");
   return polygon;
+}
+
+lanelet::Polygon3d make_hatched_road_marking(
+  const lanelet::Id id, const double y_min, const double y_max)
+{
+  return make_map_polygon(id, y_min, y_max, "hatched_road_markings");
 }
 
 lanelet::LineString3d make_road_border_line(const lanelet::Id id, const double y)
@@ -185,6 +191,32 @@ TEST(DrivableAreaComplianceTest, CountsHatchedRoadMarkingAsDrivableArea)
   EXPECT_EQ(result.reason, "compliant");
 }
 
+TEST(DrivableAreaComplianceTest, CountsIntersectionAreaAsDrivableArea)
+{
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(2.2),
+    make_route_handler(
+      {make_road_lanelet(1, -2.0, 2.0)}, {make_map_polygon(2, 2.0, 4.0, "intersection_area")}),
+    make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "compliant");
+}
+
+TEST(DrivableAreaComplianceTest, CountsParkingLotAsDrivableArea)
+{
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(2.2),
+    make_route_handler(
+      {make_road_lanelet(1, -2.0, 2.0)}, {make_map_polygon(2, 2.0, 4.0, "parking_lot")}),
+    make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "compliant");
+}
+
 TEST(DrivableAreaComplianceTest, CountsRoadBorderSideTestAsFallbackDrivableArea)
 {
   const auto result = calculate_drivable_area_compliance(
@@ -207,7 +239,12 @@ TEST(DrivableAreaComplianceTest, ReturnsZeroWhenAnyCornerLeavesDrivableArea)
   EXPECT_DOUBLE_EQ(result.score, 0.0);
   EXPECT_EQ(result.reason, "non_compliant_corner_outside_drivable_area");
   EXPECT_TRUE(std::isfinite(result.debug_info.first_failure_time_s));
+  EXPECT_DOUBLE_EQ(result.debug_info.first_failure_time_s, 0.0);
   EXPECT_FALSE(result.debug_info.failing_corners.empty());
+  EXPECT_FALSE(result.debug_info.failing_corner_indices.empty());
+  EXPECT_EQ(
+    result.debug_info.failing_corner_indices.front(),
+    result.debug_info.failing_corners.front().corner_index);
   EXPECT_FALSE(result.debug_info.ego_horizon_footprints.empty());
   EXPECT_FALSE(result.debug_info.admissible_road_areas.empty());
 }
@@ -221,6 +258,45 @@ TEST(DrivableAreaComplianceTest, ReturnsUnavailableWhenRequiredInputsAreMissing)
   EXPECT_FALSE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
   EXPECT_EQ(result.reason, "unavailable_no_route_handler");
+}
+
+TEST(DrivableAreaComplianceTest, ReturnsUnavailableWhenRouteHandlerMapIsNotReady)
+{
+  const auto result = calculate_drivable_area_compliance(
+    make_trajectory(0.0), std::make_shared<RouteHandler>(), make_vehicle_info());
+
+  EXPECT_FALSE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "unavailable_route_handler_map_not_ready");
+}
+
+TEST(DrivableAreaComplianceTest, ReturnsUnavailableWhenFootprintEvaluationSizeMismatches)
+{
+  const auto trajectory = make_trajectory(0.0);
+  const std::vector<TrajectoryFootprintEvaluation> footprint_evaluations(1);
+  const auto result = calculate_drivable_area_compliance(
+    trajectory, make_route_handler({make_road_lanelet(1, -2.0, 2.0)}), make_vehicle_info(),
+    &footprint_evaluations);
+
+  EXPECT_FALSE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "unavailable_footprint_evaluation_size_mismatch");
+  EXPECT_TRUE(result.debug_info.ego_horizon_footprints.empty());
+}
+
+TEST(DrivableAreaComplianceTest, ReturnsUnavailableWhenDrivableAreaQueryFails)
+{
+  const auto trajectory = make_trajectory(0.0);
+  const std::vector<TrajectoryFootprintEvaluation> footprint_evaluations(trajectory.points.size());
+  const auto result = calculate_drivable_area_compliance(
+    trajectory, make_route_handler({make_road_lanelet(1, -2.0, 2.0)}), make_vehicle_info(),
+    &footprint_evaluations);
+
+  EXPECT_FALSE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "unavailable_drivable_area_query_failed");
+  EXPECT_TRUE(result.debug_info.ego_horizon_footprints.empty());
+  EXPECT_FALSE(std::isfinite(result.debug_info.first_failure_time_s));
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics


### PR DESCRIPTION
## Description

### Scope

- PR type: subscore.
- Target metric: EPDMS drivable area compliance (DAC).
- Base branch: `upstream/main`.
- This is the DAC PR in the gradual EPDMS patch series after NC.

### What Changed

- Migrates DAC from the old route-lanelet hull check to the shared ego-footprint semantic drivable-area evaluation.
- Uses existing `TrajectoryFootprintEvaluation` output instead of recomputing ego footprints in the DAC scorer.
- Adds DAC debug summary material and unit coverage for road lane, shoulder, hatched road marking, road-border fallback, and outside-area failure.
- Score semantics changed: yes, DAC now follows the NAVSIM-style corner-in-drivable-area check.
- Debug topics changed: no new topic contract in this PR; debug data remains behind `open_loop.debug_topics_enabled`.
- Output topic or JSON keys changed: no.
- DAC reason values changed: yes, e.g.
  `unavailable_footprint_evaluation_size_mismatch`,
  `non_compliant_corner_outside_drivable_area`, and route-handler unavailable reasons.
- Duplication audit: performed; repeated footprint/map queries are handled through shared ego-footprint evaluation; remaining repetition is limited to debug field serialization.

### Logic Change

As-is pipeline:

1. Build ego footprints along the trajectory.
2. Collect route-relevant drivable lanelets.
3. Fuse candidate lanelet polygons.
4. Pass only if each full footprint stays within the fused lanelet area.

To-be pipeline:

1. Reuse per-sample `TrajectoryFootprintEvaluation` prepared by the shared EPDMS geometry context.
2. For each ego footprint corner, check semantic drivable area: road lanelets, road shoulders, intersection areas, hatched road markings, parking lots, and the existing conservative road-border fallback evidence.
3. Fail DAC when any evaluated sample has a non-drivable corner.
4. Report the first failing sample and candidate-area counts for debugging.

Line-count note:

- Additions are larger than deletions because the PR exposes DAC-specific debug details and tests while reusing shared footprint/context infrastructure added by earlier PRs.

## How was this PR tested?

### Local Checks

- Build:
  - Command: `CCACHE_DISABLE=1 colcon build --symlink-install --packages-select autoware_planning_data_analyzer --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo`
  - Result: passed with temporary validation-only `pilot-auto.x2` lanelet API compatibility patch, restored before push.
- Unit tests:
  - Command: `build/autoware_planning_data_analyzer/test_metrics`
  - Result: 61 passed.
  - Command: `build/autoware_planning_data_analyzer/test_offline_evaluation`
  - Result: 20 passed.
- Pre-commit:
  - Command: `pre-commit run --all-files`
  - Result: passed.

### Full Analyzer Runs

- Takanawa:
  - Input: `/home/beomseokkim2/rosbag/x2_takanawa/input_bag`
  - Output artifact: `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260519_165136`
  - Command/script: `/tmp/run_takanawa_epdms_defaults_no_debug.fish`
  - Inference time: `192.57s`
  - Analyzer time: `193.13s`
- Odaiba:
  - Not run; Takanawa-only is the required validation bag for this PR series.

### Metric Comparison

- Baseline artifact: `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260506_155345/eval_json/time_step_based_trajectory_detailed_result.json`
- PR artifact: `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260519_165136/eval_json/time_step_based_trajectory_detailed_result.json`
- Total evaluated trajectories: `8695`.
- DAC comparison: exact match.
- DAC availability: `8695` available, `0` unavailable.
- DAC non-1/failure count: `396` baseline, `396` PR.
- DAC reason counts: `compliant: 8299`, `non_compliant_corner_outside_drivable_area: 396`.
- Representative changed timestamps: N/A for DAC; changed timestamp count is `0`.
- NC comparison: shows the accepted PR #426 semantic delta (`74 -> 87` non-1) from the already-merged NC de-dup fix.
- Other EPDMS subscores are not compared as regression targets in this DAC PR because they are not yet migrated in the upstream PR series.

### Topic Verification

- Metric topics produced: EPDMS metric topics remain under `/open_loop/metrics/epdms/*`.
- Debug topics produced: disabled by default in this validation run.
- Existing ported topics still produced: yes.

## Notes for reviewers

- Review focus: DAC semantic area sources, use of shared footprint evaluations, and DAC-specific debug/test coverage.
- Known limitation: road-border evidence is the conservative fallback already present in the shared ego-footprint context; this PR only activates that existing context for DAC.
- Follow-up PRs: DDC, TLC, TTC, LK, HC/EC, EP, aggregation/human-filter.

## Effects on system behavior

- Runtime behavior: DAC uses shared per-sample footprint/map evaluation rather than route-lanelet polygon fusion.
- Score behavior: DAC score semantics change intentionally.
- Debug/output behavior: no topic or JSON-key contract change; debug output remains opt-in.
- Reason behavior: DAC reason values changed intentionally to describe the new semantic-corner
  failure and unavailable cases.
- Backward compatibility: existing metric topic names and JSON keys are preserved.
