### PR TITLE
feat(planning_data_analyzer): migrate TLC metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -30,6 +30,7 @@
     tf_topic: "/tf"
     acceleration_topic: "/localization/acceleration"
     steering_topic: "/vehicle/status/steering_status"
+    turn_indicators_topic: "/vehicle/status/turn_indicators_status"
     control_mode_topic: "/vehicle/status/control_mode"
 
     open_loop:

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -164,6 +164,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   tf_topic_name_ = get_or_declare_parameter<std::string>(*this, "tf_topic");
   acceleration_topic_name_ = get_or_declare_parameter<std::string>(*this, "acceleration_topic");
   steering_topic_name_ = get_or_declare_parameter<std::string>(*this, "steering_topic");
+  turn_indicators_topic_name_ =
+    get_or_declare_parameter<std::string>(*this, "turn_indicators_topic");
   control_mode_topic_name_ = get_or_declare_parameter<std::string>(*this, "control_mode_topic");
   override_window_sec_ = get_or_declare_parameter<double>(*this, "open_loop.override.window_sec");
 
@@ -483,6 +485,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   topic_names.tf_topic = tf_topic_name_;
   topic_names.acceleration_topic = acceleration_topic_name_;
   topic_names.steering_topic = steering_topic_name_;
+  topic_names.turn_indicators_topic = turn_indicators_topic_name_;
   topic_names.control_mode_topic = control_mode_topic_name_;
   topic_names.evaluation_interval_ms = evaluation_interval_ms_;
   topic_names.sync_tolerance_ms = sync_tolerance_ms_;

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -101,6 +101,7 @@ private:
   std::string tf_topic_name_;
   std::string acceleration_topic_name_;
   std::string steering_topic_name_;
+  std::string turn_indicators_topic_name_;
   std::string control_mode_topic_name_;
   double override_window_sec_ = 0.0;
 

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -72,6 +72,8 @@ struct BagData
       max_buffer_msgs);
     create_buffer<SteeringReport>(
       "/vehicle/status/steering_status", buffer_duration_sec, max_buffer_msgs);
+    create_buffer<TurnIndicatorsReport>(
+      "/vehicle/status/turn_indicators_status", buffer_duration_sec, max_buffer_msgs);
   }
 
   // Constructor with topic names
@@ -108,6 +110,10 @@ struct BagData
         topic_names.traffic_signals_topic, buffer_duration_sec, max_buffer_msgs);
     }
     create_buffer<SteeringReport>(topic_names.steering_topic, buffer_duration_sec, max_buffer_msgs);
+    if (!topic_names.turn_indicators_topic.empty()) {
+      create_buffer<TurnIndicatorsReport>(
+        topic_names.turn_indicators_topic, buffer_duration_sec, max_buffer_msgs);
+    }
   }
 
   rcutils_time_point_value_t timestamp;
@@ -232,6 +238,23 @@ struct BagData
       synchronized_data->steering_status = steer_buffer->get_closest(traj_stamp_ns, tolerance_ms);
     } else if (steer_buffer) {
       synchronized_data->steering_status = steer_buffer->get_closest(target_time, tolerance_ms);
+    }
+
+    std::shared_ptr<Buffer<TurnIndicatorsReport>> turn_indicators_buffer;
+    for (const auto & [topic, buffer] : buffers) {
+      if (auto tb = std::dynamic_pointer_cast<Buffer<TurnIndicatorsReport>>(buffer)) {
+        turn_indicators_buffer = tb;
+        break;
+      }
+    }
+    if (turn_indicators_buffer && synchronized_data->trajectory) {
+      const auto traj_stamp_ns =
+        rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
+      synchronized_data->turn_indicators_status =
+        turn_indicators_buffer->get_closest(traj_stamp_ns, tolerance_ms);
+    } else if (turn_indicators_buffer) {
+      synchronized_data->turn_indicators_status =
+        turn_indicators_buffer->get_closest(target_time, tolerance_ms);
     }
 
     // Get objects

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -90,6 +90,11 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
       // SteeringReport doesn't have header, so we don't override timestamp
       process_and_append_message<SteeringReport>(
         serialized_message, bag_data, topic_names.steering_topic, false, logger_);
+    } else if (
+      topic_name == topic_names.turn_indicators_topic &&
+      !topic_names.turn_indicators_topic.empty()) {
+      process_and_append_message<TurnIndicatorsReport>(
+        serialized_message, bag_data, topic_names.turn_indicators_topic, false, logger_);
     } else if (topic_name == topic_names.objects_topic) {
       process_and_append_message<PredictedObjects>(
         serialized_message, bag_data, topic_names.objects_topic, use_bag_timestamp, logger_);

--- a/planning/autoware_planning_data_analyzer/src/data_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/data_types.hpp
@@ -24,6 +24,7 @@
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
@@ -46,6 +47,7 @@ using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupA
 using AccelWithCovarianceStamped = geometry_msgs::msg::AccelWithCovarianceStamped;
 using SteeringReport = autoware_vehicle_msgs::msg::SteeringReport;
 using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
+using TurnIndicatorsReport = autoware_vehicle_msgs::msg::TurnIndicatorsReport;
 
 struct TimedTrackedObjects
 {
@@ -66,6 +68,7 @@ struct SynchronizedData
   std::shared_ptr<TrackedObjects> tracked_objects;
   std::vector<TimedTrackedObjects> future_tracked_objects;
   std::shared_ptr<TrafficLightGroupArray> traffic_signals;
+  std::shared_ptr<TurnIndicatorsReport> turn_indicators_status;
   rclcpp::Time timestamp;
   rclcpp::Time bag_timestamp;
 };
@@ -84,6 +87,7 @@ struct TopicNames
   std::string tf_topic;
   std::string acceleration_topic;
   std::string steering_topic;
+  std::string turn_indicators_topic;
   std::string control_mode_topic;
   double evaluation_interval_ms = 100.0;
   double sync_tolerance_ms = 100.0;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
@@ -25,10 +25,8 @@
 #include <boost/geometry/algorithms/intersects.hpp>
 
 #include <algorithm>
-#include <cmath>
 #include <memory>
 #include <optional>
-#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -82,41 +80,6 @@ const autoware_perception_msgs::msg::TrafficLightGroup * find_signal_group(
   return nullptr;
 }
 
-std::vector<geometry_msgs::msg::Point> polygon_to_msg_points(
-  const autoware_utils_geometry::Polygon2d & polygon, const double z)
-{
-  std::vector<geometry_msgs::msg::Point> points;
-  points.reserve(polygon.outer().size() + 1U);
-  for (const auto & point : polygon.outer()) {
-    geometry_msgs::msg::Point msg;
-    msg.x = point.x();
-    msg.y = point.y();
-    msg.z = z;
-    points.push_back(msg);
-  }
-  if (
-    !points.empty() &&
-    (points.front().x != points.back().x || points.front().y != points.back().y)) {
-    points.push_back(points.front());
-  }
-  return points;
-}
-
-std::vector<geometry_msgs::msg::Point> stop_line_to_msg_points(
-  const lanelet::ConstLineString3d & stop_line, const double z)
-{
-  std::vector<geometry_msgs::msg::Point> points;
-  points.reserve(stop_line.size());
-  for (const auto & point : stop_line) {
-    geometry_msgs::msg::Point msg;
-    msg.x = point.x();
-    msg.y = point.y();
-    msg.z = z;
-    points.push_back(msg);
-  }
-  return points;
-}
-
 std::optional<TurnDirection> infer_turn_direction_from_indicator(
   const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status)
 {
@@ -153,19 +116,6 @@ std::optional<TurnDirection> infer_turn_direction_from_route_lanelets(
     }
   }
   return inferred;
-}
-
-std::string turn_direction_to_string(const TurnDirection turn_direction)
-{
-  switch (turn_direction) {
-    case TurnDirection::Straight:
-      return "straight";
-    case TurnDirection::Left:
-      return "left";
-    case TurnDirection::Right:
-      return "right";
-  }
-  return "unknown";
 }
 
 bool matches_intended_turn_direction(
@@ -259,54 +209,6 @@ bool stop_line_intersects_ego_polygon(
   return boost::geometry::intersects(ego_polygon, to_linestring2d(stop_line));
 }
 
-void record_first_failure_debug_info(
-  TrafficLightComplianceDebugInfo & debug_info, const double time_s,
-  const autoware_utils_geometry::Polygon2d & ego_polygon, const double z,
-  const RelevantTrafficLightGroup & group)
-{
-  if (!std::isinf(debug_info.first_failure_time_s)) {
-    return;
-  }
-
-  debug_info.first_failure_time_s = time_s;
-  debug_info.label_anchor = polygon_to_msg_points(ego_polygon, z + 0.12).front();
-  debug_info.regulatory_element_ids.push_back(group.regulatory_element_id);
-  for (const auto & lanelet : group.selected_lanelets) {
-    debug_info.selected_lane_ids.push_back(lanelet.id());
-  }
-  if (group.stop_line.has_value()) {
-    debug_info.stop_line_ids.push_back(group.stop_line->id());
-    debug_info.stop_lines.push_back(
-      TrafficLightComplianceDebugPolygon{
-        time_s, stop_line_to_msg_points(*group.stop_line, z + 0.10), group.stop_line->id()});
-  }
-  debug_info.selected_stop_line_count = debug_info.stop_lines.size();
-  if (group.intended_turn_direction.has_value()) {
-    debug_info.intended_movement = turn_direction_to_string(group.intended_turn_direction.value());
-  }
-}
-
-void fill_debug_horizon_footprints(
-  TrafficLightComplianceDebugInfo & debug_info,
-  const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::vector<TrajectoryFootprintEvaluation> & evaluations)
-{
-  if (evaluations.size() != trajectory.points.size()) {
-    return;
-  }
-
-  debug_info.ego_horizon_footprints.reserve(trajectory.points.size());
-  for (std::size_t index = 0; index < trajectory.points.size(); ++index) {
-    const auto time_s = rclcpp::Duration(trajectory.points.at(index).time_from_start).seconds();
-    debug_info.ego_horizon_footprints.push_back(
-      TrafficLightComplianceDebugPolygon{
-        time_s,
-        polygon_to_msg_points(
-          evaluations.at(index).ego_polygon, trajectory.points.at(index).pose.position.z + 0.02),
-        static_cast<lanelet::Id>(index)});
-  }
-}
-
 }  // namespace
 
 TrafficLightComplianceResult calculate_traffic_light_compliance(
@@ -362,22 +264,12 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
   const auto local_footprint = vehicle_info.createFootprint(0.0);
   const bool can_reuse_evaluations =
     evaluations != nullptr && evaluations->size() == trajectory.points.size();
-  if (can_reuse_evaluations) {
-    fill_debug_horizon_footprints(result.debug_info, trajectory, *evaluations);
-  }
 
   for (std::size_t point_index = 0; point_index < trajectory.points.size(); ++point_index) {
     const auto & point = trajectory.points.at(point_index);
-    const auto time_s = rclcpp::Duration(point.time_from_start).seconds();
     const auto ego_polygon = can_reuse_evaluations
                                ? evaluations->at(point_index).ego_polygon
                                : create_pose_footprint(point.pose, local_footprint);
-    if (!can_reuse_evaluations) {
-      result.debug_info.ego_horizon_footprints.push_back(
-        TrafficLightComplianceDebugPolygon{
-          time_s, polygon_to_msg_points(ego_polygon, point.pose.position.z + 0.02),
-          static_cast<lanelet::Id>(point_index)});
-    }
 
     for (const auto & group : groups) {
       if (!group.stop_line.has_value()) {
@@ -402,8 +294,6 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
         continue;
       }
 
-      record_first_failure_debug_info(
-        result.debug_info, time_s, ego_polygon, point.pose.position.z, group);
       result.reason = "red_light_stop_line_crossed";
       result.score = 0.0;
       return result;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
@@ -53,31 +53,12 @@ struct RelevantTrafficLightGroup
 const autoware_perception_msgs::msg::TrafficLightGroup * find_signal_group(
   const TrafficLightGroupArray & traffic_signals, const RelevantTrafficLightGroup & group)
 {
-  std::vector<lanelet::Id> candidate_ids;
-  candidate_ids.reserve(1U + group.selected_lanelets.size() + group.route_lanelets.size());
-  candidate_ids.push_back(group.regulatory_element_id);
-  for (const auto & lanelet : group.selected_lanelets) {
-    candidate_ids.push_back(lanelet.id());
-  }
-  for (const auto & lanelet : group.route_lanelets) {
-    candidate_ids.push_back(lanelet.id());
-  }
-
-  std::unordered_set<lanelet::Id> seen_ids;
-  for (const auto candidate_id : candidate_ids) {
-    if (!seen_ids.insert(candidate_id).second) {
-      continue;
-    }
-    const auto it = std::find_if(
-      traffic_signals.traffic_light_groups.begin(), traffic_signals.traffic_light_groups.end(),
-      [candidate_id](const auto & signal_group) {
-        return static_cast<lanelet::Id>(signal_group.traffic_light_group_id) == candidate_id;
-      });
-    if (it != traffic_signals.traffic_light_groups.end()) {
-      return &(*it);
-    }
-  }
-  return nullptr;
+  const auto it = std::find_if(
+    traffic_signals.traffic_light_groups.begin(), traffic_signals.traffic_light_groups.end(),
+    [regulatory_element_id = group.regulatory_element_id](const auto & signal_group) {
+      return static_cast<lanelet::Id>(signal_group.traffic_light_group_id) == regulatory_element_id;
+    });
+  return it == traffic_signals.traffic_light_groups.end() ? nullptr : &(*it);
 }
 
 std::optional<TurnDirection> infer_turn_direction_from_indicator(
@@ -152,6 +133,7 @@ std::vector<RelevantTrafficLightGroup> build_relevant_traffic_light_groups(
     }
     for (const auto & reg_elem :
          lanelet.regulatoryElementsAs<lanelet::autoware::AutowareTrafficLight>()) {
+      // TrafficLightGroup messages are keyed by regulatory element ID.
       const auto [it, inserted] =
         index_by_reg_elem_id.emplace(reg_elem->id(), index_by_reg_elem_id.size());
       if (inserted) {
@@ -163,7 +145,7 @@ std::vector<RelevantTrafficLightGroup> build_relevant_traffic_light_groups(
         groups.push_back(group);
       }
 
-      auto & group = groups.at(it->second);
+      auto & group = groups[it->second];
       const auto duplicate = std::any_of(
         group.route_lanelets.begin(), group.route_lanelets.end(),
         [&lanelet](const auto & candidate) { return candidate.id() == lanelet.id(); });
@@ -179,6 +161,8 @@ std::vector<RelevantTrafficLightGroup> build_relevant_traffic_light_groups(
   }
 
   for (auto & group : groups) {
+    // Indicator state is sampled once at the trajectory timestamp; per-group intent inference can
+    // be added later for multi-intersection horizons if needed.
     group.intended_turn_direction =
       indicator_turn_direction.has_value()
         ? indicator_turn_direction

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.cpp
@@ -14,23 +14,22 @@
 
 #include "traffic_light_compliance.hpp"
 
-#include "metrics/geometry/ego_footprint.hpp"
 #include "metrics/geometry/lanelet_queries.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 
+#include <autoware/lanelet2_utils/intersection.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
 
-#include <boost/geometry.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
-#include <boost/geometry/algorithms/within.hpp>
 
-#include <lanelet2_core/utility/Utilities.h>
-
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <optional>
+#include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -42,27 +41,270 @@ using autoware::route_handler::RouteHandler;
 namespace
 {
 
-using autoware_utils_geometry::LineString2d;
+using TurnDirection = autoware::experimental::lanelet2_utils::TurnDirection;
+
+struct RelevantTrafficLightGroup
+{
+  lanelet::Id regulatory_element_id{0};
+  lanelet::ConstLanelets route_lanelets;
+  lanelet::ConstLanelets selected_lanelets;
+  std::optional<lanelet::ConstLineString3d> stop_line;
+  std::optional<TurnDirection> intended_turn_direction;
+};
 
 const autoware_perception_msgs::msg::TrafficLightGroup * find_signal_group(
-  const TrafficLightGroupArray & traffic_signals, const lanelet::Id reg_elem_id)
+  const TrafficLightGroupArray & traffic_signals, const RelevantTrafficLightGroup & group)
 {
-  const auto it = std::find_if(
-    traffic_signals.traffic_light_groups.begin(), traffic_signals.traffic_light_groups.end(),
-    [reg_elem_id](const auto & group) {
-      return static_cast<lanelet::Id>(group.traffic_light_group_id) == reg_elem_id;
-    });
-  return it == traffic_signals.traffic_light_groups.end() ? nullptr : &(*it);
+  std::vector<lanelet::Id> candidate_ids;
+  candidate_ids.reserve(1U + group.selected_lanelets.size() + group.route_lanelets.size());
+  candidate_ids.push_back(group.regulatory_element_id);
+  for (const auto & lanelet : group.selected_lanelets) {
+    candidate_ids.push_back(lanelet.id());
+  }
+  for (const auto & lanelet : group.route_lanelets) {
+    candidate_ids.push_back(lanelet.id());
+  }
+
+  std::unordered_set<lanelet::Id> seen_ids;
+  for (const auto candidate_id : candidate_ids) {
+    if (!seen_ids.insert(candidate_id).second) {
+      continue;
+    }
+    const auto it = std::find_if(
+      traffic_signals.traffic_light_groups.begin(), traffic_signals.traffic_light_groups.end(),
+      [candidate_id](const auto & signal_group) {
+        return static_cast<lanelet::Id>(signal_group.traffic_light_group_id) == candidate_id;
+      });
+    if (it != traffic_signals.traffic_light_groups.end()) {
+      return &(*it);
+    }
+  }
+  return nullptr;
 }
 
-bool footprint_intersects_stop_line(
-  const geometry_msgs::msg::Pose & pose,
-  const autoware_utils_geometry::LinearRing2d & local_footprint,
+std::vector<geometry_msgs::msg::Point> polygon_to_msg_points(
+  const autoware_utils_geometry::Polygon2d & polygon, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(polygon.outer().size() + 1U);
+  for (const auto & point : polygon.outer()) {
+    geometry_msgs::msg::Point msg;
+    msg.x = point.x();
+    msg.y = point.y();
+    msg.z = z;
+    points.push_back(msg);
+  }
+  if (
+    !points.empty() &&
+    (points.front().x != points.back().x || points.front().y != points.back().y)) {
+    points.push_back(points.front());
+  }
+  return points;
+}
+
+std::vector<geometry_msgs::msg::Point> stop_line_to_msg_points(
+  const lanelet::ConstLineString3d & stop_line, const double z)
+{
+  std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(stop_line.size());
+  for (const auto & point : stop_line) {
+    geometry_msgs::msg::Point msg;
+    msg.x = point.x();
+    msg.y = point.y();
+    msg.z = z;
+    points.push_back(msg);
+  }
+  return points;
+}
+
+std::optional<TurnDirection> infer_turn_direction_from_indicator(
+  const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status)
+{
+  if (!turn_indicators_status) {
+    return std::nullopt;
+  }
+
+  switch (turn_indicators_status->report) {
+    case TurnIndicatorsReport::ENABLE_LEFT:
+      return TurnDirection::Left;
+    case TurnIndicatorsReport::ENABLE_RIGHT:
+      return TurnDirection::Right;
+    default:
+      return std::nullopt;
+  }
+}
+
+std::optional<TurnDirection> infer_turn_direction_from_route_lanelets(
+  const lanelet::ConstLanelets & lanelets)
+{
+  std::optional<TurnDirection> inferred;
+  for (const auto & lanelet : lanelets) {
+    const auto lanelet_turn_direction =
+      autoware::experimental::lanelet2_utils::get_turn_direction(lanelet);
+    if (!lanelet_turn_direction.has_value()) {
+      continue;
+    }
+    if (!inferred.has_value()) {
+      inferred = lanelet_turn_direction;
+      continue;
+    }
+    if (inferred.value() != lanelet_turn_direction.value()) {
+      return std::nullopt;
+    }
+  }
+  return inferred;
+}
+
+std::string turn_direction_to_string(const TurnDirection turn_direction)
+{
+  switch (turn_direction) {
+    case TurnDirection::Straight:
+      return "straight";
+    case TurnDirection::Left:
+      return "left";
+    case TurnDirection::Right:
+      return "right";
+  }
+  return "unknown";
+}
+
+bool matches_intended_turn_direction(
+  const lanelet::ConstLanelet & lanelet,
+  const std::optional<TurnDirection> & intended_turn_direction)
+{
+  if (!intended_turn_direction.has_value()) {
+    return true;
+  }
+
+  const auto lanelet_turn_direction =
+    autoware::experimental::lanelet2_utils::get_turn_direction(lanelet);
+  if (!lanelet_turn_direction.has_value()) {
+    return false;
+  }
+  return lanelet_turn_direction.value() == intended_turn_direction.value();
+}
+
+std::vector<RelevantTrafficLightGroup> build_relevant_traffic_light_groups(
+  const lanelet::ConstLanelets & route_lanelets,
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status)
+{
+  std::vector<RelevantTrafficLightGroup> groups;
+  if (!route_handler || !route_handler->isHandlerReady()) {
+    return groups;
+  }
+
+  const auto indicator_turn_direction = infer_turn_direction_from_indicator(turn_indicators_status);
+  std::unordered_map<lanelet::Id, std::size_t> index_by_reg_elem_id;
+  for (const auto & lanelet : route_lanelets) {
+    if (!route_handler->isRoadLanelet(lanelet)) {
+      continue;
+    }
+    for (const auto & reg_elem :
+         lanelet.regulatoryElementsAs<lanelet::autoware::AutowareTrafficLight>()) {
+      const auto [it, inserted] =
+        index_by_reg_elem_id.emplace(reg_elem->id(), index_by_reg_elem_id.size());
+      if (inserted) {
+        RelevantTrafficLightGroup group;
+        group.regulatory_element_id = reg_elem->id();
+        if (const auto stop_line = reg_elem->stopLine(); stop_line && !stop_line->empty()) {
+          group.stop_line = *stop_line;
+        }
+        groups.push_back(group);
+      }
+
+      auto & group = groups.at(it->second);
+      const auto duplicate = std::any_of(
+        group.route_lanelets.begin(), group.route_lanelets.end(),
+        [&lanelet](const auto & candidate) { return candidate.id() == lanelet.id(); });
+      if (!duplicate) {
+        group.route_lanelets.push_back(lanelet);
+      }
+      if (!group.stop_line.has_value()) {
+        if (const auto stop_line = reg_elem->stopLine(); stop_line && !stop_line->empty()) {
+          group.stop_line = *stop_line;
+        }
+      }
+    }
+  }
+
+  for (auto & group : groups) {
+    group.intended_turn_direction =
+      indicator_turn_direction.has_value()
+        ? indicator_turn_direction
+        : infer_turn_direction_from_route_lanelets(group.route_lanelets);
+
+    std::unordered_set<lanelet::Id> selected_lanelet_ids;
+    for (const auto & lanelet : group.route_lanelets) {
+      if (!matches_intended_turn_direction(lanelet, group.intended_turn_direction)) {
+        continue;
+      }
+      if (selected_lanelet_ids.insert(lanelet.id()).second) {
+        group.selected_lanelets.push_back(lanelet);
+      }
+    }
+
+    if (group.selected_lanelets.empty()) {
+      group.selected_lanelets = group.route_lanelets;
+    }
+  }
+
+  return groups;
+}
+
+bool stop_line_intersects_ego_polygon(
+  const autoware_utils_geometry::Polygon2d & ego_polygon,
   const lanelet::ConstLineString3d & stop_line)
 {
-  const auto footprint_polygon = create_pose_footprint(pose, local_footprint);
-  const auto stop_line_2d = to_linestring2d(stop_line);
-  return boost::geometry::intersects(footprint_polygon, stop_line_2d);
+  return boost::geometry::intersects(ego_polygon, to_linestring2d(stop_line));
+}
+
+void record_first_failure_debug_info(
+  TrafficLightComplianceDebugInfo & debug_info, const double time_s,
+  const autoware_utils_geometry::Polygon2d & ego_polygon, const double z,
+  const RelevantTrafficLightGroup & group)
+{
+  if (!std::isinf(debug_info.first_failure_time_s)) {
+    return;
+  }
+
+  debug_info.first_failure_time_s = time_s;
+  debug_info.label_anchor = polygon_to_msg_points(ego_polygon, z + 0.12).front();
+  debug_info.regulatory_element_ids.push_back(group.regulatory_element_id);
+  for (const auto & lanelet : group.selected_lanelets) {
+    debug_info.selected_lane_ids.push_back(lanelet.id());
+  }
+  if (group.stop_line.has_value()) {
+    debug_info.stop_line_ids.push_back(group.stop_line->id());
+    debug_info.stop_lines.push_back(
+      TrafficLightComplianceDebugPolygon{
+        time_s, stop_line_to_msg_points(*group.stop_line, z + 0.10), group.stop_line->id()});
+  }
+  debug_info.selected_stop_line_count = debug_info.stop_lines.size();
+  if (group.intended_turn_direction.has_value()) {
+    debug_info.intended_movement = turn_direction_to_string(group.intended_turn_direction.value());
+  }
+}
+
+void fill_debug_horizon_footprints(
+  TrafficLightComplianceDebugInfo & debug_info,
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const std::vector<TrajectoryFootprintEvaluation> & evaluations)
+{
+  if (evaluations.size() != trajectory.points.size()) {
+    return;
+  }
+
+  debug_info.ego_horizon_footprints.reserve(trajectory.points.size());
+  for (std::size_t index = 0; index < trajectory.points.size(); ++index) {
+    const auto time_s = rclcpp::Duration(trajectory.points.at(index).time_from_start).seconds();
+    debug_info.ego_horizon_footprints.push_back(
+      TrafficLightComplianceDebugPolygon{
+        time_s,
+        polygon_to_msg_points(
+          evaluations.at(index).ego_polygon, trajectory.points.at(index).pose.position.z + 0.02),
+        static_cast<lanelet::Id>(index)});
+  }
 }
 
 }  // namespace
@@ -71,7 +313,10 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<TrafficLightGroupArray> & traffic_signals,
   const std::shared_ptr<RouteHandler> & route_handler,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status,
+  const std::vector<TrajectoryFootprintEvaluation> * evaluations,
+  const lanelet::ConstLanelets * route_relevant_lanelets)
 {
   TrafficLightComplianceResult result;
 
@@ -92,60 +337,80 @@ TrafficLightComplianceResult calculate_traffic_light_compliance(
     return result;
   }
 
-  std::unordered_set<lanelet::Id> missing_signal_ids;
-  bool encountered_relevant_traffic_light = false;
+  const auto local_route_lanelets = route_relevant_lanelets
+                                      ? lanelet::ConstLanelets{}
+                                      : collect_route_relevant_lanelets(trajectory, route_handler);
+  const auto & route_lanelets =
+    route_relevant_lanelets ? *route_relevant_lanelets : local_route_lanelets;
+  const auto groups =
+    build_relevant_traffic_light_groups(route_lanelets, route_handler, turn_indicators_status);
   result.available = true;
-  result.reason = "available_no_relevant_traffic_lights";
+  result.reason = groups.empty() ? "available_no_relevant_traffic_lights" : "available";
   result.score = 1.0;
-  const auto local_footprint = vehicle_info.createFootprint(0.0);
-
-  for (const auto & point : trajectory.points) {
-    const auto reference_lanelet = find_reference_lanelet(point.pose, route_handler);
-    if (!reference_lanelet.has_value()) {
-      continue;
-    }
-
-    for (const auto & reg_elem :
-         reference_lanelet->regulatoryElementsAs<lanelet::autoware::AutowareTrafficLight>()) {
-      const auto stop_line = reg_elem->stopLine();
-      if (!stop_line || stop_line->empty()) {
-        continue;
-      }
-
-      encountered_relevant_traffic_light = true;
-      if (!traffic_signals) {
-        result.available = false;
-        result.reason = "unavailable_no_traffic_signals";
-        return result;
-      }
-
-      const auto * signal_group = find_signal_group(*traffic_signals, reg_elem->id());
-      if (!signal_group) {
-        missing_signal_ids.insert(reg_elem->id());
-        continue;
-      }
-
-      if (!autoware::traffic_light_utils::isTrafficSignalStop(
-            reference_lanelet.value(), *signal_group)) {
-        result.reason = "available";
-        continue;
-      }
-
-      if (footprint_intersects_stop_line(point.pose, local_footprint, *stop_line)) {
-        result.reason = "red_light_stop_line_crossed";
-        result.score = 0.0;
-        return result;
-      }
-
-      result.reason = "available";
-    }
-  }
-
-  if (!encountered_relevant_traffic_light) {
+  if (groups.empty()) {
     return result;
   }
 
-  if (!missing_signal_ids.empty()) {
+  if (!traffic_signals) {
+    result.available = false;
+    result.score = 0.0;
+    result.reason = "unavailable_no_traffic_signals";
+    return result;
+  }
+
+  std::unordered_set<lanelet::Id> missing_signal_ids_at_relevant_stop_line;
+  const auto local_footprint = vehicle_info.createFootprint(0.0);
+  const bool can_reuse_evaluations =
+    evaluations != nullptr && evaluations->size() == trajectory.points.size();
+  if (can_reuse_evaluations) {
+    fill_debug_horizon_footprints(result.debug_info, trajectory, *evaluations);
+  }
+
+  for (std::size_t point_index = 0; point_index < trajectory.points.size(); ++point_index) {
+    const auto & point = trajectory.points.at(point_index);
+    const auto time_s = rclcpp::Duration(point.time_from_start).seconds();
+    const auto ego_polygon = can_reuse_evaluations
+                               ? evaluations->at(point_index).ego_polygon
+                               : create_pose_footprint(point.pose, local_footprint);
+    if (!can_reuse_evaluations) {
+      result.debug_info.ego_horizon_footprints.push_back(
+        TrafficLightComplianceDebugPolygon{
+          time_s, polygon_to_msg_points(ego_polygon, point.pose.position.z + 0.02),
+          static_cast<lanelet::Id>(point_index)});
+    }
+
+    for (const auto & group : groups) {
+      if (!group.stop_line.has_value()) {
+        continue;
+      }
+      if (!stop_line_intersects_ego_polygon(ego_polygon, *group.stop_line)) {
+        continue;
+      }
+
+      const auto * signal_group = find_signal_group(*traffic_signals, group);
+      if (!signal_group) {
+        missing_signal_ids_at_relevant_stop_line.insert(group.regulatory_element_id);
+        continue;
+      }
+
+      const bool stop_required = std::any_of(
+        group.selected_lanelets.begin(), group.selected_lanelets.end(),
+        [signal_group](const auto & lanelet) {
+          return autoware::traffic_light_utils::isTrafficSignalStop(lanelet, *signal_group);
+        });
+      if (!stop_required) {
+        continue;
+      }
+
+      record_first_failure_debug_info(
+        result.debug_info, time_s, ego_polygon, point.pose.position.z, group);
+      result.reason = "red_light_stop_line_crossed";
+      result.score = 0.0;
+      return result;
+    }
+  }
+
+  if (!missing_signal_ids_at_relevant_stop_line.empty()) {
     result.available = false;
     result.score = 0.0;
     result.reason = "unavailable_missing_signal_group";

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.hpp
@@ -16,30 +16,62 @@
 #define METRICS__EPDMS__SUBSCORES__TRAFFIC_LIGHT_COMPLIANCE_HPP_
 
 #include "data_types.hpp"
+#include "metrics/geometry/ego_footprint.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
+#include <geometry_msgs/msg/point.hpp>
+
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <limits>
 #include <memory>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
 
 using autoware::route_handler::RouteHandler;
 
+struct TrafficLightComplianceDebugPolygon
+{
+  double time_s{0.0};
+  std::vector<geometry_msgs::msg::Point> polygon;
+  lanelet::Id source_id{0};
+};
+
+struct TrafficLightComplianceDebugInfo
+{
+  double first_failure_time_s{std::numeric_limits<double>::infinity()};
+  geometry_msgs::msg::Point label_anchor;
+  std::vector<TrafficLightComplianceDebugPolygon> ego_horizon_footprints;
+  std::vector<TrafficLightComplianceDebugPolygon> stop_lines;
+  std::vector<lanelet::Id> regulatory_element_ids;
+  std::vector<lanelet::Id> selected_lane_ids;
+  std::vector<lanelet::Id> stop_line_ids;
+  std::size_t selected_stop_line_count{0};
+  std::optional<std::string> intended_movement;
+};
+
 struct TrafficLightComplianceResult
 {
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
+  TrafficLightComplianceDebugInfo debug_info;
 };
 
 TrafficLightComplianceResult calculate_traffic_light_compliance(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
   const std::shared_ptr<TrafficLightGroupArray> & traffic_signals,
   const std::shared_ptr<RouteHandler> & route_handler,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::shared_ptr<TurnIndicatorsReport> & turn_indicators_status = nullptr,
+  const std::vector<TrajectoryFootprintEvaluation> * evaluations = nullptr,
+  const lanelet::ConstLanelets * route_relevant_lanelets = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/traffic_light_compliance.hpp
@@ -21,11 +21,8 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 
-#include <geometry_msgs/msg/point.hpp>
-
 #include <lanelet2_core/primitives/Lanelet.h>
 
-#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -36,32 +33,11 @@ namespace autoware::planning_data_analyzer::metrics
 
 using autoware::route_handler::RouteHandler;
 
-struct TrafficLightComplianceDebugPolygon
-{
-  double time_s{0.0};
-  std::vector<geometry_msgs::msg::Point> polygon;
-  lanelet::Id source_id{0};
-};
-
-struct TrafficLightComplianceDebugInfo
-{
-  double first_failure_time_s{std::numeric_limits<double>::infinity()};
-  geometry_msgs::msg::Point label_anchor;
-  std::vector<TrafficLightComplianceDebugPolygon> ego_horizon_footprints;
-  std::vector<TrafficLightComplianceDebugPolygon> stop_lines;
-  std::vector<lanelet::Id> regulatory_element_ids;
-  std::vector<lanelet::Id> selected_lane_ids;
-  std::vector<lanelet::Id> stop_line_ids;
-  std::size_t selected_stop_line_count{0};
-  std::optional<std::string> intended_movement;
-};
-
 struct TrafficLightComplianceResult
 {
   double score{0.0};
   bool available{false};
   std::string reason{"unavailable"};
-  TrafficLightComplianceDebugInfo debug_info;
 };
 
 TrafficLightComplianceResult calculate_traffic_light_compliance(

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -289,6 +289,7 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.drivable_area_compliance_reason = "unavailable_route_handler_not_ready";
     metrics.traffic_light_compliance_reason = "unavailable_route_handler_not_ready";
   } else {
+    const auto route_relevant_lanelets = collect_route_relevant_lanelets(trajectory, route_handler);
     const auto drivable_area_compliance = calculate_drivable_area_compliance(
       trajectory, route_handler, vehicle_info, &footprint_evaluations);
     metrics.drivable_area_compliance = drivable_area_compliance.score;
@@ -297,7 +298,7 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
 
     const auto traffic_light_compliance = calculate_traffic_light_compliance(
       trajectory, sync_data->traffic_signals, route_handler, vehicle_info,
-      sync_data->turn_indicators_status, &footprint_evaluations);
+      sync_data->turn_indicators_status, &footprint_evaluations, &route_relevant_lanelets);
     metrics.traffic_light_compliance = traffic_light_compliance.score;
     metrics.traffic_light_compliance_available = traffic_light_compliance.available;
     metrics.traffic_light_compliance_reason = traffic_light_compliance.reason;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -296,7 +296,8 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.drivable_area_compliance_reason = drivable_area_compliance.reason;
 
     const auto traffic_light_compliance = calculate_traffic_light_compliance(
-      trajectory, sync_data->traffic_signals, route_handler, vehicle_info);
+      trajectory, sync_data->traffic_signals, route_handler, vehicle_info,
+      sync_data->turn_indicators_status, &footprint_evaluations);
     metrics.traffic_light_compliance = traffic_light_compliance.score;
     metrics.traffic_light_compliance_available = traffic_light_compliance.available;
     metrics.traffic_light_compliance_reason = traffic_light_compliance.reason;

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_traffic_light_compliance.cpp
@@ -37,6 +37,12 @@ using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
 
+struct TrafficLightFixture
+{
+  std::shared_ptr<RouteHandler> route_handler;
+  lanelet::ConstLanelets route_lanelets;
+};
+
 geometry_msgs::msg::Pose make_pose(const double x, const double y)
 {
   geometry_msgs::msg::Pose pose;
@@ -63,7 +69,7 @@ autoware::vehicle_info_utils::VehicleInfo make_vehicle_info()
     0.3, 0.2, 2.5, 1.6, 1.0, 1.0, 0.5, 0.5, 1.8, 0.7);
 }
 
-std::shared_ptr<RouteHandler> make_route_handler_with_traffic_light(const lanelet::Id signal_id)
+TrafficLightFixture make_traffic_light_fixture(const lanelet::Id signal_id)
 {
   lanelet::LineString3d left_bound{
     11, {lanelet::Point3d{101, -5.0, 2.0, 0.0}, lanelet::Point3d{102, 12.0, 2.0, 0.0}}};
@@ -97,7 +103,7 @@ std::shared_ptr<RouteHandler> make_route_handler_with_traffic_light(const lanele
   route.goal_pose = make_pose(11.0, 0.0);
   route.segments = route_handler->createMapSegments({road_lanelet});
   route_handler->setRoute(route);
-  return route_handler;
+  return TrafficLightFixture{route_handler, {road_lanelet}};
 }
 
 std::shared_ptr<TrafficLightGroupArray> make_red_traffic_signals(const lanelet::Id signal_id)
@@ -152,9 +158,10 @@ TEST(TrafficLightComplianceTest, MissingRouteHandlerIsUnavailable)
 TEST(TrafficLightComplianceTest, ReturnsZeroWhenCrossingRedLightStopLine)
 {
   constexpr lanelet::Id signal_id = 1001;
+  const auto fixture = make_traffic_light_fixture(signal_id);
   const auto result = autoware::planning_data_analyzer::metrics::calculate_traffic_light_compliance(
     make_trajectory_crossing_stop_line(), make_red_traffic_signals(signal_id),
-    make_route_handler_with_traffic_light(signal_id), make_vehicle_info());
+    fixture.route_handler, make_vehicle_info(), nullptr, nullptr, &fixture.route_lanelets);
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_traffic_light_compliance.cpp
@@ -14,7 +14,108 @@
 
 #include "metrics/epdms/subscores/traffic_light_compliance.hpp"
 
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+
 #include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <memory>
+
+namespace
+{
+
+using autoware::route_handler::RouteHandler;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+geometry_msgs::msg::Pose make_pose(const double x, const double y)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.orientation.w = 1.0;
+  return pose;
+}
+
+autoware_planning_msgs::msg::Trajectory make_trajectory_crossing_stop_line()
+{
+  autoware_planning_msgs::msg::Trajectory trajectory;
+  trajectory.header.frame_id = "map";
+  autoware_planning_msgs::msg::TrajectoryPoint point;
+  point.pose = make_pose(3.0, 0.0);
+  point.longitudinal_velocity_mps = 2.0;
+  trajectory.points.push_back(point);
+  return trajectory;
+}
+
+autoware::vehicle_info_utils::VehicleInfo make_vehicle_info()
+{
+  return autoware::vehicle_info_utils::createVehicleInfo(
+    0.3, 0.2, 2.5, 1.6, 1.0, 1.0, 0.5, 0.5, 1.8, 0.7);
+}
+
+std::shared_ptr<RouteHandler> make_route_handler_with_traffic_light(const lanelet::Id signal_id)
+{
+  lanelet::LineString3d left_bound{
+    11, {lanelet::Point3d{101, -5.0, 2.0, 0.0}, lanelet::Point3d{102, 12.0, 2.0, 0.0}}};
+  lanelet::LineString3d right_bound{
+    12, {lanelet::Point3d{103, -5.0, -2.0, 0.0}, lanelet::Point3d{104, 12.0, -2.0, 0.0}}};
+  lanelet::Lanelet road_lanelet{1, left_bound, right_bound};
+  road_lanelet.setAttribute(lanelet::AttributeName::Subtype, lanelet::AttributeValueString::Road);
+
+  const lanelet::LineString3d traffic_light_base{
+    21, {lanelet::Point3d{201, 3.0, 3.0, 4.0}, lanelet::Point3d{202, 3.0, 4.0, 4.0}}};
+  const lanelet::LineString3d stop_line{
+    22, {lanelet::Point3d{203, 3.0, -2.0, 0.0}, lanelet::Point3d{204, 3.0, 2.0, 0.0}}};
+  const auto traffic_light = lanelet::autoware::AutowareTrafficLight::make(
+    signal_id, lanelet::AttributeMap{}, {traffic_light_base}, stop_line);
+  road_lanelet.addRegulatoryElement(traffic_light);
+
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  map->add(road_lanelet);
+
+  autoware_map_msgs::msg::LaneletMapBin map_msg;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  lanelet::utils::conversion::toBinMsg(map, &map_msg);
+#pragma GCC diagnostic pop
+
+  auto route_handler = std::make_shared<RouteHandler>();
+  route_handler->setMap(map_msg);
+
+  autoware_planning_msgs::msg::LaneletRoute route;
+  route.start_pose = make_pose(-4.0, 0.0);
+  route.goal_pose = make_pose(11.0, 0.0);
+  route.segments = route_handler->createMapSegments({road_lanelet});
+  route_handler->setRoute(route);
+  return route_handler;
+}
+
+std::shared_ptr<TrafficLightGroupArray> make_red_traffic_signals(const lanelet::Id signal_id)
+{
+  auto traffic_signals = std::make_shared<TrafficLightGroupArray>();
+  TrafficLightElement element;
+  element.color = TrafficLightElement::RED;
+  element.shape = TrafficLightElement::CIRCLE;
+  element.status = TrafficLightElement::SOLID_ON;
+
+  TrafficLightGroup group;
+  group.traffic_light_group_id = signal_id;
+  group.elements.push_back(element);
+  traffic_signals->traffic_light_groups.push_back(group);
+  return traffic_signals;
+}
+
+}  // namespace
 
 TEST(TrafficLightComplianceTest, EmptyTrajectoryIsUnavailable)
 {
@@ -46,4 +147,16 @@ TEST(TrafficLightComplianceTest, MissingRouteHandlerIsUnavailable)
 
   EXPECT_FALSE(result.available);
   EXPECT_EQ(result.reason, "unavailable_no_route_handler");
+}
+
+TEST(TrafficLightComplianceTest, ReturnsZeroWhenCrossingRedLightStopLine)
+{
+  constexpr lanelet::Id signal_id = 1001;
+  const auto result = autoware::planning_data_analyzer::metrics::calculate_traffic_light_compliance(
+    make_trajectory_crossing_stop_line(), make_red_traffic_signals(signal_id),
+    make_route_handler_with_traffic_light(signal_id), make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "red_light_stop_line_crossed");
 }

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_traffic_light_compliance.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_traffic_light_compliance.cpp
@@ -25,3 +25,25 @@ TEST(TrafficLightComplianceTest, EmptyTrajectoryIsUnavailable)
   EXPECT_FALSE(result.available);
   EXPECT_EQ(result.reason, "unavailable_empty_trajectory");
 }
+
+TEST(TrafficLightComplianceTest, MissingRouteHandlerIsUnavailable)
+{
+  autoware_planning_msgs::msg::Trajectory trajectory;
+  trajectory.points.resize(1);
+  trajectory.points.front().pose.orientation.w = 1.0;
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  vehicle_info.vehicle_length_m = 4.8;
+  vehicle_info.vehicle_width_m = 1.8;
+  vehicle_info.wheel_base_m = 2.8;
+  vehicle_info.front_overhang_m = 1.0;
+  vehicle_info.rear_overhang_m = 1.0;
+  vehicle_info.left_overhang_m = 0.9;
+  vehicle_info.right_overhang_m = 0.9;
+
+  const auto result = autoware::planning_data_analyzer::metrics::calculate_traffic_light_compliance(
+    trajectory, nullptr, nullptr, vehicle_info);
+
+  EXPECT_FALSE(result.available);
+  EXPECT_EQ(result.reason, "unavailable_no_route_handler");
+}

--- a/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
@@ -42,7 +42,7 @@ TEST_F(BagHandlerTest, BagDataConstruction)
   auto bag_data = std::make_shared<BagData>(timestamp_);
 
   EXPECT_EQ(bag_data->timestamp, timestamp_);
-  EXPECT_EQ(bag_data->buffers.size(), 9u);
+  EXPECT_EQ(bag_data->buffers.size(), 10u);
   // Check default topic names
   EXPECT_TRUE(bag_data->buffers.count("/tf"));
   EXPECT_TRUE(bag_data->buffers.count("/localization/kinematic_state"));

--- a/planning/autoware_planning_data_analyzer/test/test_replay_evaluation.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_replay_evaluation.cpp
@@ -61,6 +61,7 @@ TEST_F(ReplayEvaluationTest, TopicDefinitions)
   topic_names.trajectory_topic = "/planning/trajectory";
   topic_names.gt_trajectory_topic = "/planning/ground_truth_trajectory";
   topic_names.steering_topic = "/vehicle/status/steering_status";
+  topic_names.turn_indicators_topic = "/vehicle/status/turn_indicators_status";
   topic_names.route_topic = "/planning/mission_planning/route";
   topic_names.evaluation_interval_ms = 100.0;
   topic_names.sync_tolerance_ms = 100.0;
@@ -73,6 +74,7 @@ TEST_F(ReplayEvaluationTest, TopicDefinitions)
   EXPECT_EQ(topic_names.trajectory_topic, "/planning/trajectory");
   EXPECT_EQ(topic_names.gt_trajectory_topic, "/planning/ground_truth_trajectory");
   EXPECT_EQ(topic_names.steering_topic, "/vehicle/status/steering_status");
+  EXPECT_EQ(topic_names.turn_indicators_topic, "/vehicle/status/turn_indicators_status");
   EXPECT_EQ(topic_names.route_topic, "/planning/mission_planning/route");
   EXPECT_EQ(topic_names.evaluation_interval_ms, 100.0);
   EXPECT_EQ(topic_names.sync_tolerance_ms, 100.0);


### PR DESCRIPTION
## Description

This is the next PR in the EPDMS patch series after the DDC migration PR.

PR type: subscore.

### Logic Change

As-is pipeline:
reference lanelet -> traffic-light regulatory element -> signal group -> ego footprint / stop-line overlap.

To-be pipeline:
trajectory route lanelets -> relevant traffic-light groups -> movement-filtered controlled lanelets -> signal group association -> ego polygon / stop-line overlap.

This ports the TLC logic toward the prepared stop-line based EPDMS behavior while keeping debug-topic payload out of this score-migration PR.

### Notes for reviewers

- This PR is intentionally limited to TLC migration and required turn-indicator input plumbing.
- Reuses route-lanelet and ego-footprint helpers introduced by previous EPDMS PRs.
- TLC debug payload was intentionally removed from this PR because it is not published/tested here.

## How was this PR tested?

- Rebased onto upstream main after PR #428 was merged.
- Changed-file pre-commit passed.
- Prepared Takanawa cumulative validation with metrics ['nc','dac','ddc','tlc']:
  - Run artifact: /home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260520_012118
  - TLC exact match against reference: 68 non-1, 0 unavailable, 0 changed TLC timestamps.
  - DAC exact match remained 396 non-1.
  - DDC exact match remained 81 non-1.
  - NC differs only by the accepted PR #426 de-dup delta: 74 -> 87 non-1.