### PR TITLE
feat(planning_data_analyzer): migrate HC metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -52,6 +52,9 @@
       trajectory_evaluation_horizon: 4.0
       hc:
         # NAVSIM-aligned default thresholds for the History Comfort (HC) subscore.
+        past_horizon_s: 1.5
+        sample_interval_s: 0.1
+        future_horizon_s: 4.0
         finite_difference_epsilon: 0.001
         max_longitudinal_acceleration: 2.40
         min_longitudinal_acceleration: -4.05

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -126,6 +126,12 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   debug_topics_enabled_ = get_or_declare_parameter<bool>(*this, "open_loop.debug_topics_enabled");
   trajectory_evaluation_horizon_s_ =
     get_or_declare_parameter<double>(*this, "open_loop.trajectory_evaluation_horizon");
+  history_comfort_params_.past_horizon_s =
+    get_or_declare_parameter<double>(*this, "open_loop.hc.past_horizon_s");
+  history_comfort_params_.sample_interval_s =
+    get_or_declare_parameter<double>(*this, "open_loop.hc.sample_interval_s");
+  history_comfort_params_.future_horizon_s =
+    get_or_declare_parameter<double>(*this, "open_loop.hc.future_horizon_s");
   history_comfort_params_.finite_difference_epsilon =
     get_or_declare_parameter<double>(*this, "open_loop.hc.finite_difference_epsilon");
   history_comfort_params_.max_longitudinal_acceleration =

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -183,6 +183,10 @@ struct BagData
         if (odom_buffer) {
           synchronized_data->kinematic_state =
             odom_buffer->get_closest(traj_stamp_ns, tolerance_ms);
+          const auto history_start_ns =
+            traj_stamp_ns - static_cast<rcutils_time_point_value_t>(2.0e9);
+          synchronized_data->kinematic_state_history =
+            odom_buffer->get_range(history_start_ns, traj_stamp_ns);
         }
       }
     }
@@ -229,6 +233,9 @@ struct BagData
       const auto traj_stamp_ns =
         rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
       synchronized_data->acceleration = accel_buffer->get_closest(traj_stamp_ns, tolerance_ms);
+      const auto history_start_ns = traj_stamp_ns - static_cast<rcutils_time_point_value_t>(2.0e9);
+      synchronized_data->acceleration_history =
+        accel_buffer->get_range(history_start_ns, traj_stamp_ns);
     } else if (accel_buffer) {
       synchronized_data->acceleration = accel_buffer->get_closest(target_time, tolerance_ms);
     }

--- a/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
+++ b/planning/autoware_planning_data_analyzer/src/bag_handler.hpp
@@ -32,6 +32,7 @@ namespace autoware::planning_data_analyzer
 {
 
 constexpr rcutils_time_point_value_t kSignalHistoryPaddingNs = 2'000'000'000;
+constexpr rcutils_time_point_value_t kMotionHistoryPaddingNs = 2'000'000'000;
 
 struct BagData
 {
@@ -183,8 +184,7 @@ struct BagData
         if (odom_buffer) {
           synchronized_data->kinematic_state =
             odom_buffer->get_closest(traj_stamp_ns, tolerance_ms);
-          const auto history_start_ns =
-            traj_stamp_ns - static_cast<rcutils_time_point_value_t>(2.0e9);
+          const auto history_start_ns = traj_stamp_ns - kMotionHistoryPaddingNs;
           synchronized_data->kinematic_state_history =
             odom_buffer->get_range(history_start_ns, traj_stamp_ns);
         }
@@ -233,7 +233,7 @@ struct BagData
       const auto traj_stamp_ns =
         rclcpp::Time(synchronized_data->trajectory->header.stamp).nanoseconds();
       synchronized_data->acceleration = accel_buffer->get_closest(traj_stamp_ns, tolerance_ms);
-      const auto history_start_ns = traj_stamp_ns - static_cast<rcutils_time_point_value_t>(2.0e9);
+      const auto history_start_ns = traj_stamp_ns - kMotionHistoryPaddingNs;
       synchronized_data->acceleration_history =
         accel_buffer->get_range(history_start_ns, traj_stamp_ns);
     } else if (accel_buffer) {

--- a/planning/autoware_planning_data_analyzer/src/data_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/data_types.hpp
@@ -68,6 +68,8 @@ struct SynchronizedData
   std::shared_ptr<SteeringReport> steering_status;
   std::shared_ptr<PredictedObjects> objects;
   std::shared_ptr<TrackedObjects> tracked_objects;
+  std::vector<std::shared_ptr<const Odometry>> kinematic_state_history;
+  std::vector<std::shared_ptr<const AccelWithCovarianceStamped>> acceleration_history;
   std::vector<TimedTrackedObjects> future_tracked_objects;
   std::shared_ptr<TrafficLightGroupArray> traffic_signals;
   std::shared_ptr<HazardLightsReport> hazard_lights_status;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
@@ -14,12 +14,13 @@
 
 #include "history_comfort.hpp"
 
+#include "metrics/geometry/comfort_signal.hpp"
 #include "metrics/geometry/metric_utils.hpp"
-
-#include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <memory>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -28,20 +29,95 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
-double calculate_time_resolution(
-  const autoware_planning_msgs::msg::TrajectoryPoint & point,
-  const autoware_planning_msgs::msg::TrajectoryPoint & next_point, const double epsilon)
+struct ComfortState
 {
-  const double time_diff = rclcpp::Duration(next_point.time_from_start).seconds() -
-                           rclcpp::Duration(point.time_from_start).seconds();
-  return time_diff > epsilon ? time_diff : epsilon;
+  double time_s{0.0};
+  geometry_msgs::msg::Pose pose;
+  double longitudinal_acceleration_mps2{0.0};
+  double lateral_acceleration_mps2{0.0};
+};
+
+double stamp_to_seconds(const rclcpp::Time & stamp)
+{
+  return static_cast<double>(stamp.nanoseconds()) * 1.0e-9;
 }
 
-void backfill_last_value_from_previous(std::vector<double> & values)
+template <typename MessageT>
+std::shared_ptr<const MessageT> closest_message(
+  const std::vector<std::shared_ptr<const MessageT>> & history, const rclcpp::Time & target,
+  const double tolerance_s)
 {
-  if (values.size() > 1U) {
-    values.back() = values[values.size() - 2];
+  std::shared_ptr<const MessageT> best;
+  double best_diff_s = std::numeric_limits<double>::max();
+  for (const auto & msg : history) {
+    if (!msg) {
+      continue;
+    }
+    const double diff_s =
+      std::abs(stamp_to_seconds(rclcpp::Time(msg->header.stamp)) - stamp_to_seconds(target));
+    if (diff_s < best_diff_s) {
+      best_diff_s = diff_s;
+      best = msg;
+    }
   }
+  return best_diff_s <= tolerance_s ? best : nullptr;
+}
+
+ComfortState make_state_from_odometry(
+  const Odometry & odometry, const AccelWithCovarianceStamped * acceleration,
+  const double relative_time_s)
+{
+  ComfortState state;
+  state.time_s = relative_time_s;
+  state.pose = odometry.pose.pose;
+  if (acceleration) {
+    state.longitudinal_acceleration_mps2 = acceleration->accel.accel.linear.x;
+    state.lateral_acceleration_mps2 = acceleration->accel.accel.linear.y;
+  }
+  return state;
+}
+
+ComfortState make_state_from_trajectory_point(
+  const autoware_planning_msgs::msg::TrajectoryPoint & point, const double relative_time_s)
+{
+  ComfortState state;
+  state.time_s = relative_time_s;
+  state.pose = point.pose;
+  state.longitudinal_acceleration_mps2 = point.acceleration_mps2;
+  return state;
+}
+
+std::vector<ComfortState> build_padded_states(
+  const SynchronizedData & sync_data, const HistoryComfortParameters & parameters)
+{
+  std::vector<ComfortState> states;
+  if (!sync_data.trajectory || parameters.sample_interval_s <= 0.0) {
+    return states;
+  }
+
+  const auto trajectory_start = rclcpp::Time(sync_data.trajectory->header.stamp);
+  const double dt = parameters.sample_interval_s;
+  for (double t = -parameters.past_horizon_s; t < -dt; t += dt) {
+    const auto target = trajectory_start + rclcpp::Duration::from_seconds(t);
+    const auto odom = closest_message(sync_data.kinematic_state_history, target, dt * 0.75);
+    if (!odom) {
+      continue;
+    }
+    const auto accel = closest_message(sync_data.acceleration_history, target, dt * 0.75);
+    states.push_back(make_state_from_odometry(*odom, accel.get(), t));
+  }
+
+  for (const auto & point : sync_data.trajectory->points) {
+    const double t = rclcpp::Duration(point.time_from_start).seconds();
+    if (t < 0.0) {
+      continue;
+    }
+    if (t > parameters.future_horizon_s + 1.0e-6) {
+      break;
+    }
+    states.push_back(make_state_from_trajectory_point(point, t));
+  }
+  return states;
 }
 
 bool is_within(const std::vector<double> & values, const double min_value, const double max_value)
@@ -61,60 +137,35 @@ bool is_abs_within(const std::vector<double> & values, const double max_abs_valu
 }  // namespace
 
 void calculate_history_comfort_metrics(
-  const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const HistoryComfortParameters & history_comfort_params, TrajectoryPointMetrics & metrics)
+  const SynchronizedData & sync_data, const HistoryComfortParameters & history_comfort_params,
+  TrajectoryPointMetrics & metrics)
 {
-  const size_t num_points = trajectory.points.size();
-  if (num_points == 0U) {
+  const auto states = build_padded_states(sync_data, history_comfort_params);
+  if (states.empty()) {
+    metrics.history_comfort = 1.0;
+    metrics.history_comfort_available = true;
+    metrics.history_comfort_reason = "available_navsim_default_pass";
     return;
   }
 
-  metrics.longitudinal_accelerations.resize(num_points, 0.0);
-  metrics.lateral_accelerations.resize(num_points, 0.0);
-  metrics.lateral_jerks.resize(num_points, 0.0);
-  metrics.jerk_magnitudes.resize(num_points, 0.0);
-  metrics.longitudinal_jerks.resize(num_points, 0.0);
-  metrics.yaw_rates.resize(num_points, 0.0);
-  metrics.yaw_accelerations.resize(num_points, 0.0);
-
-  for (size_t i = 0; i < num_points - 1; ++i) {
-    const double time_resolution = calculate_time_resolution(
-      trajectory.points[i], trajectory.points[i + 1],
-      history_comfort_params.finite_difference_epsilon);
-
-    const double yaw_delta = autoware_utils_math::normalize_radian(
-      get_yaw(trajectory.points[i + 1].pose.orientation) -
-      get_yaw(trajectory.points[i].pose.orientation));
-    metrics.yaw_rates[i] = yaw_delta / time_resolution;
-    metrics.longitudinal_accelerations[i] = (trajectory.points[i + 1].longitudinal_velocity_mps -
-                                             trajectory.points[i].longitudinal_velocity_mps) /
-                                            time_resolution;
-    metrics.lateral_accelerations[i] =
-      trajectory.points[i].longitudinal_velocity_mps * metrics.yaw_rates[i];
+  std::vector<ComfortSignalInput> signal_inputs;
+  signal_inputs.reserve(states.size());
+  for (const auto & state : states) {
+    signal_inputs.push_back(
+      ComfortSignalInput{
+        state.time_s, state.pose, state.longitudinal_acceleration_mps2,
+        state.lateral_acceleration_mps2});
   }
-  backfill_last_value_from_previous(metrics.longitudinal_accelerations);
-  backfill_last_value_from_previous(metrics.lateral_accelerations);
-  backfill_last_value_from_previous(metrics.yaw_rates);
 
-  for (size_t i = 0; i < num_points - 1; ++i) {
-    const double time_resolution = calculate_time_resolution(
-      trajectory.points[i], trajectory.points[i + 1],
-      history_comfort_params.finite_difference_epsilon);
-
-    metrics.longitudinal_jerks[i] =
-      (metrics.longitudinal_accelerations[i + 1] - metrics.longitudinal_accelerations[i]) /
-      time_resolution;
-    metrics.lateral_jerks[i] =
-      (metrics.lateral_accelerations[i + 1] - metrics.lateral_accelerations[i]) / time_resolution;
-    metrics.jerk_magnitudes[i] =
-      std::hypot(metrics.longitudinal_jerks[i], metrics.lateral_jerks[i]);
-    metrics.yaw_accelerations[i] =
-      (metrics.yaw_rates[i + 1] - metrics.yaw_rates[i]) / time_resolution;
-  }
-  backfill_last_value_from_previous(metrics.longitudinal_jerks);
-  backfill_last_value_from_previous(metrics.lateral_jerks);
-  backfill_last_value_from_previous(metrics.jerk_magnitudes);
-  backfill_last_value_from_previous(metrics.yaw_accelerations);
+  const auto signals =
+    compute_comfort_signals(signal_inputs, history_comfort_params.past_horizon_s);
+  metrics.longitudinal_accelerations = signals.longitudinal_accelerations;
+  metrics.lateral_accelerations = signals.lateral_accelerations;
+  metrics.longitudinal_jerks = signals.longitudinal_jerks;
+  metrics.lateral_jerks = signals.lateral_jerks;
+  metrics.jerk_magnitudes = signals.jerk_magnitudes;
+  metrics.yaw_rates = signals.yaw_rates;
+  metrics.yaw_accelerations = signals.yaw_accelerations;
 
   const bool longitudinal_acceleration_ok = is_within(
     metrics.longitudinal_accelerations, history_comfort_params.min_longitudinal_acceleration,
@@ -134,6 +185,8 @@ void calculate_history_comfort_metrics(
                                 yaw_acceleration_ok
                               ? 1.0
                               : 0.0;
+  metrics.history_comfort_available = true;
+  metrics.history_comfort_reason = "available";
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
@@ -49,9 +49,8 @@ std::shared_ptr<const MessageT> closest_message(
   }
 
   const auto it = std::lower_bound(
-    history.begin(), history.end(), target, [](const auto & msg, const rclcpp::Time & t) {
-      return rclcpp::Time(msg->header.stamp) < t;
-    });
+    history.begin(), history.end(), target,
+    [](const auto & msg, const rclcpp::Time & t) { return rclcpp::Time(msg->header.stamp) < t; });
 
   std::shared_ptr<const MessageT> best;
   double best_diff_s = std::numeric_limits<double>::max();
@@ -114,8 +113,8 @@ std::vector<ComfortState> build_padded_states(
   const double dt = parameters.sample_interval_s;
   for (double t = -parameters.past_horizon_s; t < -dt / 2.0; t += dt) {
     const auto target = trajectory_start + rclcpp::Duration::from_seconds(t);
-    const auto odom =
-      closest_message(sync_data.kinematic_state_history, target, dt * kClosestSampleToleranceFactor);
+    const auto odom = closest_message(
+      sync_data.kinematic_state_history, target, dt * kClosestSampleToleranceFactor);
     if (!odom) {
       continue;
     }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.cpp
@@ -29,6 +29,8 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
+constexpr double kClosestSampleToleranceFactor = 0.75;
+
 struct ComfortState
 {
   double time_s{0.0};
@@ -37,29 +39,39 @@ struct ComfortState
   double lateral_acceleration_mps2{0.0};
 };
 
-double stamp_to_seconds(const rclcpp::Time & stamp)
-{
-  return static_cast<double>(stamp.nanoseconds()) * 1.0e-9;
-}
-
 template <typename MessageT>
 std::shared_ptr<const MessageT> closest_message(
   const std::vector<std::shared_ptr<const MessageT>> & history, const rclcpp::Time & target,
   const double tolerance_s)
 {
+  if (history.empty()) {
+    return nullptr;
+  }
+
+  const auto it = std::lower_bound(
+    history.begin(), history.end(), target, [](const auto & msg, const rclcpp::Time & t) {
+      return rclcpp::Time(msg->header.stamp) < t;
+    });
+
   std::shared_ptr<const MessageT> best;
   double best_diff_s = std::numeric_limits<double>::max();
-  for (const auto & msg : history) {
-    if (!msg) {
-      continue;
+
+  // Check the element at 'it' and the one before it
+  auto check_best = [&](const auto & iter) {
+    if (iter != history.end() && *iter) {
+      const double diff_s = std::abs((rclcpp::Time((*iter)->header.stamp) - target).seconds());
+      if (diff_s < best_diff_s) {
+        best_diff_s = diff_s;
+        best = *iter;
+      }
     }
-    const double diff_s =
-      std::abs(stamp_to_seconds(rclcpp::Time(msg->header.stamp)) - stamp_to_seconds(target));
-    if (diff_s < best_diff_s) {
-      best_diff_s = diff_s;
-      best = msg;
-    }
+  };
+
+  check_best(it);
+  if (it != history.begin()) {
+    check_best(std::prev(it));
   }
+
   return best_diff_s <= tolerance_s ? best : nullptr;
 }
 
@@ -71,6 +83,7 @@ ComfortState make_state_from_odometry(
   state.time_s = relative_time_s;
   state.pose = odometry.pose.pose;
   if (acceleration) {
+    // Note: This assumes the acceleration is in the vehicle body frame (base_link).
     state.longitudinal_acceleration_mps2 = acceleration->accel.accel.linear.x;
     state.lateral_acceleration_mps2 = acceleration->accel.accel.linear.y;
   }
@@ -84,6 +97,8 @@ ComfortState make_state_from_trajectory_point(
   state.time_s = relative_time_s;
   state.pose = point.pose;
   state.longitudinal_acceleration_mps2 = point.acceleration_mps2;
+  // Trajectory points don't carry lateral acceleration; NAVSIM HC is history-focused, so future
+  // lateral_acceleration_mps2 is left at 0 by design rather than derived from yaw rate.
   return state;
 }
 
@@ -97,13 +112,15 @@ std::vector<ComfortState> build_padded_states(
 
   const auto trajectory_start = rclcpp::Time(sync_data.trajectory->header.stamp);
   const double dt = parameters.sample_interval_s;
-  for (double t = -parameters.past_horizon_s; t < -dt; t += dt) {
+  for (double t = -parameters.past_horizon_s; t < -dt / 2.0; t += dt) {
     const auto target = trajectory_start + rclcpp::Duration::from_seconds(t);
-    const auto odom = closest_message(sync_data.kinematic_state_history, target, dt * 0.75);
+    const auto odom =
+      closest_message(sync_data.kinematic_state_history, target, dt * kClosestSampleToleranceFactor);
     if (!odom) {
       continue;
     }
-    const auto accel = closest_message(sync_data.acceleration_history, target, dt * 0.75);
+    const auto accel =
+      closest_message(sync_data.acceleration_history, target, dt * kClosestSampleToleranceFactor);
     states.push_back(make_state_from_odometry(*odom, accel.get(), t));
   }
 
@@ -142,9 +159,9 @@ void calculate_history_comfort_metrics(
 {
   const auto states = build_padded_states(sync_data, history_comfort_params);
   if (states.empty()) {
-    metrics.history_comfort = 1.0;
-    metrics.history_comfort_available = true;
-    metrics.history_comfort_reason = "available_navsim_default_pass";
+    metrics.history_comfort = 0.0;
+    metrics.history_comfort_available = false;
+    metrics.history_comfort_reason = "unavailable_no_motion_history";
     return;
   }
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/history_comfort.hpp
@@ -17,14 +17,12 @@
 
 #include "metrics/trajectory_metrics.hpp"
 
-#include <autoware_planning_msgs/msg/trajectory.hpp>
-
 namespace autoware::planning_data_analyzer::metrics
 {
 
 void calculate_history_comfort_metrics(
-  const autoware_planning_msgs::msg::Trajectory & trajectory,
-  const HistoryComfortParameters & history_comfort_params, TrajectoryPointMetrics & metrics);
+  const SynchronizedData & sync_data, const HistoryComfortParameters & history_comfort_params,
+  TrajectoryPointMetrics & metrics);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -293,7 +293,7 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     return metrics;
   }
 
-  calculate_history_comfort_metrics(trajectory, history_comfort_params, metrics);
+  calculate_history_comfort_metrics(*sync_data, history_comfort_params, metrics);
 
   const auto route_relevant_lanelets =
     route_handler && route_handler->isHandlerReady()

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
@@ -35,6 +35,9 @@ using autoware::route_handler::RouteHandler;
 
 struct HistoryComfortParameters
 {
+  double past_horizon_s{1.5};
+  double sample_interval_s{0.1};
+  double future_horizon_s{4.0};
   double finite_difference_epsilon{1.0e-3};
   double max_longitudinal_acceleration{2.40};
   double min_longitudinal_acceleration{-4.05};
@@ -59,6 +62,8 @@ struct TrajectoryPointMetrics
   std::vector<double> lateral_deviations;
   std::vector<double> travel_distances;
   double history_comfort{0.0};
+  bool history_comfort_available{false};
+  std::string history_comfort_reason{"unavailable"};
   double time_to_collision_within_bound{0.0};
   bool time_to_collision_within_bound_available{false};
   std::string time_to_collision_within_bound_reason{"unavailable"};

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -860,6 +860,7 @@ OpenLoopEvaluator::generate_ground_truth_trajectory_from_topic(
     gt_point.time_from_start = pred_point.time_from_start;
     gt_point.longitudinal_velocity_mps = pred_point.longitudinal_velocity_mps;
     gt_point.lateral_velocity_mps = pred_point.lateral_velocity_mps;
+    gt_point.acceleration_mps2 = pred_point.acceleration_mps2;
     gt_point.heading_rate_rps = pred_point.heading_rate_rps;
     gt_for_eval.points.push_back(gt_point);
   }

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -222,7 +222,7 @@ metrics::EpdmsMetricSnapshot build_epdms_snapshot(const OpenLoopTrajectoryMetric
 {
   metrics::EpdmsMetricSnapshot snapshot;
   snapshot.history_comfort = metrics.history_comfort;
-  snapshot.history_comfort_available = true;
+  snapshot.history_comfort_available = metrics.history_comfort_available;
   snapshot.extended_comfort = metrics.extended_comfort;
   snapshot.extended_comfort_available = metrics.extended_comfort_available;
   snapshot.ego_progress = metrics.ego_progress;
@@ -291,7 +291,7 @@ metrics::EpdmsMetricSnapshot calculate_human_reference_snapshot(
 
   metrics::EpdmsMetricSnapshot human_snapshot;
   human_snapshot.history_comfort = human_point_metrics.history_comfort;
-  human_snapshot.history_comfort_available = true;
+  human_snapshot.history_comfort_available = human_point_metrics.history_comfort_available;
   human_snapshot.extended_comfort = 0.0;
   human_snapshot.extended_comfort_available = false;
   human_snapshot.ego_progress = 1.0;
@@ -543,6 +543,8 @@ void OpenLoopEvaluator::evaluate(
           lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects);
         auto metrics = evaluate_trajectory(eval_data);
         metrics.history_comfort = trajectory_metrics.history_comfort;
+        metrics.history_comfort_available = trajectory_metrics.history_comfort_available;
+        metrics.history_comfort_reason = trajectory_metrics.history_comfort_reason;
         metrics.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
         metrics.time_to_collision_within_bound_available =
           trajectory_metrics.time_to_collision_within_bound_available;
@@ -1393,6 +1395,9 @@ void OpenLoopEvaluator::save_metrics_to_bag(
     };
 
   write_availability(
+    enabled_metrics_.history_comfort, metrics.history_comfort_available,
+    epdms_metric_topic("history_comfort_available"));
+  write_availability(
     enabled_metrics_.extended_comfort, metrics.extended_comfort_available,
     epdms_metric_topic("extended_comfort_available"));
   write_availability(
@@ -1434,6 +1439,9 @@ void OpenLoopEvaluator::save_metrics_to_bag(
       bag_writer.write(reason_msg, topic_name, message_timestamp);
     };
 
+  write_reason(
+    enabled_metrics_.history_comfort, metrics.history_comfort_reason,
+    epdms_metric_topic("history_comfort_reason"));
   write_reason(
     enabled_metrics_.extended_comfort, metrics.extended_comfort_reason,
     epdms_metric_topic("extended_comfort_reason"));
@@ -1686,12 +1694,22 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
 
   std::vector<double> history_comfort_values;
   history_comfort_values.reserve(metrics_list_.size());
+  std::size_t history_comfort_available_count = 0;
+  std::map<std::string, std::size_t> history_comfort_reason_counts;
   for (const auto & m : metrics_list_) {
-    history_comfort_values.push_back(m.history_comfort);
+    ++history_comfort_reason_counts[m.history_comfort_reason];
+    if (m.history_comfort_available) {
+      history_comfort_values.push_back(m.history_comfort);
+      ++history_comfort_available_count;
+    }
   }
   emit_metric(
     "aggregate", "history_comfort", "Binary history comfort subscore across trajectories [-]",
     history_comfort_values);
+  j["aggregate/history_comfort_available_count"] = history_comfort_available_count;
+  j["aggregate/history_comfort_unavailable_count"] =
+    metrics_list_.size() - history_comfort_available_count;
+  j["aggregate/history_comfort_reason_counts"] = history_comfort_reason_counts;
   std::vector<double> extended_comfort_values;
   extended_comfort_values.reserve(metrics_list_.size());
   std::size_t extended_comfort_available_count = 0;
@@ -2131,6 +2149,8 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
     traj["longitudinal_deviations"] = m.longitudinal_deviations;
     traj["ttc"] = m.ttc;
     traj["history_comfort"] = m.history_comfort;
+    traj["history_comfort_available"] = m.history_comfort_available;
+    traj["history_comfort_reason"] = m.history_comfort_reason;
     traj["extended_comfort"] = m.extended_comfort;
     traj["extended_comfort_available"] = m.extended_comfort_available;
     traj["extended_comfort_reason"] = m.extended_comfort_reason;
@@ -2251,6 +2271,8 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
       traj["trajectory_point_metrics"]["lateral_deviations"] = pm.lateral_deviations;
       traj["trajectory_point_metrics"]["travel_distances"] = pm.travel_distances;
       traj["trajectory_point_metrics"]["history_comfort"] = pm.history_comfort;
+      traj["trajectory_point_metrics"]["history_comfort_available"] = pm.history_comfort_available;
+      traj["trajectory_point_metrics"]["history_comfort_reason"] = pm.history_comfort_reason;
       traj["trajectory_point_metrics"]["time_to_collision_within_bound"] =
         pm.time_to_collision_within_bound;
       traj["trajectory_point_metrics"]["time_to_collision_within_bound_available"] =
@@ -2358,6 +2380,7 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
   if (enabled_metrics_.history_comfort) {
     add_topic(epdms_metric_topic("history_comfort"), "std_msgs/msg/Float64");
   }
+  add_epdms_availability_reason_if(enabled_metrics_.history_comfort, "history_comfort");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "longitudinal_accelerations");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "lateral_accelerations");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "lateral_jerks");

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -73,7 +73,9 @@ struct OpenLoopTrajectoryMetrics
   std::vector<double> heading_errors;       // Absolute heading error at each trajectory point [rad]
   std::vector<double> ttc;                  // Time To Collision at each trajectory point
   double history_comfort{0.0};              // Binary comfort subscore for the trajectory
-  double extended_comfort{0.0};             // Binary extended comfort subscore
+  bool history_comfort_available{false};
+  std::string history_comfort_reason{"unavailable"};
+  double extended_comfort{0.0};  // Binary extended comfort subscore
   bool extended_comfort_available{false};
   std::string extended_comfort_reason{"unavailable"};
   double time_to_collision_within_bound{0.0};

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -433,29 +433,19 @@ TEST_F(OpenLoopGTSourceModeTest, ExtendedComfortAvailabilityIsReportedAcrossCons
   EXPECT_TRUE(metrics[1].extended_comfort_available);
 }
 
-TEST_F(
-  OpenLoopGTSourceModeTest,
-  HistoryComfortUsesYawRateForLateralAccelerationWhenLateralVelocityIsZero)
+TEST_F(OpenLoopGTSourceModeTest, HistoryComfortUsesPlannedAccelerationSignals)
 {
   const rclcpp::Time start_time(55, 0);
 
-  auto turning_prediction = make_trajectory(start_time, {0.0, 1.0, 2.0, 3.0});
+  auto uncomfortable_prediction = make_trajectory(start_time, {0.0, 1.0, 2.0, 3.0});
   const auto gt = std::make_shared<Trajectory>(make_trajectory(start_time, {0.0, 1.0, 2.0, 3.0}));
 
-  for (auto & point : turning_prediction.points) {
-    point.longitudinal_velocity_mps = 10.0;
-    point.lateral_velocity_mps = 0.0;
-  }
-
-  double yaw = 0.0;
-  for (auto & point : turning_prediction.points) {
-    point.pose.orientation.z = std::sin(yaw * 0.5);
-    point.pose.orientation.w = std::cos(yaw * 0.5);
-    yaw += 0.05;
+  for (auto & point : uncomfortable_prediction.points) {
+    point.acceleration_mps2 = 10.0;
   }
 
   std::vector<std::shared_ptr<SynchronizedData>> sync_data_list{
-    make_sync_data(turning_prediction, gt)};
+    make_sync_data(uncomfortable_prediction, gt)};
 
   OpenLoopEvaluator evaluator(
     rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
@@ -466,6 +456,8 @@ TEST_F(
   const auto metrics = evaluator.get_metrics();
   ASSERT_EQ(metrics.size(), 1u);
   EXPECT_DOUBLE_EQ(metrics[0].history_comfort, 0.0);
+  EXPECT_TRUE(metrics[0].history_comfort_available);
+  EXPECT_EQ(metrics[0].history_comfort_reason, "available");
 }
 
 TEST_F(OpenLoopGTSourceModeTest, HeadingMetricsUseWrappedYawErrorPerHorizon)

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -278,14 +278,11 @@ TEST_F(OpenLoopGTSourceModeTest, HistoryComfortIsReportedForComfortableAndUncomf
   const auto gt = std::make_shared<Trajectory>(make_trajectory(start_time, {0.0, 0.5, 1.0, 1.5}));
 
   for (auto & point : comfortable_prediction.points) {
-    point.longitudinal_velocity_mps = 2.0;
+    point.acceleration_mps2 = 0.0;
   }
   for (auto & point : uncomfortable_prediction.points) {
-    point.longitudinal_velocity_mps = 2.0;
+    point.acceleration_mps2 = 10.0;
   }
-  uncomfortable_prediction.points[1].longitudinal_velocity_mps = 3.0;
-  uncomfortable_prediction.points[2].longitudinal_velocity_mps = 5.0;
-  uncomfortable_prediction.points[3].longitudinal_velocity_mps = 6.0;
 
   std::vector<std::shared_ptr<SynchronizedData>> sync_data_list{
     make_sync_data(comfortable_prediction, gt), make_sync_data(uncomfortable_prediction, gt)};
@@ -330,17 +327,11 @@ TEST_F(OpenLoopGTSourceModeTest, HumanFilterPromotesAgentHistoryComfortWhenHuman
   auto gt = std::make_shared<Trajectory>(make_trajectory(start_time, {0.0, 0.5, 1.0, 1.5}));
 
   for (auto & point : prediction.points) {
-    point.longitudinal_velocity_mps = 2.0;
+    point.acceleration_mps2 = 10.0;
   }
   for (auto & point : gt->points) {
-    point.longitudinal_velocity_mps = 2.0;
+    point.acceleration_mps2 = 10.0;
   }
-  prediction.points[1].longitudinal_velocity_mps = 3.0;
-  prediction.points[2].longitudinal_velocity_mps = 5.0;
-  prediction.points[3].longitudinal_velocity_mps = 6.0;
-  gt->points[1].longitudinal_velocity_mps = 3.0;
-  gt->points[2].longitudinal_velocity_mps = 5.0;
-  gt->points[3].longitudinal_velocity_mps = 6.0;
 
   OpenLoopEvaluator evaluator(
     rclcpp::get_logger("open_loop_gt_source_test"), nullptr,


### PR DESCRIPTION
## DES
This is the HC score PR in the EPDMS patch series.

## Scope
Migrate HC to the NAVSIM-style history-comfort calculation. This PR does not add HC debug visualization.

## Logic change
As-is:
- Planned trajectory only.
- Comfort signals were derived from future trajectory finite differences.

To-be:
- Build one padded HC sequence: recent ego odometry/acceleration history + planned 4 s trajectory.
- Reuse the shared comfort-signal helper.
- Apply NAVSIM HC thresholds to longitudinal acceleration, lateral acceleration, jerk magnitude, longitudinal jerk, yaw rate, and yaw acceleration.
- Publish HC availability/reason outputs consistently with the other migrated EPDMS scores.

## Validation
- HC matched the reference baseline: `66` non-1, `0` unavailable, reason counts: `available: 8695`


