### PR TITLE
feat(planning_data_analyzer): migrate EP metric

### DIFF
--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
@@ -127,8 +127,8 @@ EgoProgressResult calculate_ego_progress(
   constexpr double kProgressDistanceThresholdM = 5.0;
   if (result.denominator_m > kProgressDistanceThresholdM) {
     // Note: Since we only have a single trajectory candidate in this implementation,
-    // the score simplifies to 1.0 (raw_progress / denominator where denominator = raw_progress * 1.0)
-    // if all multiplicative metrics passed.
+    // the score simplifies to 1.0 (raw_progress / denominator where denominator = raw_progress
+    // * 1.0) if all multiplicative metrics passed.
     result.score = std::clamp(result.raw_progress_m / result.denominator_m, 0.0, 1.0);
     result.reason = "available_single_proposal_navsim_ratio";
   } else {

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
@@ -20,11 +20,8 @@
 #include <autoware/lanelet2_utils/geometry.hpp>
 
 #include <algorithm>
-#include <cmath>
-#include <limits>
 #include <memory>
 #include <optional>
-#include <unordered_set>
 #include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
@@ -36,19 +33,38 @@ namespace
 {
 
 std::optional<double> calculate_raw_progress_m(
-  const Trajectory & trajectory, const std::shared_ptr<RouteHandler> & route_handler)
+  const Trajectory & trajectory, const std::shared_ptr<RouteHandler> & route_handler,
+  std::vector<geometry_msgs::msg::Point> * route_reference_points,
+  const lanelet::ConstLanelets * route_relevant_lanelets)
 {
   if (trajectory.points.size() < 2U) {
     return std::nullopt;
   }
 
-  const auto route_lanelets = collect_route_relevant_lanelets(trajectory, route_handler);
+  const auto local_route_lanelets = route_relevant_lanelets
+                                      ? lanelet::ConstLanelets{}
+                                      : collect_route_relevant_lanelets(trajectory, route_handler);
+  const auto & route_lanelets =
+    route_relevant_lanelets ? *route_relevant_lanelets : local_route_lanelets;
   if (route_lanelets.empty()) {
     return std::nullopt;
   }
   const auto lanelet_map_ptr = route_handler->getLaneletMapPtr();
   if (!lanelet_map_ptr) {
     return std::nullopt;
+  }
+
+  if (route_reference_points) {
+    route_reference_points->clear();
+    for (const auto & lanelet : route_lanelets) {
+      for (const auto & point : lanelet.centerline()) {
+        geometry_msgs::msg::Point msg_point;
+        msg_point.x = point.x();
+        msg_point.y = point.y();
+        msg_point.z = point.z();
+        route_reference_points->push_back(msg_point);
+      }
+    }
   }
 
   const auto start_arc =
@@ -61,68 +77,16 @@ std::optional<double> calculate_raw_progress_m(
   return std::max(end_arc.length - start_arc.length, 0.0);
 }
 
-Trajectory to_trajectory(
-  const autoware_internal_planning_msgs::msg::CandidateTrajectory & candidate_trajectory)
-{
-  Trajectory trajectory;
-  trajectory.header = candidate_trajectory.header;
-  trajectory.points = candidate_trajectory.points;
-  return trajectory;
-}
-
-double calculate_trajectory_similarity(const Trajectory & lhs, const Trajectory & rhs)
-{
-  if (lhs.points.empty() || rhs.points.empty()) {
-    return std::numeric_limits<double>::max();
-  }
-
-  const auto shared_size = std::min(lhs.points.size(), rhs.points.size());
-  if (shared_size == 0U) {
-    return std::numeric_limits<double>::max();
-  }
-
-  double total_distance = 0.0;
-  for (size_t i = 0; i < shared_size; ++i) {
-    const auto & lp = lhs.points.at(i).pose.position;
-    const auto & rp = rhs.points.at(i).pose.position;
-    total_distance += std::hypot(lp.x - rp.x, lp.y - rp.y);
-  }
-
-  // Normalize by the shared prefix length so candidate matching is not biased toward
-  // trajectories with more points in common.
-  total_distance /= static_cast<double>(shared_size);
-  total_distance += std::abs(static_cast<double>(lhs.points.size()) - rhs.points.size());
-  return total_distance;
-}
-
-std::optional<size_t> find_selected_candidate_index(
-  const Trajectory & selected_trajectory, const CandidateTrajectories & candidate_trajectories)
-{
-  if (candidate_trajectories.candidate_trajectories.empty()) {
-    return std::nullopt;
-  }
-
-  size_t best_index = 0U;
-  double best_similarity = std::numeric_limits<double>::max();
-
-  for (size_t i = 0; i < candidate_trajectories.candidate_trajectories.size(); ++i) {
-    const auto candidate = to_trajectory(candidate_trajectories.candidate_trajectories.at(i));
-    const double similarity = calculate_trajectory_similarity(selected_trajectory, candidate);
-    if (similarity < best_similarity) {
-      best_similarity = similarity;
-      best_index = i;
-    }
-  }
-
-  return best_index;
-}
-
 }  // namespace
 
 EgoProgressResult calculate_ego_progress(
   const std::shared_ptr<Trajectory> & selected_trajectory,
-  const std::shared_ptr<CandidateTrajectories> & candidate_trajectories,
-  const std::shared_ptr<RouteHandler> & route_handler)
+  const std::shared_ptr<RouteHandler> & route_handler, const double no_at_fault_collision,
+  const bool no_at_fault_collision_available, const double drivable_area_compliance,
+  const bool drivable_area_compliance_available, const double driving_direction_compliance,
+  const bool driving_direction_compliance_available, const double traffic_light_compliance,
+  const bool traffic_light_compliance_available,
+  const lanelet::ConstLanelets * route_relevant_lanelets)
 {
   EgoProgressResult result;
 
@@ -138,68 +102,39 @@ EgoProgressResult calculate_ego_progress(
     result.reason = "unavailable_route_handler_not_ready";
     return result;
   }
+  if (selected_trajectory->points.size() < 2U) {
+    result.reason = "unavailable_short_trajectory";
+    return result;
+  }
+  if (
+    !no_at_fault_collision_available || !drivable_area_compliance_available ||
+    !driving_direction_compliance_available || !traffic_light_compliance_available) {
+    result.reason = "unavailable_missing_multiplicative_metric";
+    return result;
+  }
 
-  const auto selected_raw_progress = calculate_raw_progress_m(*selected_trajectory, route_handler);
+  result.start_point = selected_trajectory->points.front().pose.position;
+  result.end_point = selected_trajectory->points.back().pose.position;
+  const auto selected_raw_progress = calculate_raw_progress_m(
+    *selected_trajectory, route_handler, &result.route_reference_points, route_relevant_lanelets);
   if (!selected_raw_progress.has_value()) {
     result.reason = "unavailable_no_route_lanelets";
     return result;
   }
   result.raw_progress_m = selected_raw_progress.value();
-
-  if (!candidate_trajectories) {
-    result.reason = "unavailable_no_candidate_trajectories";
-    return result;
-  }
-  if (candidate_trajectories->candidate_trajectories.empty()) {
-    result.reason = "unavailable_empty_candidate_trajectories";
-    return result;
-  }
-
-  const auto selected_candidate_index =
-    find_selected_candidate_index(*selected_trajectory, *candidate_trajectories);
-  if (!selected_candidate_index.has_value()) {
-    result.reason = "unavailable_no_matching_selected_candidate";
-    return result;
-  }
-
-  double best_raw_progress_m = 0.0;
-  bool has_valid_candidate = false;
-  std::optional<double> selected_candidate_raw_progress;
-
-  for (size_t i = 0; i < candidate_trajectories->candidate_trajectories.size(); ++i) {
-    const auto candidate = to_trajectory(candidate_trajectories->candidate_trajectories.at(i));
-    const auto candidate_raw_progress = calculate_raw_progress_m(candidate, route_handler);
-    if (!candidate_raw_progress.has_value()) {
-      continue;
-    }
-
-    has_valid_candidate = true;
-    best_raw_progress_m = std::max(best_raw_progress_m, candidate_raw_progress.value());
-    if (i == selected_candidate_index.value()) {
-      selected_candidate_raw_progress = candidate_raw_progress;
-    }
-  }
-
-  if (!has_valid_candidate) {
-    result.reason = "unavailable_no_valid_candidate_progress";
-    return result;
-  }
-  if (!selected_candidate_raw_progress.has_value()) {
-    result.reason = "unavailable_selected_candidate_invalid";
-    return result;
-  }
-
-  result.raw_progress_m = selected_candidate_raw_progress.value();
-  result.best_raw_progress_m = best_raw_progress_m;
+  result.multiplicative_mask = no_at_fault_collision * drivable_area_compliance *
+                               driving_direction_compliance * traffic_light_compliance;
+  result.denominator_m = result.raw_progress_m * result.multiplicative_mask;
+  result.best_raw_progress_m = result.denominator_m;
   result.available = true;
-  result.reason = "available";
 
   constexpr double kProgressDistanceThresholdM = 5.0;
-  if (best_raw_progress_m > kProgressDistanceThresholdM) {
-    result.score =
-      std::clamp(selected_candidate_raw_progress.value() / best_raw_progress_m, 0.0, 1.0);
+  if (result.denominator_m > kProgressDistanceThresholdM) {
+    result.score = std::clamp(result.raw_progress_m / result.denominator_m, 0.0, 1.0);
+    result.reason = "available_single_proposal_navsim_ratio";
   } else {
     result.score = 1.0;
+    result.reason = "available_single_proposal_navsim_fallback";
   }
 
   return result;

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.cpp
@@ -18,6 +18,7 @@
 #include "metrics/geometry/metric_utils.hpp"
 
 #include <autoware/lanelet2_utils/geometry.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -58,11 +59,8 @@ std::optional<double> calculate_raw_progress_m(
     route_reference_points->clear();
     for (const auto & lanelet : route_lanelets) {
       for (const auto & point : lanelet.centerline()) {
-        geometry_msgs::msg::Point msg_point;
-        msg_point.x = point.x();
-        msg_point.y = point.y();
-        msg_point.z = point.z();
-        route_reference_points->push_back(msg_point);
+        route_reference_points->push_back(
+          autoware_utils::create_point(point.x(), point.y(), point.z()));
       }
     }
   }
@@ -81,11 +79,9 @@ std::optional<double> calculate_raw_progress_m(
 
 EgoProgressResult calculate_ego_progress(
   const std::shared_ptr<Trajectory> & selected_trajectory,
-  const std::shared_ptr<RouteHandler> & route_handler, const double no_at_fault_collision,
-  const bool no_at_fault_collision_available, const double drivable_area_compliance,
-  const bool drivable_area_compliance_available, const double driving_direction_compliance,
-  const bool driving_direction_compliance_available, const double traffic_light_compliance,
-  const bool traffic_light_compliance_available,
+  const std::shared_ptr<RouteHandler> & route_handler, const MetricScore & no_at_fault_collision,
+  const MetricScore & drivable_area_compliance, const MetricScore & driving_direction_compliance,
+  const MetricScore & traffic_light_compliance,
   const lanelet::ConstLanelets * route_relevant_lanelets)
 {
   EgoProgressResult result;
@@ -107,8 +103,8 @@ EgoProgressResult calculate_ego_progress(
     return result;
   }
   if (
-    !no_at_fault_collision_available || !drivable_area_compliance_available ||
-    !driving_direction_compliance_available || !traffic_light_compliance_available) {
+    !no_at_fault_collision.available || !drivable_area_compliance.available ||
+    !driving_direction_compliance.available || !traffic_light_compliance.available) {
     result.reason = "unavailable_missing_multiplicative_metric";
     return result;
   }
@@ -122,14 +118,17 @@ EgoProgressResult calculate_ego_progress(
     return result;
   }
   result.raw_progress_m = selected_raw_progress.value();
-  result.multiplicative_mask = no_at_fault_collision * drivable_area_compliance *
-                               driving_direction_compliance * traffic_light_compliance;
+  result.best_raw_progress_m = result.raw_progress_m;
+  result.multiplicative_mask = no_at_fault_collision.score * drivable_area_compliance.score *
+                               driving_direction_compliance.score * traffic_light_compliance.score;
   result.denominator_m = result.raw_progress_m * result.multiplicative_mask;
-  result.best_raw_progress_m = result.denominator_m;
   result.available = true;
 
   constexpr double kProgressDistanceThresholdM = 5.0;
   if (result.denominator_m > kProgressDistanceThresholdM) {
+    // Note: Since we only have a single trajectory candidate in this implementation,
+    // the score simplifies to 1.0 (raw_progress / denominator where denominator = raw_progress * 1.0)
+    // if all multiplicative metrics passed.
     result.score = std::clamp(result.raw_progress_m / result.denominator_m, 0.0, 1.0);
     result.reason = "available_single_proposal_navsim_ratio";
   } else {

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.hpp
@@ -16,6 +16,7 @@
 #define METRICS__EPDMS__SUBSCORES__EGO_PROGRESS_HPP_
 
 #include "data_types.hpp"
+#include "metrics/metric_types.hpp"
 
 #include <autoware/route_handler/route_handler.hpp>
 
@@ -46,11 +47,9 @@ struct EgoProgressResult
 
 EgoProgressResult calculate_ego_progress(
   const std::shared_ptr<Trajectory> & selected_trajectory,
-  const std::shared_ptr<RouteHandler> & route_handler, double no_at_fault_collision,
-  bool no_at_fault_collision_available, double drivable_area_compliance,
-  bool drivable_area_compliance_available, double driving_direction_compliance,
-  bool driving_direction_compliance_available, double traffic_light_compliance,
-  bool traffic_light_compliance_available,
+  const std::shared_ptr<RouteHandler> & route_handler, const MetricScore & no_at_fault_collision,
+  const MetricScore & drivable_area_compliance, const MetricScore & driving_direction_compliance,
+  const MetricScore & traffic_light_compliance,
   const lanelet::ConstLanelets * route_relevant_lanelets = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/subscores/ego_progress.hpp
@@ -19,8 +19,11 @@
 
 #include <autoware/route_handler/route_handler.hpp>
 
+#include <lanelet2_core/primitives/Lanelet.h>
+
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::planning_data_analyzer::metrics
 {
@@ -34,12 +37,21 @@ struct EgoProgressResult
   std::string reason{"unavailable"};
   double raw_progress_m{0.0};
   double best_raw_progress_m{0.0};
+  double multiplicative_mask{0.0};
+  double denominator_m{0.0};
+  geometry_msgs::msg::Point start_point;
+  geometry_msgs::msg::Point end_point;
+  std::vector<geometry_msgs::msg::Point> route_reference_points;
 };
 
 EgoProgressResult calculate_ego_progress(
   const std::shared_ptr<Trajectory> & selected_trajectory,
-  const std::shared_ptr<CandidateTrajectories> & candidate_trajectories,
-  const std::shared_ptr<RouteHandler> & route_handler);
+  const std::shared_ptr<RouteHandler> & route_handler, double no_at_fault_collision,
+  bool no_at_fault_collision_available, double drivable_area_compliance,
+  bool drivable_area_compliance_available, double driving_direction_compliance,
+  bool driving_direction_compliance_available, double traffic_light_compliance,
+  bool traffic_light_compliance_available,
+  const lanelet::ConstLanelets * route_relevant_lanelets = nullptr);
 
 }  // namespace autoware::planning_data_analyzer::metrics
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/metric_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/metric_types.hpp
@@ -24,6 +24,20 @@
 #include <string>
 #include <vector>
 
+namespace autoware::planning_data_analyzer::metrics
+{
+
+/**
+ * @brief Metric score with availability
+ */
+struct MetricScore
+{
+  double score{0.0};
+  bool available{false};
+};
+
+}  // namespace autoware::planning_data_analyzer::metrics
+
 namespace metrics
 {
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -376,11 +376,11 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
   }
 
   const auto ego_progress = calculate_ego_progress(
-    sync_data->trajectory, route_handler, metrics.no_at_fault_collision,
-    metrics.no_at_fault_collision_available, metrics.drivable_area_compliance,
-    metrics.drivable_area_compliance_available, metrics.driving_direction_compliance,
-    metrics.driving_direction_compliance_available, metrics.traffic_light_compliance,
-    metrics.traffic_light_compliance_available,
+    sync_data->trajectory, route_handler,
+    {metrics.no_at_fault_collision, metrics.no_at_fault_collision_available},
+    {metrics.drivable_area_compliance, metrics.drivable_area_compliance_available},
+    {metrics.driving_direction_compliance, metrics.driving_direction_compliance_available},
+    {metrics.traffic_light_compliance, metrics.traffic_light_compliance_available},
     route_relevant_lanelets.empty() ? nullptr : &route_relevant_lanelets);
   metrics.ego_progress = ego_progress.score;
   metrics.ego_progress_available = ego_progress.available;

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.cpp
@@ -16,6 +16,7 @@
 
 #include "metrics/epdms/subscores/drivable_area_compliance.hpp"
 #include "metrics/epdms/subscores/driving_direction_compliance.hpp"
+#include "metrics/epdms/subscores/ego_progress.hpp"
 #include "metrics/epdms/subscores/history_comfort.hpp"
 #include "metrics/epdms/subscores/no_at_fault_collision.hpp"
 #include "metrics/epdms/subscores/traffic_light_compliance.hpp"
@@ -373,6 +374,24 @@ TrajectoryPointMetrics calculate_trajectory_point_metrics(
     metrics.traffic_light_compliance_available = traffic_light_compliance.available;
     metrics.traffic_light_compliance_reason = traffic_light_compliance.reason;
   }
+
+  const auto ego_progress = calculate_ego_progress(
+    sync_data->trajectory, route_handler, metrics.no_at_fault_collision,
+    metrics.no_at_fault_collision_available, metrics.drivable_area_compliance,
+    metrics.drivable_area_compliance_available, metrics.driving_direction_compliance,
+    metrics.driving_direction_compliance_available, metrics.traffic_light_compliance,
+    metrics.traffic_light_compliance_available,
+    route_relevant_lanelets.empty() ? nullptr : &route_relevant_lanelets);
+  metrics.ego_progress = ego_progress.score;
+  metrics.ego_progress_available = ego_progress.available;
+  metrics.ego_progress_reason = ego_progress.reason;
+  metrics.ego_progress_raw_m = ego_progress.raw_progress_m;
+  metrics.ego_progress_best_raw_m = ego_progress.best_raw_progress_m;
+  metrics.ego_progress_mask = ego_progress.multiplicative_mask;
+  metrics.ego_progress_denominator_m = ego_progress.denominator_m;
+  metrics.ego_progress_start_point = ego_progress.start_point;
+  metrics.ego_progress_end_point = ego_progress.end_point;
+  metrics.ego_progress_route_reference_points = ego_progress.route_reference_points;
 
   // Calculate TTC for each point (based on autoware_trajectory_ranker implementation)
   constexpr double max_ttc_value = 10.0;  // Maximum TTC value in seconds

--- a/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/trajectory_metrics.hpp
@@ -17,6 +17,7 @@
 
 #include "data_types.hpp"
 #include "metrics/epdms/subscores/driving_direction_compliance.hpp"
+#include "metrics/epdms/subscores/ego_progress.hpp"
 #include "metrics/epdms/subscores/lane_keeping.hpp"
 #include "metrics/epdms/subscores/traffic_light_compliance.hpp"
 
@@ -71,6 +72,16 @@ struct TrajectoryPointMetrics
   double lane_keeping{0.0};
   bool lane_keeping_available{false};
   std::string lane_keeping_reason{"unavailable"};
+  double ego_progress{0.0};
+  bool ego_progress_available{false};
+  std::string ego_progress_reason{"unavailable"};
+  double ego_progress_raw_m{0.0};
+  double ego_progress_best_raw_m{0.0};
+  double ego_progress_mask{0.0};
+  double ego_progress_denominator_m{0.0};
+  geometry_msgs::msg::Point ego_progress_start_point;
+  geometry_msgs::msg::Point ego_progress_end_point;
+  std::vector<geometry_msgs::msg::Point> ego_progress_route_reference_points;
   double drivable_area_compliance{0.0};
   bool drivable_area_compliance_available{false};
   std::string drivable_area_compliance_reason{"unavailable"};

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -555,16 +555,13 @@ void OpenLoopEvaluator::evaluate(
         metrics.lane_keeping = trajectory_metrics.lane_keeping;
         metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
         metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
-        const auto ego_progress = metrics::calculate_ego_progress(
-          eval_data.synchronized_data ? eval_data.synchronized_data->trajectory : nullptr,
-          eval_data.synchronized_data ? eval_data.synchronized_data->candidate_trajectories
-                                      : nullptr,
-          route_handler_);
-        metrics.ego_progress = ego_progress.score;
-        metrics.ego_progress_available = ego_progress.available;
-        metrics.ego_progress_reason = ego_progress.reason;
-        metrics.ego_progress_raw_m = ego_progress.raw_progress_m;
-        metrics.ego_progress_best_raw_m = ego_progress.best_raw_progress_m;
+        metrics.ego_progress = trajectory_metrics.ego_progress;
+        metrics.ego_progress_available = trajectory_metrics.ego_progress_available;
+        metrics.ego_progress_reason = trajectory_metrics.ego_progress_reason;
+        metrics.ego_progress_raw_m = trajectory_metrics.ego_progress_raw_m;
+        metrics.ego_progress_best_raw_m = trajectory_metrics.ego_progress_best_raw_m;
+        metrics.ego_progress_mask = trajectory_metrics.ego_progress_mask;
+        metrics.ego_progress_denominator_m = trajectory_metrics.ego_progress_denominator_m;
         metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
         metrics.drivable_area_compliance_available =
           trajectory_metrics.drivable_area_compliance_available;
@@ -2167,6 +2164,8 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
     traj["ego_progress_reason"] = m.ego_progress_reason;
     traj["ego_progress_raw_m"] = m.ego_progress_raw_m;
     traj["ego_progress_best_raw_m"] = m.ego_progress_best_raw_m;
+    traj["ego_progress_multiplicative_mask"] = m.ego_progress_mask;
+    traj["ego_progress_denominator_m"] = m.ego_progress_denominator_m;
     traj["drivable_area_compliance"] = m.drivable_area_compliance;
     traj["drivable_area_compliance_available"] = m.drivable_area_compliance_available;
     traj["drivable_area_compliance_reason"] = m.drivable_area_compliance_reason;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -90,6 +90,8 @@ struct OpenLoopTrajectoryMetrics
   std::string ego_progress_reason{"unavailable"};
   double ego_progress_raw_m{0.0};
   double ego_progress_best_raw_m{0.0};
+  double ego_progress_mask{0.0};
+  double ego_progress_denominator_m{0.0};
   double drivable_area_compliance{0.0};  // Binary drivable area compliance subscore
   bool drivable_area_compliance_available{false};
   std::string drivable_area_compliance_reason{"unavailable"};

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_ego_progress.cpp
@@ -21,7 +21,7 @@
 TEST(EgoProgressTest, ReturnsUnavailableWhenSelectedTrajectoryIsMissing)
 {
   const auto result = autoware::planning_data_analyzer::metrics::calculate_ego_progress(
-    nullptr, nullptr, 1.0, true, 1.0, true, 1.0, true, 1.0, true);
+    nullptr, nullptr, {1.0, true}, {1.0, true}, {1.0, true}, {1.0, true});
 
   EXPECT_FALSE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
@@ -35,7 +35,7 @@ TEST(EgoProgressTest, ReturnsUnavailableWhenRouteHandlerIsMissing)
   trajectory->points.resize(2);
 
   const auto result = autoware::planning_data_analyzer::metrics::calculate_ego_progress(
-    trajectory, nullptr, 1.0, true, 1.0, true, 1.0, true, 1.0, true);
+    trajectory, nullptr, {1.0, true}, {1.0, true}, {1.0, true}, {1.0, true});
 
   EXPECT_FALSE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_ego_progress.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_ego_progress.cpp
@@ -20,8 +20,8 @@
 
 TEST(EgoProgressTest, ReturnsUnavailableWhenSelectedTrajectoryIsMissing)
 {
-  const auto result =
-    autoware::planning_data_analyzer::metrics::calculate_ego_progress(nullptr, nullptr, nullptr);
+  const auto result = autoware::planning_data_analyzer::metrics::calculate_ego_progress(
+    nullptr, nullptr, 1.0, true, 1.0, true, 1.0, true, 1.0, true);
 
   EXPECT_FALSE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);
@@ -34,8 +34,8 @@ TEST(EgoProgressTest, ReturnsUnavailableWhenRouteHandlerIsMissing)
   trajectory->header.frame_id = "map";
   trajectory->points.resize(2);
 
-  const auto result =
-    autoware::planning_data_analyzer::metrics::calculate_ego_progress(trajectory, nullptr, nullptr);
+  const auto result = autoware::planning_data_analyzer::metrics::calculate_ego_progress(
+    trajectory, nullptr, 1.0, true, 1.0, true, 1.0, true, 1.0, true);
 
   EXPECT_FALSE(result.available);
   EXPECT_DOUBLE_EQ(result.score, 0.0);


### PR DESCRIPTION
This is the EP score PR in the EPDMS patch series.

## Scope
Migrate EP to the NAVSIM-style single selected trajectory progress calculation. Multi-candidate proposal-batch EP is left as a documented follow-up.

## Logic change
As-is pipeline:
selected trajectory + candidate trajectories -> selected-candidate matching -> best candidate progress ratio -> EP

To-be pipeline:
selected trajectory -> route-relative raw progress -> multiplicative NC/DAC/DDC/TLC mask -> masked denominator -> single-proposal NAVSIM-style EP

## Validation
- Takanawa cumulative run through EP: `/home/beomseokkim2/rosbag/x2_takanawa/run_logs/20260521_200556` was compared, then deleted after recording the summary.
- Evaluated trajectories: `8695`
- EP matched the reference baseline score: `0` non-1, `0` unavailable, changed timestamps `0`
- EP reason counts shifted only because of the accepted NC de-dup delta: fallback `5659 -> 5672`, ratio `3036 -> 3023`