### PR TITLE
feat(planning_data_analyzer): migrate EC metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -73,7 +73,6 @@
         max_jerk_rms: 0.5  # Maximum RMS jerk discrepancy between consecutive plans [m/s^3]
         max_yaw_rate_rms: 0.1  # Maximum RMS yaw-rate discrepancy between consecutive plans [rad/s]
         max_yaw_acceleration_rms: 0.1  # Maximum RMS yaw-acceleration discrepancy between consecutive plans [rad/s^2]
-        finite_difference_epsilon: 0.001  # Minimum delta time used for EC finite differences [s]
       lane_keep:
         max_lateral_deviation: 0.5  # Maximum absolute lateral deviation allowed for LK [m]
         max_continuous_violation_time: 2.0  # Continuous over-threshold duration allowed for LK [s]

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -156,8 +156,6 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
     get_or_declare_parameter<double>(*this, "open_loop.extended_comfort.max_yaw_rate_rms");
   extended_comfort_parameters_.max_yaw_acceleration_rms =
     get_or_declare_parameter<double>(*this, "open_loop.extended_comfort.max_yaw_acceleration_rms");
-  extended_comfort_parameters_.finite_difference_epsilon =
-    get_or_declare_parameter<double>(*this, "open_loop.extended_comfort.finite_difference_epsilon");
   lane_keeping_params_.max_lateral_deviation =
     get_or_declare_parameter<double>(*this, "open_loop.lane_keep.max_lateral_deviation");
   lane_keeping_params_.max_continuous_violation_time =

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
@@ -14,9 +14,9 @@
 
 #include "extended_comfort.hpp"
 
-#include "metrics/geometry/metric_utils.hpp"
+#include "metrics/geometry/comfort_signal.hpp"
 
-#include <autoware_utils_math/normalization.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -28,13 +28,7 @@ namespace autoware::planning_data_analyzer::metrics
 namespace
 {
 
-struct DynamicSignals
-{
-  std::vector<double> accelerations;
-  std::vector<double> jerks;
-  std::vector<double> yaw_rates;
-  std::vector<double> yaw_accelerations;
-};
+constexpr double kDefaultTrajectoryDt = 0.1;
 
 double get_time_seconds(const builtin_interfaces::msg::Duration & time_from_start)
 {
@@ -42,69 +36,44 @@ double get_time_seconds(const builtin_interfaces::msg::Duration & time_from_star
          static_cast<double>(time_from_start.nanosec) * 1e-9;
 }
 
-double compute_rms_difference(const std::vector<double> & lhs, const std::vector<double> & rhs)
+double trajectory_dt_s(const autoware_planning_msgs::msg::Trajectory & trajectory)
 {
-  const auto count = std::min(lhs.size(), rhs.size());
+  if (trajectory.points.size() < 2U) {
+    return kDefaultTrajectoryDt;
+  }
+  const double dt = get_time_seconds(trajectory.points.at(1).time_from_start) -
+                    get_time_seconds(trajectory.points.front().time_from_start);
+  return dt > 0.0 ? dt : kDefaultTrajectoryDt;
+}
+
+std::vector<ComfortSignalInput> make_overlap_signal_inputs(
+  const autoware_planning_msgs::msg::Trajectory & trajectory, const std::size_t start_index,
+  const std::size_t count, const double dt)
+{
+  std::vector<ComfortSignalInput> inputs;
+  inputs.reserve(count);
+  for (std::size_t index = 0; index < count; ++index) {
+    const auto & point = trajectory.points.at(start_index + index);
+    inputs.push_back(
+      ComfortSignalInput{
+        static_cast<double>(index) * dt, point.pose, point.acceleration_mps2, 0.0});
+  }
+  return inputs;
+}
+
+double rms_difference(const std::vector<double> & current, const std::vector<double> & previous)
+{
+  const auto count = std::min(current.size(), previous.size());
   if (count == 0U) {
     return 0.0;
   }
 
-  double sum_squared_error = 0.0;
-  for (std::size_t i = 0; i < count; ++i) {
-    const double error = lhs.at(i) - rhs.at(i);
-    sum_squared_error += error * error;
+  double sum_squared = 0.0;
+  for (std::size_t index = 0; index < count; ++index) {
+    const double delta = current.at(index) - previous.at(index);
+    sum_squared += delta * delta;
   }
-
-  return std::sqrt(sum_squared_error / static_cast<double>(count));
-}
-
-DynamicSignals calculate_dynamic_signals(
-  const autoware_planning_msgs::msg::Trajectory & trajectory, const double epsilon)
-{
-  DynamicSignals signals;
-  const auto num_points = trajectory.points.size();
-  if (num_points < 2U) {
-    return signals;
-  }
-
-  signals.accelerations.resize(num_points - 1U, 0.0);
-  signals.yaw_rates.resize(num_points - 1U, 0.0);
-
-  for (std::size_t i = 0; i + 1U < num_points; ++i) {
-    const auto & point = trajectory.points.at(i);
-    const auto & next_point = trajectory.points.at(i + 1U);
-    const double dt = std::max(
-      get_time_seconds(next_point.time_from_start) - get_time_seconds(point.time_from_start),
-      epsilon);
-
-    const double speed = std::hypot(point.longitudinal_velocity_mps, point.lateral_velocity_mps);
-    const double next_speed =
-      std::hypot(next_point.longitudinal_velocity_mps, next_point.lateral_velocity_mps);
-    signals.accelerations.at(i) = (next_speed - speed) / dt;
-
-    const double yaw = get_yaw(point.pose.orientation);
-    const double next_yaw = get_yaw(next_point.pose.orientation);
-    const double delta_yaw = autoware_utils_math::normalize_radian(next_yaw - yaw);
-    signals.yaw_rates.at(i) = delta_yaw / dt;
-  }
-
-  if (signals.accelerations.size() >= 2U) {
-    signals.jerks.resize(signals.accelerations.size() - 1U, 0.0);
-    signals.yaw_accelerations.resize(signals.yaw_rates.size() - 1U, 0.0);
-
-    for (std::size_t i = 0; i + 1U < signals.accelerations.size(); ++i) {
-      const auto & point = trajectory.points.at(i);
-      const auto & next_point = trajectory.points.at(i + 1U);
-      const double dt = std::max(
-        get_time_seconds(next_point.time_from_start) - get_time_seconds(point.time_from_start),
-        epsilon);
-      signals.jerks.at(i) = (signals.accelerations.at(i + 1U) - signals.accelerations.at(i)) / dt;
-      signals.yaw_accelerations.at(i) =
-        (signals.yaw_rates.at(i + 1U) - signals.yaw_rates.at(i)) / dt;
-    }
-  }
-
-  return signals;
+  return std::sqrt(sum_squared / static_cast<double>(count));
 }
 
 bool are_parameters_valid(const ExtendedComfortParameters & parameters)
@@ -121,43 +90,60 @@ ExtendedComfortResult calculate_extended_comfort(
   const autoware_planning_msgs::msg::Trajectory & current_trajectory,
   const ExtendedComfortParameters & parameters)
 {
+  ExtendedComfortResult result;
   if (!are_parameters_valid(parameters)) {
-    return {0.0, false, "unavailable_invalid_parameters"};
+    result.reason = "unavailable_invalid_parameters";
+    return result;
   }
 
-  if (previous_trajectory.points.size() < 3U || current_trajectory.points.size() < 3U) {
-    return {0.0, false, "unavailable_short_trajectory"};
+  const double dt = trajectory_dt_s(current_trajectory);
+  const double raw_observation_interval =
+    (rclcpp::Time(current_trajectory.header.stamp) - rclcpp::Time(previous_trajectory.header.stamp))
+      .seconds();
+  const double observation_interval =
+    raw_observation_interval > 0.0 ? raw_observation_interval : dt;
+  const auto overlap_shift = static_cast<std::size_t>(std::llround(observation_interval / dt));
+  if (dt <= 0.0 || overlap_shift == 0U) {
+    result.reason = "unavailable_invalid_time_alignment";
+    return result;
   }
 
-  auto previous_signals =
-    calculate_dynamic_signals(previous_trajectory, parameters.finite_difference_epsilon);
-  auto current_signals =
-    calculate_dynamic_signals(current_trajectory, parameters.finite_difference_epsilon);
-
-  if (
-    previous_signals.accelerations.empty() || current_signals.accelerations.empty() ||
-    previous_signals.jerks.empty() || current_signals.jerks.empty() ||
-    previous_signals.yaw_rates.empty() || current_signals.yaw_rates.empty() ||
-    previous_signals.yaw_accelerations.empty() || current_signals.yaw_accelerations.empty()) {
-    return {0.0, false, "unavailable_short_trajectory"};
+  const auto previous_size = previous_trajectory.points.size();
+  const auto current_size = current_trajectory.points.size();
+  if (previous_size < 3U || current_size < 3U || overlap_shift >= previous_size) {
+    result.reason = "unavailable_short_trajectory";
+    return result;
   }
 
-  const double acceleration_rms =
-    compute_rms_difference(previous_signals.accelerations, current_signals.accelerations);
-  const double jerk_rms = compute_rms_difference(previous_signals.jerks, current_signals.jerks);
-  const double yaw_rate_rms =
-    compute_rms_difference(previous_signals.yaw_rates, current_signals.yaw_rates);
+  const auto overlap_count = std::min(current_size, previous_size - overlap_shift);
+  if (overlap_count < 3U) {
+    result.reason = "unavailable_short_overlap";
+    return result;
+  }
+
+  const auto current_inputs = make_overlap_signal_inputs(current_trajectory, 0U, overlap_count, dt);
+  const auto previous_inputs =
+    make_overlap_signal_inputs(previous_trajectory, overlap_shift, overlap_count, dt);
+  const auto current_signals = compute_comfort_signals(current_inputs);
+  const auto previous_signals = compute_comfort_signals(previous_inputs);
+
+  const double acceleration_rms = rms_difference(
+    current_signals.acceleration_magnitudes, previous_signals.acceleration_magnitudes);
+  const double jerk_rms =
+    rms_difference(current_signals.jerk_magnitudes, previous_signals.jerk_magnitudes);
+  const double yaw_rate_rms = rms_difference(current_signals.yaw_rates, previous_signals.yaw_rates);
   const double yaw_acceleration_rms =
-    compute_rms_difference(previous_signals.yaw_accelerations, current_signals.yaw_accelerations);
+    rms_difference(current_signals.yaw_accelerations, previous_signals.yaw_accelerations);
 
-  if (
-    acceleration_rms > parameters.max_acceleration_rms || jerk_rms > parameters.max_jerk_rms ||
-    yaw_rate_rms > parameters.max_yaw_rate_rms ||
-    yaw_acceleration_rms > parameters.max_yaw_acceleration_rms) {
-    return {0.0, true, "available"};
-  }
+  const bool acceleration_ok = acceleration_rms <= parameters.max_acceleration_rms;
+  const bool jerk_ok = jerk_rms <= parameters.max_jerk_rms;
+  const bool yaw_rate_ok = yaw_rate_rms <= parameters.max_yaw_rate_rms;
+  const bool yaw_acceleration_ok = yaw_acceleration_rms <= parameters.max_yaw_acceleration_rms;
 
-  return {1.0, true, "available"};
+  result.available = true;
+  result.reason = "available";
+  result.score = acceleration_ok && jerk_ok && yaw_rate_ok && yaw_acceleration_ok ? 1.0 : 0.0;
+  return result;
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
@@ -52,7 +52,8 @@ std::vector<ComfortSignalInput> make_overlap_signal_inputs(
 {
   std::vector<ComfortSignalInput> inputs;
   inputs.reserve(count);
-  const double start_time_s = rclcpp::Duration(trajectory.points[start_index].time_from_start).seconds();
+  const double start_time_s =
+    rclcpp::Duration(trajectory.points[start_index].time_from_start).seconds();
   for (std::size_t index = 0; index < count; ++index) {
     const auto & point = trajectory.points[start_index + index];
     const double time_s = rclcpp::Duration(point.time_from_start).seconds() - start_time_s;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
@@ -48,15 +48,17 @@ double trajectory_dt_s(const autoware_planning_msgs::msg::Trajectory & trajector
 
 std::vector<ComfortSignalInput> make_overlap_signal_inputs(
   const autoware_planning_msgs::msg::Trajectory & trajectory, const std::size_t start_index,
-  const std::size_t count, const double dt)
+  const std::size_t count)
 {
   std::vector<ComfortSignalInput> inputs;
   inputs.reserve(count);
+  const double start_time_s = get_time_seconds(trajectory.points.at(start_index).time_from_start);
   for (std::size_t index = 0; index < count; ++index) {
     const auto & point = trajectory.points.at(start_index + index);
-    inputs.push_back(
-      ComfortSignalInput{
-        static_cast<double>(index) * dt, point.pose, point.acceleration_mps2, 0.0});
+    const double time_s = get_time_seconds(point.time_from_start) - start_time_s;
+    // Trajectory points do not carry lateral acceleration; EC therefore compares
+    // longitudinal-only acceleration magnitudes for planned horizons.
+    inputs.push_back(ComfortSignalInput{time_s, point.pose, point.acceleration_mps2, 0.0});
   }
   return inputs;
 }
@@ -79,8 +81,7 @@ double rms_difference(const std::vector<double> & current, const std::vector<dou
 bool are_parameters_valid(const ExtendedComfortParameters & parameters)
 {
   return parameters.max_acceleration_rms >= 0.0 && parameters.max_jerk_rms >= 0.0 &&
-         parameters.max_yaw_rate_rms >= 0.0 && parameters.max_yaw_acceleration_rms >= 0.0 &&
-         parameters.finite_difference_epsilon > 0.0;
+         parameters.max_yaw_rate_rms >= 0.0 && parameters.max_yaw_acceleration_rms >= 0.0;
 }
 
 }  // namespace
@@ -100,10 +101,14 @@ ExtendedComfortResult calculate_extended_comfort(
   const double raw_observation_interval =
     (rclcpp::Time(current_trajectory.header.stamp) - rclcpp::Time(previous_trajectory.header.stamp))
       .seconds();
+  if (raw_observation_interval < 0.0) {
+    result.reason = "unavailable_invalid_time_alignment";
+    return result;
+  }
   const double observation_interval =
     raw_observation_interval > 0.0 ? raw_observation_interval : dt;
   const auto overlap_shift = static_cast<std::size_t>(std::llround(observation_interval / dt));
-  if (dt <= 0.0 || overlap_shift == 0U) {
+  if (overlap_shift == 0U) {
     result.reason = "unavailable_invalid_time_alignment";
     return result;
   }
@@ -121,9 +126,9 @@ ExtendedComfortResult calculate_extended_comfort(
     return result;
   }
 
-  const auto current_inputs = make_overlap_signal_inputs(current_trajectory, 0U, overlap_count, dt);
+  const auto current_inputs = make_overlap_signal_inputs(current_trajectory, 0U, overlap_count);
   const auto previous_inputs =
-    make_overlap_signal_inputs(previous_trajectory, overlap_shift, overlap_count, dt);
+    make_overlap_signal_inputs(previous_trajectory, overlap_shift, overlap_count);
   const auto current_signals = compute_comfort_signals(current_inputs);
   const auto previous_signals = compute_comfort_signals(previous_inputs);
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.cpp
@@ -16,7 +16,8 @@
 
 #include "metrics/geometry/comfort_signal.hpp"
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/duration.hpp>
+#include <rclcpp/time.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -30,34 +31,31 @@ namespace
 
 constexpr double kDefaultTrajectoryDt = 0.1;
 
-double get_time_seconds(const builtin_interfaces::msg::Duration & time_from_start)
-{
-  return static_cast<double>(time_from_start.sec) +
-         static_cast<double>(time_from_start.nanosec) * 1e-9;
-}
-
 double trajectory_dt_s(const autoware_planning_msgs::msg::Trajectory & trajectory)
 {
   if (trajectory.points.size() < 2U) {
     return kDefaultTrajectoryDt;
   }
-  const double dt = get_time_seconds(trajectory.points.at(1).time_from_start) -
-                    get_time_seconds(trajectory.points.front().time_from_start);
+  const double dt = rclcpp::Duration(trajectory.points[1].time_from_start).seconds() -
+                    rclcpp::Duration(trajectory.points.front().time_from_start).seconds();
   return dt > 0.0 ? dt : kDefaultTrajectoryDt;
 }
 
+/**
+ * @brief Prepare ComfortSignalInputs for a trajectory segment.
+ * @note Trajectory points do not carry lateral acceleration; EC therefore compares
+ * longitudinal-only acceleration magnitudes for planned horizons.
+ */
 std::vector<ComfortSignalInput> make_overlap_signal_inputs(
   const autoware_planning_msgs::msg::Trajectory & trajectory, const std::size_t start_index,
   const std::size_t count)
 {
   std::vector<ComfortSignalInput> inputs;
   inputs.reserve(count);
-  const double start_time_s = get_time_seconds(trajectory.points.at(start_index).time_from_start);
+  const double start_time_s = rclcpp::Duration(trajectory.points[start_index].time_from_start).seconds();
   for (std::size_t index = 0; index < count; ++index) {
-    const auto & point = trajectory.points.at(start_index + index);
-    const double time_s = get_time_seconds(point.time_from_start) - start_time_s;
-    // Trajectory points do not carry lateral acceleration; EC therefore compares
-    // longitudinal-only acceleration magnitudes for planned horizons.
+    const auto & point = trajectory.points[start_index + index];
+    const double time_s = rclcpp::Duration(point.time_from_start).seconds() - start_time_s;
     inputs.push_back(ComfortSignalInput{time_s, point.pose, point.acceleration_mps2, 0.0});
   }
   return inputs;
@@ -72,7 +70,7 @@ double rms_difference(const std::vector<double> & current, const std::vector<dou
 
   double sum_squared = 0.0;
   for (std::size_t index = 0; index < count; ++index) {
-    const double delta = current.at(index) - previous.at(index);
+    const double delta = current[index] - previous[index];
     sum_squared += delta * delta;
   }
   return std::sqrt(sum_squared / static_cast<double>(count));

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/extended_comfort.hpp
@@ -28,7 +28,6 @@ struct ExtendedComfortParameters
   double max_jerk_rms{0.5};
   double max_yaw_rate_rms{0.1};
   double max_yaw_acceleration_rms{0.1};
-  double finite_difference_epsilon{1.0e-3};
 };
 
 struct ExtendedComfortResult

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_extended_comfort.cpp
@@ -23,17 +23,19 @@ namespace
 {
 
 autoware_planning_msgs::msg::Trajectory make_trajectory(
-  const std::vector<double> & velocities, const std::vector<double> & yaws)
+  const std::vector<double> & accelerations, const std::vector<double> & yaws,
+  const int32_t stamp_nsec = 0)
 {
   autoware_planning_msgs::msg::Trajectory trajectory;
   trajectory.header.frame_id = "map";
+  trajectory.header.stamp.nanosec = static_cast<uint32_t>(stamp_nsec);
 
-  for (std::size_t i = 0; i < velocities.size(); ++i) {
+  for (std::size_t i = 0; i < accelerations.size(); ++i) {
     autoware_planning_msgs::msg::TrajectoryPoint point;
     point.pose.position.x = static_cast<double>(i);
     point.pose.orientation.z = std::sin(yaws.at(i) * 0.5);
     point.pose.orientation.w = std::cos(yaws.at(i) * 0.5);
-    point.longitudinal_velocity_mps = velocities.at(i);
+    point.acceleration_mps2 = accelerations.at(i);
     point.time_from_start.nanosec = static_cast<uint32_t>(i * 100000000UL);
     trajectory.points.push_back(point);
   }
@@ -45,10 +47,13 @@ autoware_planning_msgs::msg::Trajectory make_trajectory(
 
 TEST(ExtendedComfortTest, ReturnsAvailableOneForMatchingConsecutiveTrajectories)
 {
-  const auto trajectory = make_trajectory({1.0, 1.2, 1.4, 1.6}, {0.0, 0.01, 0.02, 0.03});
+  const auto previous_trajectory =
+    make_trajectory({1.0, 1.2, 1.4, 1.6}, {0.0, 0.01, 0.02, 0.03}, 0);
+  const auto current_trajectory =
+    make_trajectory({1.2, 1.4, 1.6, 1.8}, {0.01, 0.02, 0.03, 0.04}, 100000000);
 
   const auto result = autoware::planning_data_analyzer::metrics::calculate_extended_comfort(
-    trajectory, trajectory, {});
+    previous_trajectory, current_trajectory, {});
 
   EXPECT_TRUE(result.available);
   EXPECT_EQ(result.reason, "available");
@@ -60,8 +65,9 @@ TEST(ExtendedComfortTest, ReturnsAvailableZeroWhenRmsDiscrepancyExceedsThreshold
   autoware::planning_data_analyzer::metrics::ExtendedComfortParameters parameters;
   parameters.max_acceleration_rms = 0.1;
 
-  const auto previous_trajectory = make_trajectory({1.0, 1.0, 1.0, 1.0}, {0.0, 0.0, 0.0, 0.0});
-  const auto current_trajectory = make_trajectory({1.0, 2.0, 3.0, 4.0}, {0.0, 0.0, 0.0, 0.0});
+  const auto previous_trajectory = make_trajectory({1.0, 1.0, 1.0, 1.0}, {0.0, 0.0, 0.0, 0.0}, 0);
+  const auto current_trajectory =
+    make_trajectory({1.0, 2.0, 3.0, 4.0}, {0.0, 0.0, 0.0, 0.0}, 100000000);
 
   const auto result = autoware::planning_data_analyzer::metrics::calculate_extended_comfort(
     previous_trajectory, current_trajectory, parameters);
@@ -73,8 +79,8 @@ TEST(ExtendedComfortTest, ReturnsAvailableZeroWhenRmsDiscrepancyExceedsThreshold
 
 TEST(ExtendedComfortTest, ReturnsUnavailableForShortTrajectory)
 {
-  const auto short_trajectory = make_trajectory({1.0, 1.1}, {0.0, 0.01});
-  const auto long_trajectory = make_trajectory({1.0, 1.1, 1.2}, {0.0, 0.01, 0.02});
+  const auto short_trajectory = make_trajectory({1.0, 1.1}, {0.0, 0.01}, 0);
+  const auto long_trajectory = make_trajectory({1.0, 1.1, 1.2}, {0.0, 0.01, 0.02}, 100000000);
 
   const auto result = autoware::planning_data_analyzer::metrics::calculate_extended_comfort(
     short_trajectory, long_trajectory, {});

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_extended_comfort.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_extended_comfort.cpp
@@ -24,7 +24,7 @@ namespace
 
 autoware_planning_msgs::msg::Trajectory make_trajectory(
   const std::vector<double> & accelerations, const std::vector<double> & yaws,
-  const int32_t stamp_nsec = 0)
+  const int32_t stamp_nsec = 0, const std::vector<uint32_t> & sample_times_nsec = {})
 {
   autoware_planning_msgs::msg::Trajectory trajectory;
   trajectory.header.frame_id = "map";
@@ -36,7 +36,8 @@ autoware_planning_msgs::msg::Trajectory make_trajectory(
     point.pose.orientation.z = std::sin(yaws.at(i) * 0.5);
     point.pose.orientation.w = std::cos(yaws.at(i) * 0.5);
     point.acceleration_mps2 = accelerations.at(i);
-    point.time_from_start.nanosec = static_cast<uint32_t>(i * 100000000UL);
+    point.time_from_start.nanosec =
+      sample_times_nsec.empty() ? static_cast<uint32_t>(i * 100000000UL) : sample_times_nsec.at(i);
     trajectory.points.push_back(point);
   }
 
@@ -88,4 +89,33 @@ TEST(ExtendedComfortTest, ReturnsUnavailableForShortTrajectory)
   EXPECT_FALSE(result.available);
   EXPECT_EQ(result.reason, "unavailable_short_trajectory");
   EXPECT_DOUBLE_EQ(result.score, 0.0);
+}
+
+TEST(ExtendedComfortTest, HandlesNonUniformSampleTimes)
+{
+  const std::vector<uint32_t> times{0U, 100000000U, 250000000U, 450000000U, 700000000U};
+  const auto previous_trajectory =
+    make_trajectory({1.0, 1.2, 1.4, 1.6, 1.8}, {0.0, 0.01, 0.02, 0.03, 0.04}, 0, times);
+  const auto current_trajectory =
+    make_trajectory({1.2, 1.4, 1.6, 1.8, 2.0}, {0.01, 0.02, 0.03, 0.04, 0.05}, 100000000, times);
+
+  const auto result = autoware::planning_data_analyzer::metrics::calculate_extended_comfort(
+    previous_trajectory, current_trajectory, {});
+
+  EXPECT_TRUE(result.available);
+  EXPECT_EQ(result.reason, "available");
+}
+
+TEST(ExtendedComfortTest, ReturnsUnavailableForNegativeTimeAlignment)
+{
+  const auto previous_trajectory =
+    make_trajectory({1.0, 1.2, 1.4, 1.6}, {0.0, 0.01, 0.02, 0.03}, 200000000);
+  const auto current_trajectory =
+    make_trajectory({1.2, 1.4, 1.6, 1.8}, {0.01, 0.02, 0.03, 0.04}, 100000000);
+
+  const auto result = autoware::planning_data_analyzer::metrics::calculate_extended_comfort(
+    previous_trajectory, current_trajectory, {});
+
+  EXPECT_FALSE(result.available);
+  EXPECT_EQ(result.reason, "unavailable_invalid_time_alignment");
 }


### PR DESCRIPTION
## Description
This is the EC score PR in the EPDMS patch series.

## Scope
Migrate EC to the NAVSIM-style two-frame extended-comfort calculation. This PR does not add EC debug visualization.

## Logic change
As-is pipeline:
previous trajectory + current trajectory -> compare whole finite-difference signal sequences -> threshold EC

To-be pipeline:
previous/current trajectory stamps -> observation interval -> shifted overlapping horizon -> shared comfort-signal extraction -> RMS checks for acceleration magnitude, jerk magnitude, yaw rate, and yaw acceleration -> EC

## Validation
- Takanawa cumulative run through EC: `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260521_160201`
- Evaluated trajectories: `8695`
- EC matched the reference baseline: `351` non-1, `1` unavailable, changed timestamps `0`
- DAC/DDC/TLC/TTC/LK/HC stayed matched. NC differs only by the accepted PR #426 de-dup fix.
