### PR TITLE
feat(planning_data_analyzer): migrate LK metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -30,6 +30,7 @@
     tf_topic: "/tf"
     acceleration_topic: "/localization/acceleration"
     steering_topic: "/vehicle/status/steering_status"
+    hazard_lights_topic: "/vehicle/status/hazard_lights_status"
     turn_indicators_topic: "/vehicle/status/turn_indicators_status"
     control_mode_topic: "/vehicle/status/control_mode"
 

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -74,6 +74,8 @@
       lane_keep:
         max_lateral_deviation: 0.5  # Maximum absolute lateral deviation allowed for LK [m]
         max_continuous_violation_time: 2.0  # Continuous over-threshold duration allowed for LK [s]
+        lane_change_pre_grace_time: 1.0  # Time before turn/hazard activation exempted from LK [s]
+        lane_change_post_grace_time: 1.0  # Time after turn/hazard deactivation exempted from LK [s]
       override:
         # Time window [s] after every AUTONOMOUS->MANUAL transition used to compute
         # the override_only/* aggregate statistics in the summary JSON.

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -156,6 +156,10 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
     get_or_declare_parameter<double>(*this, "open_loop.lane_keep.max_lateral_deviation");
   lane_keeping_params_.max_continuous_violation_time =
     get_or_declare_parameter<double>(*this, "open_loop.lane_keep.max_continuous_violation_time");
+  lane_keeping_params_.lane_change_pre_grace_time =
+    get_or_declare_parameter<double>(*this, "open_loop.lane_keep.lane_change_pre_grace_time");
+  lane_keeping_params_.lane_change_post_grace_time =
+    get_or_declare_parameter<double>(*this, "open_loop.lane_keep.lane_change_post_grace_time");
   objects_topic_name_ = get_or_declare_parameter<std::string>(*this, "objects_topic");
   tracked_objects_topic_name_ =
     get_or_declare_parameter<std::string>(*this, "tracked_objects_topic");

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -164,6 +164,7 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   tf_topic_name_ = get_or_declare_parameter<std::string>(*this, "tf_topic");
   acceleration_topic_name_ = get_or_declare_parameter<std::string>(*this, "acceleration_topic");
   steering_topic_name_ = get_or_declare_parameter<std::string>(*this, "steering_topic");
+  hazard_lights_topic_name_ = get_or_declare_parameter<std::string>(*this, "hazard_lights_topic");
   turn_indicators_topic_name_ =
     get_or_declare_parameter<std::string>(*this, "turn_indicators_topic");
   control_mode_topic_name_ = get_or_declare_parameter<std::string>(*this, "control_mode_topic");
@@ -485,6 +486,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
   topic_names.tf_topic = tf_topic_name_;
   topic_names.acceleration_topic = acceleration_topic_name_;
   topic_names.steering_topic = steering_topic_name_;
+  topic_names.hazard_lights_topic = hazard_lights_topic_name_;
   topic_names.turn_indicators_topic = turn_indicators_topic_name_;
   topic_names.control_mode_topic = control_mode_topic_name_;
   topic_names.evaluation_interval_ms = evaluation_interval_ms_;

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -101,6 +101,7 @@ private:
   std::string tf_topic_name_;
   std::string acceleration_topic_name_;
   std::string steering_topic_name_;
+  std::string hazard_lights_topic_name_;
   std::string turn_indicators_topic_name_;
   std::string control_mode_topic_name_;
   double override_window_sec_ = 0.0;

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -36,6 +36,7 @@ struct BagData
   std::string trajectory_topic_key{};
   std::string candidate_trajectories_topic_key{};
   std::string gt_trajectory_topic_key{};
+  double trajectory_evaluation_horizon_s{0.0};
   // Template helper to create and configure buffer
   template <typename MessageType>
   void create_buffer(
@@ -72,6 +73,8 @@ struct BagData
       max_buffer_msgs);
     create_buffer<SteeringReport>(
       "/vehicle/status/steering_status", buffer_duration_sec, max_buffer_msgs);
+    create_buffer<HazardLightsReport>(
+      "/vehicle/status/hazard_lights_status", buffer_duration_sec, max_buffer_msgs);
     create_buffer<TurnIndicatorsReport>(
       "/vehicle/status/turn_indicators_status", buffer_duration_sec, max_buffer_msgs);
   }
@@ -80,7 +83,8 @@ struct BagData
   explicit BagData(
     const rcutils_time_point_value_t timestamp, const TopicNames & topic_names,
     const double buffer_duration_sec = 20.0, const size_t max_buffer_msgs = 10000)
-  : timestamp{timestamp}
+  : trajectory_evaluation_horizon_s{topic_names.trajectory_evaluation_horizon_s},
+    timestamp{timestamp}
   {
     // Create buffers using provided topic names
     create_buffer<TFMessage>(topic_names.tf_topic, buffer_duration_sec, max_buffer_msgs);
@@ -110,6 +114,10 @@ struct BagData
         topic_names.traffic_signals_topic, buffer_duration_sec, max_buffer_msgs);
     }
     create_buffer<SteeringReport>(topic_names.steering_topic, buffer_duration_sec, max_buffer_msgs);
+    if (!topic_names.hazard_lights_topic.empty()) {
+      create_buffer<HazardLightsReport>(
+        topic_names.hazard_lights_topic, buffer_duration_sec, max_buffer_msgs);
+    }
     if (!topic_names.turn_indicators_topic.empty()) {
       create_buffer<TurnIndicatorsReport>(
         topic_names.turn_indicators_topic, buffer_duration_sec, max_buffer_msgs);
@@ -240,6 +248,34 @@ struct BagData
       synchronized_data->steering_status = steer_buffer->get_closest(target_time, tolerance_ms);
     }
 
+    const auto synchronize_signal_status =
+      [&](const auto & signal_buffer, auto & status, auto & history) {
+        if (signal_buffer && synchronized_data->trajectory) {
+          const auto traj_stamp_ns =
+            rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
+          status = signal_buffer->get_closest(traj_stamp_ns, tolerance_ms);
+          const auto history_start_ns =
+            traj_stamp_ns - static_cast<rcutils_time_point_value_t>(2.0e9);
+          const auto history_end_ns =
+            traj_stamp_ns + static_cast<rcutils_time_point_value_t>(
+                              (trajectory_evaluation_horizon_s + 2.0) * 1.0e9);
+          history = signal_buffer->get_range(history_start_ns, history_end_ns);
+        } else if (signal_buffer) {
+          status = signal_buffer->get_closest(target_time, tolerance_ms);
+        }
+      };
+
+    std::shared_ptr<Buffer<HazardLightsReport>> hazard_lights_buffer;
+    for (const auto & [topic, buffer] : buffers) {
+      if (auto hb = std::dynamic_pointer_cast<Buffer<HazardLightsReport>>(buffer)) {
+        hazard_lights_buffer = hb;
+        break;
+      }
+    }
+    synchronize_signal_status(
+      hazard_lights_buffer, synchronized_data->hazard_lights_status,
+      synchronized_data->hazard_lights_history);
+
     std::shared_ptr<Buffer<TurnIndicatorsReport>> turn_indicators_buffer;
     for (const auto & [topic, buffer] : buffers) {
       if (auto tb = std::dynamic_pointer_cast<Buffer<TurnIndicatorsReport>>(buffer)) {
@@ -247,15 +283,9 @@ struct BagData
         break;
       }
     }
-    if (turn_indicators_buffer && synchronized_data->trajectory) {
-      const auto traj_stamp_ns =
-        rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
-      synchronized_data->turn_indicators_status =
-        turn_indicators_buffer->get_closest(traj_stamp_ns, tolerance_ms);
-    } else if (turn_indicators_buffer) {
-      synchronized_data->turn_indicators_status =
-        turn_indicators_buffer->get_closest(target_time, tolerance_ms);
-    }
+    synchronize_signal_status(
+      turn_indicators_buffer, synchronized_data->turn_indicators_status,
+      synchronized_data->turn_indicators_history);
 
     // Get objects
     // Find objects buffer

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -31,6 +31,8 @@
 namespace autoware::planning_data_analyzer
 {
 
+constexpr rcutils_time_point_value_t kSignalHistoryPaddingNs = 2'000'000'000;
+
 struct BagData
 {
   std::string trajectory_topic_key{};
@@ -254,11 +256,11 @@ struct BagData
           const auto traj_stamp_ns =
             rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
           status = signal_buffer->get_closest(traj_stamp_ns, tolerance_ms);
-          const auto history_start_ns =
-            traj_stamp_ns - static_cast<rcutils_time_point_value_t>(2.0e9);
+          const auto history_start_ns = traj_stamp_ns - kSignalHistoryPaddingNs;
           const auto history_end_ns =
-            traj_stamp_ns + static_cast<rcutils_time_point_value_t>(
-                              (trajectory_evaluation_horizon_s + 2.0) * 1.0e9);
+            traj_stamp_ns +
+            static_cast<rcutils_time_point_value_t>(trajectory_evaluation_horizon_s * 1.0e9) +
+            kSignalHistoryPaddingNs;
           history = signal_buffer->get_range(history_start_ns, history_end_ns);
         } else if (signal_buffer) {
           status = signal_buffer->get_closest(target_time, tolerance_ms);

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -91,6 +91,10 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
       process_and_append_message<SteeringReport>(
         serialized_message, bag_data, topic_names.steering_topic, false, logger_);
     } else if (
+      topic_name == topic_names.hazard_lights_topic && !topic_names.hazard_lights_topic.empty()) {
+      process_and_append_message<HazardLightsReport>(
+        serialized_message, bag_data, topic_names.hazard_lights_topic, false, logger_);
+    } else if (
       topic_name == topic_names.turn_indicators_topic &&
       !topic_names.turn_indicators_topic.empty()) {
       process_and_append_message<TurnIndicatorsReport>(

--- a/planning/autoware_planning_data_analyzer/src/buffer.hpp
+++ b/planning/autoware_planning_data_analyzer/src/buffer.hpp
@@ -174,6 +174,28 @@ struct Buffer : BufferBase
     }
     return std::make_shared<T>(*latest_itr);
   }
+
+  auto get_range(
+    const rcutils_time_point_value_t start_time, const rcutils_time_point_value_t end_time) const
+    -> std::vector<typename T::ConstSharedPtr>
+  {
+    std::vector<typename T::ConstSharedPtr> range;
+    if (msgs.empty() || end_time < start_time) {
+      return range;
+    }
+
+    for (const auto & msg : msgs) {
+      const auto stamp_ns = message_stamp(msg).nanoseconds();
+      if (stamp_ns < start_time) {
+        continue;
+      }
+      if (stamp_ns > end_time) {
+        break;
+      }
+      range.push_back(std::make_shared<const T>(msg));
+    }
+    return range;
+  }
 };
 
 // Template specializations for messages without standard header.stamp

--- a/planning/autoware_planning_data_analyzer/src/data_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/data_types.hpp
@@ -23,6 +23,7 @@
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
@@ -47,6 +48,7 @@ using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupA
 using AccelWithCovarianceStamped = geometry_msgs::msg::AccelWithCovarianceStamped;
 using SteeringReport = autoware_vehicle_msgs::msg::SteeringReport;
 using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
+using HazardLightsReport = autoware_vehicle_msgs::msg::HazardLightsReport;
 using TurnIndicatorsReport = autoware_vehicle_msgs::msg::TurnIndicatorsReport;
 
 struct TimedTrackedObjects
@@ -68,7 +70,10 @@ struct SynchronizedData
   std::shared_ptr<TrackedObjects> tracked_objects;
   std::vector<TimedTrackedObjects> future_tracked_objects;
   std::shared_ptr<TrafficLightGroupArray> traffic_signals;
+  std::shared_ptr<HazardLightsReport> hazard_lights_status;
   std::shared_ptr<TurnIndicatorsReport> turn_indicators_status;
+  std::vector<std::shared_ptr<const HazardLightsReport>> hazard_lights_history;
+  std::vector<std::shared_ptr<const TurnIndicatorsReport>> turn_indicators_history;
   rclcpp::Time timestamp;
   rclcpp::Time bag_timestamp;
 };
@@ -87,6 +92,7 @@ struct TopicNames
   std::string tf_topic;
   std::string acceleration_topic;
   std::string steering_topic;
+  std::string hazard_lights_topic;
   std::string turn_indicators_topic;
   std::string control_mode_topic;
   double evaluation_interval_ms = 100.0;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
@@ -14,6 +14,7 @@
 
 #include "lane_keeping.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <optional>
 #include <vector>
@@ -21,41 +22,99 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-double calculate_lane_keeping_score(
+LaneKeepingResult calculate_lane_keeping_result(
   const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
-  const LaneKeepingParameters & parameters)
+  const LaneKeepingParameters & parameters,
+  const std::vector<std::pair<double, double>> & lane_change_windows_s)
 {
+  LaneKeepingResult result;
   if (
     evaluation_points.empty() || parameters.max_lateral_deviation < 0.0 ||
     parameters.max_continuous_violation_time < 0.0) {
-    return 0.0;
+    return result;
   }
 
   std::optional<rclcpp::Duration> violation_start_time;
+  double max_violation_duration = 0.0;
+  double peak_abs_lateral_deviation = 0.0;
+  bool failure_recorded = false;
+  std::optional<double> queue_release_until_s;
 
-  for (const auto & evaluation_point : evaluation_points) {
-    if (evaluation_point.is_in_intersection || !std::isfinite(evaluation_point.lateral_deviation)) {
-      violation_start_time.reset();
+  const auto reset_violation_run = [&]() { violation_start_time.reset(); };
+
+  for (std::size_t index = 0; index < evaluation_points.size(); ++index) {
+    const auto & evaluation_point = evaluation_points.at(index);
+    const double time_s = evaluation_point.time_from_start.seconds();
+    const bool finite = std::isfinite(evaluation_point.lateral_deviation);
+    if (!finite) {
+      reset_violation_run();
       continue;
     }
 
-    if (std::abs(evaluation_point.lateral_deviation) <= parameters.max_lateral_deviation) {
-      violation_start_time.reset();
-      continue;
+    peak_abs_lateral_deviation =
+      std::max(peak_abs_lateral_deviation, std::abs(evaluation_point.lateral_deviation));
+
+    const bool over_threshold =
+      std::abs(evaluation_point.lateral_deviation) > parameters.max_lateral_deviation;
+    const bool lane_change_exempt = std::any_of(
+      lane_change_windows_s.begin(), lane_change_windows_s.end(),
+      [&](const auto & window) { return time_s >= window.first && time_s <= window.second; });
+
+    const double progress_window_start =
+      std::max(0.0, time_s - parameters.queue_progress_window_time);
+    double progress_window_distance = 0.0;
+    for (std::size_t lookback = index; lookback > 0; --lookback) {
+      const auto & previous = evaluation_points.at(lookback - 1U);
+      const auto & current = evaluation_points.at(lookback);
+      if (current.time_from_start.seconds() < progress_window_start) {
+        break;
+      }
+      progress_window_distance =
+        evaluation_point.cumulative_progress_m - previous.cumulative_progress_m;
     }
 
+    const bool queue_signal_available = std::isfinite(evaluation_point.speed_mps) &&
+                                        std::isfinite(evaluation_point.cumulative_progress_m);
+    const bool queue_exempt = queue_signal_available &&
+                              evaluation_point.speed_mps <= parameters.queue_speed_threshold &&
+                              progress_window_distance <= parameters.queue_progress_threshold;
+    if (queue_exempt) {
+      queue_release_until_s = time_s + parameters.queue_release_grace_time;
+    }
+    const bool queue_release_exempt =
+      !queue_exempt && queue_release_until_s.has_value() && time_s <= *queue_release_until_s;
+
+    if (
+      evaluation_point.is_in_intersection || lane_change_exempt || queue_exempt ||
+      queue_release_exempt || !over_threshold) {
+      reset_violation_run();
+      continue;
+    }
     if (!violation_start_time.has_value()) {
       violation_start_time = evaluation_point.time_from_start;
     }
 
     const double violation_duration =
       (evaluation_point.time_from_start - violation_start_time.value()).seconds();
-    if (violation_duration >= parameters.max_continuous_violation_time) {
-      return 0.0;
+    max_violation_duration = std::max(max_violation_duration, violation_duration);
+    if (!failure_recorded && violation_duration >= parameters.max_continuous_violation_time) {
+      result.first_failure_time_s = time_s;
+      failure_recorded = true;
     }
   }
 
-  return 1.0;
+  result.score = failure_recorded ? 0.0 : 1.0;
+  result.max_continuous_violation_time_s = max_violation_duration;
+  result.peak_abs_lateral_deviation_m = peak_abs_lateral_deviation;
+  return result;
+}
+
+double calculate_lane_keeping_score(
+  const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
+  const LaneKeepingParameters & parameters,
+  const std::vector<std::pair<double, double>> & lane_change_windows_s)
+{
+  return calculate_lane_keeping_result(evaluation_points, parameters, lane_change_windows_s).score;
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
@@ -39,10 +39,9 @@ double calculate_lane_keeping_score(
   const auto reset_violation_run = [&]() { violation_start_time.reset(); };
 
   for (std::size_t index = 0; index < evaluation_points.size(); ++index) {
-    const auto & evaluation_point = evaluation_points.at(index);
+    const auto & evaluation_point = evaluation_points[index];
     const double time_s = evaluation_point.time_from_start.seconds();
-    const bool finite = std::isfinite(evaluation_point.lateral_deviation);
-    if (!finite) {
+    if (!std::isfinite(evaluation_point.lateral_deviation)) {
       reset_violation_run();
       continue;
     }
@@ -76,6 +75,8 @@ double calculate_lane_keeping_score(
     const bool queue_release_exempt =
       !queue_exempt && queue_release_until_s.has_value() && time_s <= *queue_release_until_s;
 
+    // Reset the violation run on any exemption: intersection samples, signalled lane-change
+    // windows, queue, queue-release grace, or sub-threshold deviation.
     if (
       evaluation_point.is_in_intersection || lane_change_exempt || queue_exempt ||
       queue_release_exempt || !over_threshold) {
@@ -87,7 +88,7 @@ double calculate_lane_keeping_score(
     }
 
     const double violation_duration =
-      (evaluation_point.time_from_start - violation_start_time.value()).seconds();
+      (evaluation_point.time_from_start - *violation_start_time).seconds();
     if (violation_duration >= parameters.max_continuous_violation_time) {
       return 0.0;
     }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.cpp
@@ -22,22 +22,18 @@
 namespace autoware::planning_data_analyzer::metrics
 {
 
-LaneKeepingResult calculate_lane_keeping_result(
+double calculate_lane_keeping_score(
   const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
   const LaneKeepingParameters & parameters,
   const std::vector<std::pair<double, double>> & lane_change_windows_s)
 {
-  LaneKeepingResult result;
   if (
     evaluation_points.empty() || parameters.max_lateral_deviation < 0.0 ||
     parameters.max_continuous_violation_time < 0.0) {
-    return result;
+    return 0.0;
   }
 
   std::optional<rclcpp::Duration> violation_start_time;
-  double max_violation_duration = 0.0;
-  double peak_abs_lateral_deviation = 0.0;
-  bool failure_recorded = false;
   std::optional<double> queue_release_until_s;
 
   const auto reset_violation_run = [&]() { violation_start_time.reset(); };
@@ -51,9 +47,6 @@ LaneKeepingResult calculate_lane_keeping_result(
       continue;
     }
 
-    peak_abs_lateral_deviation =
-      std::max(peak_abs_lateral_deviation, std::abs(evaluation_point.lateral_deviation));
-
     const bool over_threshold =
       std::abs(evaluation_point.lateral_deviation) > parameters.max_lateral_deviation;
     const bool lane_change_exempt = std::any_of(
@@ -62,16 +55,15 @@ LaneKeepingResult calculate_lane_keeping_result(
 
     const double progress_window_start =
       std::max(0.0, time_s - parameters.queue_progress_window_time);
-    double progress_window_distance = 0.0;
-    for (std::size_t lookback = index; lookback > 0; --lookback) {
-      const auto & previous = evaluation_points.at(lookback - 1U);
-      const auto & current = evaluation_points.at(lookback);
-      if (current.time_from_start.seconds() < progress_window_start) {
-        break;
-      }
-      progress_window_distance =
-        evaluation_point.cumulative_progress_m - previous.cumulative_progress_m;
+    std::size_t earliest_in_window = index;
+    while (earliest_in_window > 0 &&
+           evaluation_points.at(earliest_in_window - 1U).time_from_start.seconds() >=
+             progress_window_start) {
+      --earliest_in_window;
     }
+    const double progress_window_distance =
+      evaluation_point.cumulative_progress_m -
+      evaluation_points.at(earliest_in_window).cumulative_progress_m;
 
     const bool queue_signal_available = std::isfinite(evaluation_point.speed_mps) &&
                                         std::isfinite(evaluation_point.cumulative_progress_m);
@@ -96,25 +88,12 @@ LaneKeepingResult calculate_lane_keeping_result(
 
     const double violation_duration =
       (evaluation_point.time_from_start - violation_start_time.value()).seconds();
-    max_violation_duration = std::max(max_violation_duration, violation_duration);
-    if (!failure_recorded && violation_duration >= parameters.max_continuous_violation_time) {
-      result.first_failure_time_s = time_s;
-      failure_recorded = true;
+    if (violation_duration >= parameters.max_continuous_violation_time) {
+      return 0.0;
     }
   }
 
-  result.score = failure_recorded ? 0.0 : 1.0;
-  result.max_continuous_violation_time_s = max_violation_duration;
-  result.peak_abs_lateral_deviation_m = peak_abs_lateral_deviation;
-  return result;
-}
-
-double calculate_lane_keeping_score(
-  const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
-  const LaneKeepingParameters & parameters,
-  const std::vector<std::pair<double, double>> & lane_change_windows_s)
-{
-  return calculate_lane_keeping_result(evaluation_points, parameters, lane_change_windows_s).score;
+  return 1.0;
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.hpp
@@ -17,6 +17,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <limits>
+#include <utility>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -26,6 +28,12 @@ struct LaneKeepingParameters
 {
   double max_lateral_deviation{0.5};
   double max_continuous_violation_time{2.0};
+  double lane_change_pre_grace_time{0.5};
+  double lane_change_post_grace_time{1.0};
+  double queue_speed_threshold{1.0};
+  double queue_progress_window_time{1.0};
+  double queue_progress_threshold{1.5};
+  double queue_release_grace_time{1.5};
 };
 
 struct LaneKeepingEvaluationPoint
@@ -33,6 +41,16 @@ struct LaneKeepingEvaluationPoint
   rclcpp::Duration time_from_start{0, 0};
   double lateral_deviation{0.0};
   bool is_in_intersection{false};
+  double speed_mps{std::numeric_limits<double>::quiet_NaN()};
+  double cumulative_progress_m{std::numeric_limits<double>::quiet_NaN()};
+};
+
+struct LaneKeepingResult
+{
+  double score{0.0};
+  double first_failure_time_s{std::numeric_limits<double>::infinity()};
+  double max_continuous_violation_time_s{0.0};
+  double peak_abs_lateral_deviation_m{0.0};
 };
 
 /**
@@ -41,9 +59,15 @@ struct LaneKeepingEvaluationPoint
  * Returns `0.0` when the continuous over-threshold duration reaches the configured limit,
  * otherwise returns `1.0`.
  */
+LaneKeepingResult calculate_lane_keeping_result(
+  const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
+  const LaneKeepingParameters & parameters = LaneKeepingParameters{},
+  const std::vector<std::pair<double, double>> & lane_change_windows_s = {});
+
 double calculate_lane_keeping_score(
   const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
-  const LaneKeepingParameters & parameters = LaneKeepingParameters{});
+  const LaneKeepingParameters & parameters = LaneKeepingParameters{},
+  const std::vector<std::pair<double, double>> & lane_change_windows_s = {});
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/lane_keeping.hpp
@@ -28,7 +28,7 @@ struct LaneKeepingParameters
 {
   double max_lateral_deviation{0.5};
   double max_continuous_violation_time{2.0};
-  double lane_change_pre_grace_time{0.5};
+  double lane_change_pre_grace_time{1.0};
   double lane_change_post_grace_time{1.0};
   double queue_speed_threshold{1.0};
   double queue_progress_window_time{1.0};
@@ -45,25 +45,12 @@ struct LaneKeepingEvaluationPoint
   double cumulative_progress_m{std::numeric_limits<double>::quiet_NaN()};
 };
 
-struct LaneKeepingResult
-{
-  double score{0.0};
-  double first_failure_time_s{std::numeric_limits<double>::infinity()};
-  double max_continuous_violation_time_s{0.0};
-  double peak_abs_lateral_deviation_m{0.0};
-};
-
 /**
  * @brief Evaluate the binary lane-keeping subscore for one trajectory.
  *
  * Returns `0.0` when the continuous over-threshold duration reaches the configured limit,
  * otherwise returns `1.0`.
  */
-LaneKeepingResult calculate_lane_keeping_result(
-  const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
-  const LaneKeepingParameters & parameters = LaneKeepingParameters{},
-  const std::vector<std::pair<double, double>> & lane_change_windows_s = {});
-
 double calculate_lane_keeping_score(
   const std::vector<LaneKeepingEvaluationPoint> & evaluation_points,
   const LaneKeepingParameters & parameters = LaneKeepingParameters{},

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -99,10 +99,11 @@ std::vector<std::pair<double, double>> merge_windows(std::vector<std::pair<doubl
   merged.push_back(windows.front());
   for (std::size_t index = 1; index < windows.size(); ++index) {
     auto & current = merged.back();
-    if (windows.at(index).first <= current.second) {
-      current.second = std::max(current.second, windows.at(index).second);
+    const auto & next_window = windows.at(index);
+    if (next_window.first <= current.second) {
+      current.second = std::max(current.second, next_window.second);
     } else {
-      merged.push_back(windows.at(index));
+      merged.push_back(next_window);
     }
   }
   return merged;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -445,10 +445,13 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
         return msg.report == TurnIndicatorsReport::ENABLE_LEFT ||
                msg.report == TurnIndicatorsReport::ENABLE_RIGHT;
       },
-      1.0, 1.0);
+      lane_keeping_params.lane_change_pre_grace_time,
+      lane_keeping_params.lane_change_post_grace_time);
     auto hazard_windows = collect_signal_active_windows<HazardLightsReport>(
       sync_data->hazard_lights_history, trajectory_start_time,
-      [](const auto & msg) { return msg.report == HazardLightsReport::ENABLE; }, 1.0, 1.0);
+      [](const auto & msg) { return msg.report == HazardLightsReport::ENABLE; },
+      lane_keeping_params.lane_change_pre_grace_time,
+      lane_keeping_params.lane_change_post_grace_time);
     turn_windows.insert(
       turn_windows.end(), std::make_move_iterator(hazard_windows.begin()),
       std::make_move_iterator(hazard_windows.end()));

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -32,10 +32,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -45,6 +47,66 @@ using autoware::route_handler::RouteHandler;
 
 namespace
 {
+
+template <typename MessageT, typename ActivePredicate>
+std::vector<std::pair<double, double>> collect_signal_active_windows(
+  const std::vector<std::shared_ptr<const MessageT>> & history,
+  const rclcpp::Time & trajectory_start, const ActivePredicate & is_active,
+  const double pre_grace_s, const double post_grace_s)
+{
+  std::vector<std::pair<double, double>> windows;
+  if (history.empty()) {
+    return windows;
+  }
+
+  bool has_active_start = false;
+  double active_start_s = 0.0;
+  bool previous_active = false;
+  for (const auto & msg : history) {
+    if (!msg) {
+      continue;
+    }
+    const auto sample_time_s = (rclcpp::Time(msg->stamp) - trajectory_start).seconds();
+    const bool active = is_active(*msg);
+    if (active && !previous_active) {
+      active_start_s = sample_time_s;
+      has_active_start = true;
+    } else if (!active && previous_active && has_active_start) {
+      windows.emplace_back(active_start_s - pre_grace_s, sample_time_s + post_grace_s);
+      has_active_start = false;
+    }
+    previous_active = active;
+  }
+
+  if (previous_active && has_active_start) {
+    const auto last_time_s = (rclcpp::Time(history.back()->stamp) - trajectory_start).seconds();
+    windows.emplace_back(active_start_s - pre_grace_s, last_time_s + post_grace_s);
+  }
+
+  return windows;
+}
+
+std::vector<std::pair<double, double>> merge_windows(std::vector<std::pair<double, double>> windows)
+{
+  if (windows.empty()) {
+    return windows;
+  }
+  std::sort(windows.begin(), windows.end(), [](const auto & lhs, const auto & rhs) {
+    return lhs.first < rhs.first;
+  });
+
+  std::vector<std::pair<double, double>> merged;
+  merged.push_back(windows.front());
+  for (std::size_t index = 1; index < windows.size(); ++index) {
+    auto & current = merged.back();
+    if (windows.at(index).first <= current.second) {
+      current.second = std::max(current.second, windows.at(index).second);
+    } else {
+      merged.push_back(windows.at(index));
+    }
+  }
+  return merged;
+}
 
 /**
  * @brief Get velocity in world coordinate frame from trajectory point
@@ -337,6 +399,13 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
 
   std::vector<LaneKeepingEvaluationPoint> lane_keeping_evaluation_points;
   lane_keeping_evaluation_points.reserve(num_points);
+  std::vector<std::pair<double, double>> lane_change_windows_s;
+
+  // Calculate travel distances once and reuse them in LK queue/creep logic.
+  for (size_t i = 0; i < num_points; ++i) {
+    metrics.travel_distances[i] =
+      autoware::motion_utils::calcSignedArcLength(trajectory.points, 0, i);
+  }
 
   // Calculate lateral deviation from the local route lane at each pose.
   if (!route_handler) {
@@ -350,18 +419,40 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
       if (!reference_lanelet.has_value()) {
         metrics.lateral_deviations[i] = std::numeric_limits<double>::quiet_NaN();
         lane_keeping_evaluation_points.push_back(
-          LaneKeepingEvaluationPoint{point.time_from_start, metrics.lateral_deviations[i], false});
+          LaneKeepingEvaluationPoint{
+            point.time_from_start, metrics.lateral_deviations[i], false,
+            std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps),
+            metrics.travel_distances[i]});
       } else {
         metrics.lateral_deviations[i] =
           autoware::experimental::lanelet2_utils::get_lateral_distance_to_centerline(
             reference_lanelet.value(), point.pose);
+        const auto local_context =
+          compute_driving_direction_local_context(point.pose, route_handler);
         lane_keeping_evaluation_points.push_back(
           LaneKeepingEvaluationPoint{
             point.time_from_start, metrics.lateral_deviations[i],
-            autoware::experimental::lanelet2_utils::is_intersection_lanelet(
-              reference_lanelet.value())});
+            local_context.has_value() && local_context->in_intersection,
+            std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps),
+            metrics.travel_distances[i]});
       }
     }
+
+    const auto trajectory_start_time = rclcpp::Time(sync_data->trajectory->header.stamp);
+    auto turn_windows = collect_signal_active_windows<TurnIndicatorsReport>(
+      sync_data->turn_indicators_history, trajectory_start_time,
+      [](const auto & msg) {
+        return msg.report == TurnIndicatorsReport::ENABLE_LEFT ||
+               msg.report == TurnIndicatorsReport::ENABLE_RIGHT;
+      },
+      1.0, 1.0);
+    auto hazard_windows = collect_signal_active_windows<HazardLightsReport>(
+      sync_data->hazard_lights_history, trajectory_start_time,
+      [](const auto & msg) { return msg.report == HazardLightsReport::ENABLE; }, 1.0, 1.0);
+    turn_windows.insert(
+      turn_windows.end(), std::make_move_iterator(hazard_windows.begin()),
+      std::make_move_iterator(hazard_windows.end()));
+    lane_change_windows_s = merge_windows(std::move(turn_windows));
   }
   const auto has_finite_lane_keeping_sample = std::any_of(
     lane_keeping_evaluation_points.begin(), lane_keeping_evaluation_points.end(),
@@ -369,18 +460,12 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
       return std::isfinite(evaluation_point.lateral_deviation);
     });
   if (has_finite_lane_keeping_sample) {
-    metrics.lane_keeping =
-      calculate_lane_keeping_score(lane_keeping_evaluation_points, lane_keeping_params);
+    metrics.lane_keeping = calculate_lane_keeping_score(
+      lane_keeping_evaluation_points, lane_keeping_params, lane_change_windows_s);
     metrics.lane_keeping_available = true;
     metrics.lane_keeping_reason = "available";
   } else if (metrics.lane_keeping_reason == "unavailable") {
     metrics.lane_keeping_reason = "unavailable_no_reference_lanelet";
-  }
-
-  // Calculate travel distances using motion_utils
-  for (size_t i = 0; i < num_points; ++i) {
-    metrics.travel_distances[i] =
-      autoware::motion_utils::calcSignedArcLength(trajectory.points, 0, i);
   }
 
   return metrics;

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_lane_keeping.cpp
@@ -144,3 +144,21 @@ TEST(LaneKeepingTest, QueueExemptionAndReleaseGraceBreakViolationRun)
 
   EXPECT_DOUBLE_EQ(score, 1.0);
 }
+
+TEST(LaneKeepingTest, QueueProgressWindowStartsAtEarliestInWindowSample)
+{
+  const std::vector<LaneKeepingEvaluationPoint> evaluation_points{
+    make_evaluation_point(0.0, 0.7, false, 0.0, 0.0),
+    make_evaluation_point(0.5, 0.8, false, 0.0, 0.2),
+    make_evaluation_point(1.5, 0.9, false, 0.0, 0.3)};
+  auto parameters = make_parameters();
+  parameters.max_continuous_violation_time = 1.0;
+  parameters.queue_progress_window_time = 1.0;
+  parameters.queue_progress_threshold = 0.15;
+  parameters.queue_release_grace_time = 0.0;
+
+  const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
+    evaluation_points, parameters);
+
+  EXPECT_DOUBLE_EQ(score, 1.0);
+}

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_lane_keeping.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_lane_keeping.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <utility>
 #include <vector>
 
 using autoware::planning_data_analyzer::metrics::LaneKeepingEvaluationPoint;
@@ -26,10 +27,20 @@ namespace
 {
 
 LaneKeepingEvaluationPoint make_evaluation_point(
-  const double seconds, const double lateral_deviation, const bool is_in_intersection = false)
+  const double seconds, const double lateral_deviation, const bool is_in_intersection = false,
+  const double speed_mps = 5.0, const double cumulative_progress_m = 0.0)
 {
   return LaneKeepingEvaluationPoint{
-    rclcpp::Duration::from_seconds(seconds), lateral_deviation, is_in_intersection};
+    rclcpp::Duration::from_seconds(seconds), lateral_deviation, is_in_intersection, speed_mps,
+    cumulative_progress_m};
+}
+
+LaneKeepingParameters make_parameters()
+{
+  LaneKeepingParameters parameters;
+  parameters.max_lateral_deviation = 0.5;
+  parameters.max_continuous_violation_time = 2.0;
+  return parameters;
 }
 
 }  // namespace
@@ -41,7 +52,7 @@ TEST(LaneKeepingTest, ReturnsOneWhenAllDeviationsStayWithinThreshold)
     make_evaluation_point(2.0, 0.5)};
 
   const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
-    evaluation_points, LaneKeepingParameters{0.5, 2.0});
+    evaluation_points, make_parameters());
 
   EXPECT_DOUBLE_EQ(score, 1.0);
 }
@@ -53,7 +64,7 @@ TEST(LaneKeepingTest, ReturnsOneForShortThresholdSpike)
     make_evaluation_point(1.0, 0.1)};
 
   const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
-    evaluation_points, LaneKeepingParameters{0.5, 2.0});
+    evaluation_points, make_parameters());
 
   EXPECT_DOUBLE_EQ(score, 1.0);
 }
@@ -65,7 +76,7 @@ TEST(LaneKeepingTest, ReturnsZeroForContinuousViolationLongerThanWindow)
     make_evaluation_point(2.1, 0.9)};
 
   const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
-    evaluation_points, LaneKeepingParameters{0.5, 2.0});
+    evaluation_points, make_parameters());
 
   EXPECT_DOUBLE_EQ(score, 0.0);
 }
@@ -77,7 +88,7 @@ TEST(LaneKeepingTest, IgnoresViolationsInsideIntersections)
     make_evaluation_point(2.5, 0.1, false)};
 
   const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
-    evaluation_points, LaneKeepingParameters{0.5, 2.0});
+    evaluation_points, make_parameters());
 
   EXPECT_DOUBLE_EQ(score, 1.0);
 }
@@ -87,7 +98,7 @@ TEST(LaneKeepingTest, ReturnsZeroWhenSamplesAreEmpty)
   const std::vector<LaneKeepingEvaluationPoint> evaluation_points;
 
   const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
-    evaluation_points, LaneKeepingParameters{0.5, 2.0});
+    evaluation_points, make_parameters());
 
   EXPECT_DOUBLE_EQ(score, 0.0);
 }
@@ -100,7 +111,36 @@ TEST(LaneKeepingTest, NonFiniteGapBreaksContinuousViolationWindow)
     make_evaluation_point(2.1, 0.9)};
 
   const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
-    evaluation_points, LaneKeepingParameters{0.5, 2.0});
+    evaluation_points, make_parameters());
+
+  EXPECT_DOUBLE_EQ(score, 1.0);
+}
+
+TEST(LaneKeepingTest, LaneChangeWindowBreaksViolationRun)
+{
+  const std::vector<LaneKeepingEvaluationPoint> evaluation_points{
+    make_evaluation_point(0.0, 0.7), make_evaluation_point(1.0, 0.8),
+    make_evaluation_point(2.1, 0.9)};
+  const std::vector<std::pair<double, double>> lane_change_windows{{0.5, 1.5}};
+
+  const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
+    evaluation_points, make_parameters(), lane_change_windows);
+
+  EXPECT_DOUBLE_EQ(score, 1.0);
+}
+
+TEST(LaneKeepingTest, QueueExemptionAndReleaseGraceBreakViolationRun)
+{
+  const std::vector<LaneKeepingEvaluationPoint> evaluation_points{
+    make_evaluation_point(0.0, 0.7, false, 0.0, 0.0),
+    make_evaluation_point(1.0, 0.8, false, 0.0, 0.1),
+    make_evaluation_point(2.1, 0.9, false, 5.0, 0.2),
+    make_evaluation_point(3.6, 0.9, false, 5.0, 6.0)};
+  auto parameters = make_parameters();
+  parameters.queue_release_grace_time = 1.5;
+
+  const auto score = autoware::planning_data_analyzer::metrics::calculate_lane_keeping_score(
+    evaluation_points, parameters);
 
   EXPECT_DOUBLE_EQ(score, 1.0);
 }

--- a/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_bag_handler.cpp
@@ -42,7 +42,7 @@ TEST_F(BagHandlerTest, BagDataConstruction)
   auto bag_data = std::make_shared<BagData>(timestamp_);
 
   EXPECT_EQ(bag_data->timestamp, timestamp_);
-  EXPECT_EQ(bag_data->buffers.size(), 10u);
+  EXPECT_EQ(bag_data->buffers.size(), 11u);
   // Check default topic names
   EXPECT_TRUE(bag_data->buffers.count("/tf"));
   EXPECT_TRUE(bag_data->buffers.count("/localization/kinematic_state"));
@@ -53,6 +53,8 @@ TEST_F(BagHandlerTest, BagDataConstruction)
   EXPECT_TRUE(bag_data->buffers.count("/perception/object_recognition/tracking/objects"));
   EXPECT_TRUE(bag_data->buffers.count("/perception/traffic_light_recognition/traffic_signals"));
   EXPECT_TRUE(bag_data->buffers.count("/vehicle/status/steering_status"));
+  EXPECT_TRUE(bag_data->buffers.count("/vehicle/status/hazard_lights_status"));
+  EXPECT_TRUE(bag_data->buffers.count("/vehicle/status/turn_indicators_status"));
 }
 
 TEST_F(BagHandlerTest, GetLatestBeforeOrEqual)

--- a/planning/autoware_planning_data_analyzer/test/test_replay_evaluation.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_replay_evaluation.cpp
@@ -61,6 +61,7 @@ TEST_F(ReplayEvaluationTest, TopicDefinitions)
   topic_names.trajectory_topic = "/planning/trajectory";
   topic_names.gt_trajectory_topic = "/planning/ground_truth_trajectory";
   topic_names.steering_topic = "/vehicle/status/steering_status";
+  topic_names.hazard_lights_topic = "/vehicle/status/hazard_lights_status";
   topic_names.turn_indicators_topic = "/vehicle/status/turn_indicators_status";
   topic_names.route_topic = "/planning/mission_planning/route";
   topic_names.evaluation_interval_ms = 100.0;
@@ -74,6 +75,7 @@ TEST_F(ReplayEvaluationTest, TopicDefinitions)
   EXPECT_EQ(topic_names.trajectory_topic, "/planning/trajectory");
   EXPECT_EQ(topic_names.gt_trajectory_topic, "/planning/ground_truth_trajectory");
   EXPECT_EQ(topic_names.steering_topic, "/vehicle/status/steering_status");
+  EXPECT_EQ(topic_names.hazard_lights_topic, "/vehicle/status/hazard_lights_status");
   EXPECT_EQ(topic_names.turn_indicators_topic, "/vehicle/status/turn_indicators_status");
   EXPECT_EQ(topic_names.route_topic, "/planning/mission_planning/route");
   EXPECT_EQ(topic_names.evaluation_interval_ms, 100.0);


### PR DESCRIPTION
## Description

This is the next PR in the EPDMS patch series after TTC (#431). It migrates the lane keeping (LK) subscore to the prepared EPDMS implementation.

Pipeline:

- As-is: LK failed on a continuous centerline deviation run using the current reference lanelet/intersection handling, without explicit driver-signal or queue exemptions.
- To-be: LK samples the trajectory, computes lateral distance to the route reference lanelet centerline, skips turn/hazard lane-change windows, queue/queue-release periods, and intersection samples, then fails only when non-exempt deviation continues long enough.

This PR also adds the signal history buffering needed by LK and reuses the shared local intersection context instead of adding separate lanelet-query logic.

Duplication audit: performed; signal-window collection/merging and signal-history synchronization are centralized; remaining repeated turn/hazard calls are intentional because they bind different message types and predicates.

## Validation

- `colcon build --packages-select autoware_planning_data_analyzer --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon test --packages-select autoware_planning_data_analyzer --ctest-args -R test_metrics --output-on-failure --return-code-on-test-failure`
- `pre-commit run --all-files`
- Takanawa cumulative full run through LK, compared with baseline `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260506_155345`

Full-run comparison:

- Samples: 8695 -> 8695
- NC: 74 -> 87 non-1 (accepted NC migration delta)
- DAC: 396 -> 396 non-1
- DDC: 81 -> 81 non-1
- TLC: 68 -> 68 non-1
- TTC: 102 -> 102 non-1
- LK: 367 -> 367 non-1

Generated full-run artifact `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260520_203441` was deleted after comparison.
