### PR TITLE
feat(planning_data_analyzer): migrate TTC metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.cpp
@@ -17,10 +17,8 @@
 #include "metrics/geometry/ego_footprint.hpp"
 #include "metrics/geometry/lanelet_queries.hpp"
 #include "metrics/geometry/metric_utils.hpp"
+#include "metrics/geometry/object_tracks.hpp"
 
-#include <autoware_utils_geometry/boost_geometry.hpp>
-#include <autoware_utils_geometry/boost_polygon_utils.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
 #include <tf2/LinearMath/Vector3.hpp>
 
 #include <boost/geometry.hpp>
@@ -30,8 +28,8 @@
 #include <cmath>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -42,20 +40,10 @@ using autoware::route_handler::RouteHandler;
 namespace
 {
 
-using autoware_utils_geometry::LinearRing2d;
-using autoware_utils_geometry::Point2d;
-using autoware_utils_geometry::Polygon2d;
-
 constexpr double kStoppedSpeedThreshold = 5.0e-3;
 constexpr std::array<double, 4> kFutureProjectionOffsetsSec{{0.0, 0.3, 0.6, 0.9}};
-
-struct PredictedObjectCache
-{
-  const autoware_perception_msgs::msg::PredictedObject * object{};
-  const autoware_perception_msgs::msg::PredictedPath * path{};
-  double dt{0.0};
-  double max_time{0.0};
-};
+constexpr double kAheadAngleThresholdRad = M_PI / 6.0;
+constexpr double kBehindAngleThresholdRad = 5.0 * M_PI / 6.0;
 
 tf2::Vector3 get_velocity_in_world_coordinate(
   const autoware_planning_msgs::msg::TrajectoryPoint & point)
@@ -77,66 +65,43 @@ geometry_msgs::msg::Pose project_pose(
   return projected;
 }
 
-bool is_agent_ahead(
+double relative_agent_angle(
   const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & object_pose)
 {
-  return forward_offset_in_ego_frame(ego_pose, object_pose) > 0.0;
+  const double yaw = get_yaw(ego_pose.orientation);
+  const double dx = object_pose.position.x - ego_pose.position.x;
+  const double dy = object_pose.position.y - ego_pose.position.y;
+  const double distance = std::hypot(dx, dy);
+  if (distance <= 1.0e-6) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  const double cos_angle =
+    std::clamp((std::cos(yaw) * dx + std::sin(yaw) * dy) / distance, -1.0, 1.0);
+  return std::acos(cos_angle);
 }
 
-std::vector<PredictedObjectCache> build_object_caches(const PredictedObjects & objects)
+bool is_agent_ahead_nuplan(
+  const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & object_pose)
 {
-  std::vector<PredictedObjectCache> caches;
-  caches.reserve(objects.objects.size());
-
-  for (const auto & object : objects.objects) {
-    PredictedObjectCache cache;
-    cache.object = &object;
-    cache.path = highest_confidence_path(object);
-    if (cache.path && cache.path->path.size() >= 2) {
-      cache.dt = rclcpp::Duration(cache.path->time_step).seconds();
-      if (cache.dt > 0.0) {
-        cache.max_time = cache.dt * static_cast<double>(cache.path->path.size() - 1);
-      } else {
-        cache.path = nullptr;
-        cache.dt = 0.0;
-      }
-    } else {
-      cache.path = nullptr;
-    }
-    caches.push_back(cache);
-  }
-
-  return caches;
+  return relative_agent_angle(ego_pose, object_pose) < kAheadAngleThresholdRad;
 }
 
-std::optional<geometry_msgs::msg::Pose> interpolate_object_pose(
-  const PredictedObjectCache & cache, const double query_time_s)
+bool is_agent_behind_nuplan(
+  const geometry_msgs::msg::Pose & ego_pose, const geometry_msgs::msg::Pose & object_pose)
 {
-  if (!cache.object) {
-    return std::nullopt;
-  }
-  if (query_time_s <= 0.0) {
-    return cache.object->kinematics.initial_pose_with_covariance.pose;
-  }
-  if (!cache.path || query_time_s > cache.max_time) {
-    return std::nullopt;
-  }
-
-  const std::size_t index =
-    std::min(static_cast<std::size_t>(query_time_s / cache.dt), cache.path->path.size() - 2);
-  const double t_i = static_cast<double>(index) * cache.dt;
-  const double ratio = std::clamp((query_time_s - t_i) / cache.dt, 0.0, 1.0);
-  return autoware_utils_geometry::calc_interpolated_pose(
-    cache.path->path.at(index), cache.path->path.at(index + 1), ratio);
+  return relative_agent_angle(ego_pose, object_pose) > kBehindAngleThresholdRad;
 }
 
 }  // namespace
 
 TTCWithinBoundResult calculate_ttc_within_bound(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::shared_ptr<PredictedObjects> & objects,
+  const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<RouteHandler> & route_handler,
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations,
+  const std::vector<LoggedObjectTrack> * object_tracks)
 {
   TTCWithinBoundResult result;
 
@@ -144,8 +109,8 @@ TTCWithinBoundResult calculate_ttc_within_bound(
     result.reason = "unavailable_empty_trajectory";
     return result;
   }
-  if (!objects) {
-    result.reason = "unavailable_no_objects_message";
+  if (future_objects.empty()) {
+    result.reason = "unavailable_no_future_objects";
     return result;
   }
   if (!is_vehicle_info_valid(vehicle_info)) {
@@ -157,43 +122,87 @@ TTCWithinBoundResult calculate_ttc_within_bound(
   result.score = 1.0;
   result.reason = "available";
 
-  if (objects->objects.empty()) {
+  const auto local_object_tracks =
+    object_tracks ? std::vector<LoggedObjectTrack>{} : build_logged_object_tracks(future_objects);
+  const auto & tracks = object_tracks ? *object_tracks : local_object_tracks;
+  if (tracks.empty()) {
     return result;
   }
 
   const auto local_footprint = vehicle_info.createFootprint(0.0);
-  const auto object_caches = build_object_caches(*objects);
+  const auto local_evaluations =
+    footprint_evaluations
+      ? std::vector<TrajectoryFootprintEvaluation>{}
+      : evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler, nullptr, true);
+  const auto & evaluations = footprint_evaluations ? *footprint_evaluations : local_evaluations;
+  if (!evaluations.empty() && evaluations.size() != trajectory.points.size()) {
+    result.available = false;
+    result.score = 0.0;
+    result.reason = "unavailable_invalid_footprint";
+    return result;
+  }
 
-  for (const auto & point : trajectory.points) {
+  const auto trajectory_start_time = rclcpp::Time(trajectory.header.stamp);
+  std::unordered_set<unique_identifier_msgs::msg::UUID, UuidHash> collided_object_ids;
+
+  for (std::size_t index = 0; index < trajectory.points.size(); ++index) {
+    const auto & point = trajectory.points.at(index);
     const auto velocity_world = get_velocity_in_world_coordinate(point);
     const double speed = std::hypot(velocity_world.x(), velocity_world.y());
     if (speed < kStoppedSpeedThreshold) {
       continue;
     }
 
-    const bool ego_in_intersection = is_pose_in_intersection(point.pose, route_handler);
+    bool multiple_lanes = false;
+    bool non_drivable_area = false;
+    if (
+      !evaluations.empty() && index < evaluations.size() &&
+      evaluations.at(index).ego_area_evaluation.has_value()) {
+      const auto & flags = evaluations.at(index).ego_area_evaluation->flags;
+      multiple_lanes = flags.multiple_lanes;
+      non_drivable_area = flags.non_drivable_area;
+    }
+    const bool ego_in_intersection =
+      !evaluations.empty() && index < evaluations.size() &&
+          evaluations.at(index).ego_area_evaluation.has_value() &&
+          evaluations.at(index).ego_area_evaluation->flags.intersection_context_available
+        ? evaluations.at(index).ego_area_evaluation->flags.in_intersection
+        : is_pose_in_intersection(point.pose, route_handler);
+    const bool bad_or_intersection = multiple_lanes || non_drivable_area || ego_in_intersection;
+    const double time_s = rclcpp::Duration(point.time_from_start).seconds();
 
     for (const double future_offset_s : kFutureProjectionOffsetsSec) {
-      const double query_time_s =
-        rclcpp::Duration(point.time_from_start).seconds() + future_offset_s;
+      const double query_time_s = time_s + future_offset_s;
+      const auto query_time = trajectory_start_time + rclcpp::Duration::from_seconds(query_time_s);
       const auto projected_pose = project_pose(point.pose, velocity_world, future_offset_s);
       const auto ego_polygon = create_pose_footprint(projected_pose, local_footprint);
 
-      for (const auto & object_cache : object_caches) {
-        const auto object_pose = interpolate_object_pose(object_cache, query_time_s);
-        if (!object_pose.has_value()) {
-          continue;
-        }
-
-        const auto object_polygon =
-          autoware_utils_geometry::to_polygon2d(*object_pose, object_cache.object->shape);
-        if (!boost::geometry::intersects(ego_polygon, object_polygon)) {
-          continue;
-        }
-
+      for (const auto & object_track : tracks) {
         if (
-          is_agent_ahead(point.pose, *object_pose) ||
-          (ego_in_intersection && !is_agent_behind(point.pose, *object_pose))) {
+          object_track.has_valid_object_id &&
+          collided_object_ids.count(object_track.object_id) > 0U) {
+          continue;
+        }
+
+        const auto object_state = interpolate_logged_object_state(object_track, query_time);
+        if (!object_state.has_value()) {
+          continue;
+        }
+        if (is_unknown_classification(object_state->classification)) {
+          continue;
+        }
+
+        if (!boost::geometry::intersects(ego_polygon, object_state->polygon)) {
+          continue;
+        }
+
+        if (object_state->has_valid_object_id) {
+          collided_object_ids.insert(object_state->object_id);
+        }
+
+        const bool ahead = is_agent_ahead_nuplan(projected_pose, object_state->pose);
+        const bool behind = is_agent_behind_nuplan(projected_pose, object_state->pose);
+        if (ahead || (bad_or_intersection && !behind)) {
           result.score = 0.0;
           result.reason = "collision_within_bound";
           result.infraction_time_s = query_time_s;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.cpp
@@ -168,6 +168,7 @@ TTCWithinBoundResult calculate_ttc_within_bound(
           evaluations.at(index).ego_area_evaluation->flags.intersection_context_available
         ? evaluations.at(index).ego_area_evaluation->flags.in_intersection
         : is_pose_in_intersection(point.pose, route_handler);
+    // NAVSIM bad-area branch: straddling lanes, outside drivable area, or inside intersection.
     const bool bad_or_intersection = multiple_lanes || non_drivable_area || ego_in_intersection;
     const double time_s = rclcpp::Duration(point.time_from_start).seconds();
 
@@ -175,6 +176,8 @@ TTCWithinBoundResult calculate_ttc_within_bound(
       const double query_time_s = time_s + future_offset_s;
       const auto query_time = trajectory_start_time + rclcpp::Duration::from_seconds(query_time_s);
       const auto projected_pose = project_pose(point.pose, velocity_world, future_offset_s);
+      // Shared footprint evaluations are used only for current-point area flags above; TTC must
+      // rebuild the ego polygon at each projected future pose.
       const auto ego_polygon = create_pose_footprint(projected_pose, local_footprint);
 
       for (const auto & object_track : tracks) {

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ttc_within_bound.hpp
@@ -16,6 +16,8 @@
 #define METRICS__EPDMS__SUBSCORES__TTC_WITHIN_BOUND_HPP_
 
 #include "data_types.hpp"
+#include "metrics/geometry/ego_footprint.hpp"
+#include "metrics/geometry/object_tracks.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
@@ -23,6 +25,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
@@ -39,9 +42,11 @@ struct TTCWithinBoundResult
 
 TTCWithinBoundResult calculate_ttc_within_bound(
   const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const std::shared_ptr<PredictedObjects> & objects,
+  const std::vector<TimedTrackedObjects> & future_objects,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::shared_ptr<RouteHandler> & route_handler = nullptr);
+  const std::shared_ptr<RouteHandler> & route_handler = nullptr,
+  const std::vector<TrajectoryFootprintEvaluation> * footprint_evaluations = nullptr,
+  const std::vector<LoggedObjectTrack> * object_tracks = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -232,19 +232,27 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
 
   calculate_history_comfort_metrics(trajectory, history_comfort_params, metrics);
 
-  const auto ttc_within_bound =
-    calculate_ttc_within_bound(trajectory, sync_data->objects, vehicle_info, route_handler);
+  const auto route_relevant_lanelets =
+    route_handler && route_handler->isHandlerReady()
+      ? collect_route_relevant_lanelets(trajectory, route_handler)
+      : lanelet::ConstLanelets{};
+  const auto footprint_evaluations = evaluate_trajectory_footprints(
+    trajectory, vehicle_info, route_handler,
+    route_relevant_lanelets.empty() ? nullptr : &route_relevant_lanelets, true);
+  const auto object_tracks = logged_future_objects.empty()
+                               ? std::vector<LoggedObjectTrack>{}
+                               : build_logged_object_tracks(logged_future_objects);
+  const auto ttc_within_bound = calculate_ttc_within_bound(
+    trajectory, logged_future_objects, vehicle_info, route_handler, &footprint_evaluations,
+    object_tracks.empty() ? nullptr : &object_tracks);
   metrics.time_to_collision_within_bound = ttc_within_bound.score;
   metrics.time_to_collision_within_bound_available = ttc_within_bound.available;
   metrics.time_to_collision_within_bound_reason = ttc_within_bound.reason;
   metrics.time_to_collision_infraction_time_s = ttc_within_bound.infraction_time_s;
-  const auto footprint_evaluations =
-    evaluate_trajectory_footprints(trajectory, vehicle_info, route_handler);
   NoAtFaultCollisionResult no_at_fault_collision;
   if (logged_future_objects.empty()) {
     no_at_fault_collision.reason = "unavailable_no_future_objects";
   } else {
-    const auto object_tracks = build_logged_object_tracks(logged_future_objects);
     no_at_fault_collision = calculate_no_at_fault_collision(
       trajectory, object_tracks, vehicle_info, route_handler, footprint_evaluations);
   }
@@ -289,7 +297,6 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.drivable_area_compliance_reason = "unavailable_route_handler_not_ready";
     metrics.traffic_light_compliance_reason = "unavailable_route_handler_not_ready";
   } else {
-    const auto route_relevant_lanelets = collect_route_relevant_lanelets(trajectory, route_handler);
     const auto drivable_area_compliance = calculate_drivable_area_compliance(
       trajectory, route_handler, vehicle_info, &footprint_evaluations);
     metrics.drivable_area_compliance = drivable_area_compliance.score;

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_ttc_within_bound.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_ttc_within_bound.cpp
@@ -13,19 +13,25 @@
 // limitations under the License.
 
 #include "metrics/epdms/subscores/ttc_within_bound.hpp"
+#include "metrics/geometry/ego_footprint.hpp"
 
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
+#include <builtin_interfaces/msg/time.hpp>
 
-#include <autoware_perception_msgs/msg/predicted_object.hpp>
-#include <autoware_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_perception_msgs/msg/predicted_path.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
+#include <autoware_perception_msgs/msg/tracked_object.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cmath>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -74,25 +80,73 @@ autoware_planning_msgs::msg::Trajectory make_straight_trajectory(const double sp
   return trajectory;
 }
 
-autoware_perception_msgs::msg::PredictedObject make_stationary_object(
-  const double x, const double y)
+autoware_perception_msgs::msg::TrackedObject make_stationary_object(const double x, const double y)
 {
-  autoware_perception_msgs::msg::PredictedObject object;
-  object.kinematics.initial_pose_with_covariance.pose = make_pose(x, y);
+  autoware_perception_msgs::msg::TrackedObject object;
+  object.kinematics.pose_with_covariance.pose = make_pose(x, y);
   object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   object.shape.dimensions.x = 2.0;
   object.shape.dimensions.y = 1.0;
   object.shape.dimensions.z = 1.5;
 
-  autoware_perception_msgs::msg::PredictedPath path;
-  path.time_step = rclcpp::Duration::from_seconds(0.5);
-  path.confidence = 1.0;
-  path.path.push_back(make_pose(x, y));
-  path.path.push_back(make_pose(x, y));
-  path.path.push_back(make_pose(x, y));
-  object.kinematics.predicted_paths.push_back(path);
+  autoware_perception_msgs::msg::ObjectClassification classification;
+  classification.label = autoware_perception_msgs::msg::ObjectClassification::CAR;
+  classification.probability = 1.0f;
+  object.classification.push_back(classification);
 
   return object;
+}
+
+autoware_perception_msgs::msg::TrackedObject make_box_object(
+  const double x, const double y, const unique_identifier_msgs::msg::UUID & object_id)
+{
+  auto object = make_stationary_object(x, y);
+  object.object_id = object_id;
+  return object;
+}
+
+builtin_interfaces::msg::Time make_stamp(const double stamp_s)
+{
+  const auto stamp_ns = static_cast<int64_t>(std::llround(stamp_s * 1.0e9));
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = static_cast<int32_t>(stamp_ns / 1'000'000'000);
+  stamp.nanosec = static_cast<uint32_t>(stamp_ns % 1'000'000'000);
+  return stamp;
+}
+
+std::vector<TimedTrackedObjects> make_future_objects(
+  std::vector<autoware_perception_msgs::msg::TrackedObject> objects, const double stamp_s = 0.0)
+{
+  auto msg = std::make_shared<TrackedObjects>();
+  msg->header.stamp = make_stamp(stamp_s);
+  msg->objects = std::move(objects);
+  return {TimedTrackedObjects{rclcpp::Time(msg->header.stamp), msg}};
+}
+
+unique_identifier_msgs::msg::UUID make_uuid(const std::array<uint8_t, 16> & bytes)
+{
+  unique_identifier_msgs::msg::UUID id;
+  id.uuid = bytes;
+  return id;
+}
+
+std::vector<TrajectoryFootprintEvaluation> make_footprint_evaluations(
+  const autoware_planning_msgs::msg::Trajectory & trajectory,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const bool multiple_lanes,
+  const bool non_drivable_area)
+{
+  std::vector<TrajectoryFootprintEvaluation> evaluations;
+  evaluations.reserve(trajectory.points.size());
+  for (const auto & point : trajectory.points) {
+    TrajectoryFootprintEvaluation evaluation;
+    evaluation.ego_polygon = create_pose_footprint(point.pose, vehicle_info);
+    EgoAreaEvaluation area;
+    area.flags.multiple_lanes = multiple_lanes;
+    area.flags.non_drivable_area = non_drivable_area;
+    evaluation.ego_area_evaluation = area;
+    evaluations.push_back(std::move(evaluation));
+  }
+  return evaluations;
 }
 
 }  // namespace
@@ -100,8 +154,9 @@ autoware_perception_msgs::msg::PredictedObject make_stationary_object(
 TEST(TTCWithinBound, EmptyObjectsPasses)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
-  const auto result = calculate_ttc_within_bound(trajectory, objects, make_vehicle_info());
+  auto objects = std::make_shared<TrackedObjects>();
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);
@@ -111,10 +166,11 @@ TEST(TTCWithinBound, EmptyObjectsPasses)
 TEST(TTCWithinBound, AheadCollisionFails)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
+  auto objects = std::make_shared<TrackedObjects>();
   objects->objects.push_back(make_stationary_object(4.0, 0.0));
 
-  const auto result = calculate_ttc_within_bound(trajectory, objects, make_vehicle_info());
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
@@ -122,49 +178,98 @@ TEST(TTCWithinBound, AheadCollisionFails)
   EXPECT_GE(result.infraction_time_s, 0.0);
 }
 
-TEST(TTCWithinBound, BehindCollisionDoesNotFail)
+TEST(TTCWithinBound, UnknownCollisionIsIgnored)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
-  objects->objects.push_back(make_stationary_object(-4.0, 0.0));
+  auto objects = std::make_shared<TrackedObjects>();
+  auto object = make_stationary_object(4.0, 0.0);
+  object.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+  objects->objects.push_back(object);
 
-  const auto result = calculate_ttc_within_bound(trajectory, objects, make_vehicle_info());
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);
   EXPECT_EQ(result.reason, "available");
 }
 
-TEST(TTCWithinBound, UsesHighestConfidencePredictedPath)
+TEST(TTCWithinBound, BehindCollisionDoesNotFail)
 {
   const auto trajectory = make_straight_trajectory(5.0);
-  auto objects = std::make_shared<PredictedObjects>();
+  auto objects = std::make_shared<TrackedObjects>();
+  objects->objects.push_back(make_stationary_object(-4.0, 0.0));
 
-  autoware_perception_msgs::msg::PredictedObject object;
-  object.kinematics.initial_pose_with_covariance.pose = make_pose(20.0, 0.0);
-  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
-  object.shape.dimensions.x = 2.0;
-  object.shape.dimensions.y = 1.0;
-  object.shape.dimensions.z = 1.5;
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info());
 
-  autoware_perception_msgs::msg::PredictedPath colliding_path;
-  colliding_path.time_step = rclcpp::Duration::from_seconds(0.5);
-  colliding_path.confidence = 0.1;
-  colliding_path.path.push_back(make_pose(4.0, 0.0));
-  colliding_path.path.push_back(make_pose(4.0, 0.0));
-  colliding_path.path.push_back(make_pose(4.0, 0.0));
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "available");
+}
 
-  autoware_perception_msgs::msg::PredictedPath safe_path;
-  safe_path.time_step = rclcpp::Duration::from_seconds(0.5);
-  safe_path.confidence = 0.9;
-  safe_path.path.push_back(make_pose(20.0, 0.0));
-  safe_path.path.push_back(make_pose(20.0, 0.0));
-  safe_path.path.push_back(make_pose(20.0, 0.0));
+TEST(TTCWithinBound, UsesTrackedObjectPose)
+{
+  const auto trajectory = make_straight_trajectory(5.0);
+  auto objects = std::make_shared<TrackedObjects>();
+  objects->objects.push_back(make_stationary_object(4.0, 0.0));
 
-  object.kinematics.predicted_paths = {colliding_path, safe_path};
-  objects->objects.push_back(object);
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info());
 
-  const auto result = calculate_ttc_within_bound(trajectory, objects, make_vehicle_info());
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "collision_within_bound");
+}
+
+TEST(TTCWithinBound, NuplanAheadAngleDoesNotFailForLargeLateralOffset)
+{
+  const auto trajectory = make_straight_trajectory(5.0);
+  auto objects = std::make_shared<TrackedObjects>();
+  objects->objects.push_back(make_stationary_object(1.0, 1.2));
+
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info());
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "available");
+}
+
+TEST(TTCWithinBound, BadAreaAllowsLateralOverlapToFail)
+{
+  const auto trajectory = make_straight_trajectory(5.0);
+  auto objects = std::make_shared<TrackedObjects>();
+  objects->objects.push_back(make_stationary_object(1.0, 1.2));
+  const auto evaluations = make_footprint_evaluations(trajectory, make_vehicle_info(), false, true);
+
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info(), nullptr, &evaluations);
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 0.0);
+  EXPECT_EQ(result.reason, "collision_within_bound");
+}
+
+TEST(TTCWithinBound, PreviouslyCollidedObjectIsIgnored)
+{
+  const auto trajectory = make_straight_trajectory(5.0);
+  const auto object_id = make_uuid({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+
+  auto objects_t0 = std::make_shared<TrackedObjects>();
+  objects_t0->header.stamp = make_stamp(0.0);
+  objects_t0->objects.push_back(make_box_object(-1.5, 0.0, object_id));
+
+  auto objects_t1 = std::make_shared<TrackedObjects>();
+  objects_t1->header.stamp = make_stamp(1.0);
+  objects_t1->objects.push_back(make_box_object(6.0, 0.0, object_id));
+
+  const std::vector<TimedTrackedObjects> future_objects = {
+    TimedTrackedObjects{rclcpp::Time(objects_t0->header.stamp), objects_t0},
+    TimedTrackedObjects{rclcpp::Time(objects_t1->header.stamp), objects_t1}};
+
+  const auto result = calculate_ttc_within_bound(trajectory, future_objects, make_vehicle_info());
 
   EXPECT_TRUE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 1.0);

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_ttc_within_bound.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_ttc_within_bound.cpp
@@ -252,6 +252,21 @@ TEST(TTCWithinBound, BadAreaAllowsLateralOverlapToFail)
   EXPECT_EQ(result.reason, "collision_within_bound");
 }
 
+TEST(TTCWithinBound, BadAreaBehindCollisionDoesNotFail)
+{
+  const auto trajectory = make_straight_trajectory(5.0);
+  auto objects = std::make_shared<TrackedObjects>();
+  objects->objects.push_back(make_stationary_object(-4.0, 0.0));
+  const auto evaluations = make_footprint_evaluations(trajectory, make_vehicle_info(), false, true);
+
+  const auto result = calculate_ttc_within_bound(
+    trajectory, make_future_objects(objects->objects), make_vehicle_info(), nullptr, &evaluations);
+
+  EXPECT_TRUE(result.available);
+  EXPECT_DOUBLE_EQ(result.score, 1.0);
+  EXPECT_EQ(result.reason, "available");
+}
+
 TEST(TTCWithinBound, PreviouslyCollidedObjectIsIgnored)
 {
   const auto trajectory = make_straight_trajectory(5.0);


### PR DESCRIPTION
## Description
Fourth PR in the EPDMS metric migration series.

Migrates TTC within bound to the NAVSIM-style logged-object future check while reusing the shared EPDMS helpers introduced in earlier PRs.

Pipeline change:
- As-is: TTC used predicted object paths from the synchronized object message and treated the forward ego-frame half-plane as ahead.
- To-be: TTC uses logged future tracked-object states, projects ego at 0.0/0.3/0.6/0.9 s, ignores unknown and previously-collided objects, applies the NAVSIM/nuPlan ahead cone instead of the full forward half-plane, and uses the NAVSIM ahead / bad-area-or-intersection / behind logic.

## Validation
- pre-commit run on changed files: passed
- Takanawa full run through NC/DAC/DDC/TLC/TTC using pilot-auto.x2 underlay: completed
- TTC reproduced baseline exactly: 102 non-1, 0 unavailable, same mean
- DAC/DDC/TLC unchanged vs baseline

## Notes
- Debug topic changes are intentionally reserved for a later debug-topic PR.
- Local validation used the known pilot-auto.x2 lanelet compatibility patch only during validation; it was restored before this PR branch.
