### PR TITLE
feat(planning_data_analyzer): update EPDMS aggregation filter

### DIFF
--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.cpp
@@ -23,6 +23,7 @@ namespace
 {
 
 constexpr double kHumanFilterZeroEpsilon = 1.0e-9;
+constexpr double kSyntheticWeightedDenominator = 16.0;
 
 double apply_human_filter(
   const double agent_value, const bool agent_available, const double human_value,
@@ -40,6 +41,23 @@ void populate_human_filter_metric(
   metric.human_reference_available = human_available;
   metric.filtered = apply_human_filter(
     agent_value, agent_available, human_value, human_available, metric.filter_applied);
+}
+
+double calculate_multiplicative_metrics_prod(
+  const double no_at_fault_collision, const double drivable_area_compliance,
+  const double driving_direction_compliance, const double traffic_light_compliance)
+{
+  return no_at_fault_collision * drivable_area_compliance * driving_direction_compliance *
+         traffic_light_compliance;
+}
+
+double calculate_weighted_metrics(
+  const double ego_progress, const double time_to_collision_within_bound, const double lane_keeping,
+  const double history_comfort, const double extended_comfort)
+{
+  return (5.0 * ego_progress + 5.0 * time_to_collision_within_bound + 2.0 * lane_keeping +
+          2.0 * history_comfort + 2.0 * extended_comfort) /
+         kSyntheticWeightedDenominator;
 }
 
 }  // namespace
@@ -100,7 +118,6 @@ SyntheticEpdmsMetrics calculate_synthetic_epdms(
   const EpdmsMetricSnapshot & agent_metrics, const HumanFilterMetrics & human_filter_metrics)
 {
   SyntheticEpdmsMetrics result;
-  constexpr double kSyntheticWeightedDenominator = 16.0;
 
   const bool raw_multiplicative_available = agent_metrics.no_at_fault_collision_available &&
                                             agent_metrics.drivable_area_compliance_available &&
@@ -113,14 +130,12 @@ SyntheticEpdmsMetrics calculate_synthetic_epdms(
                                       agent_metrics.extended_comfort_available;
   result.raw.available = raw_multiplicative_available && raw_weighted_available;
   if (result.raw.available) {
-    result.raw.multiplicative_metrics_prod =
-      agent_metrics.no_at_fault_collision * agent_metrics.drivable_area_compliance *
-      agent_metrics.driving_direction_compliance * agent_metrics.traffic_light_compliance;
-    result.raw.weighted_metrics =
-      (5.0 * agent_metrics.ego_progress + 5.0 * agent_metrics.time_to_collision_within_bound +
-       2.0 * agent_metrics.lane_keeping + 2.0 * agent_metrics.history_comfort +
-       2.0 * agent_metrics.extended_comfort) /
-      kSyntheticWeightedDenominator;
+    result.raw.multiplicative_metrics_prod = calculate_multiplicative_metrics_prod(
+      agent_metrics.no_at_fault_collision, agent_metrics.drivable_area_compliance,
+      agent_metrics.driving_direction_compliance, agent_metrics.traffic_light_compliance);
+    result.raw.weighted_metrics = calculate_weighted_metrics(
+      agent_metrics.ego_progress, agent_metrics.time_to_collision_within_bound,
+      agent_metrics.lane_keeping, agent_metrics.history_comfort, agent_metrics.extended_comfort);
     result.raw.epdms = result.raw.multiplicative_metrics_prod * result.raw.weighted_metrics;
   }
 
@@ -137,20 +152,16 @@ SyntheticEpdmsMetrics calculate_synthetic_epdms(
   result.human_filtered.available =
     human_filtered_multiplicative_available && human_filtered_weighted_available;
   if (result.human_filtered.available) {
-    result.human_filtered.multiplicative_metrics_prod =
-      human_filter_metrics.no_at_fault_collision.filtered *
-      human_filter_metrics.drivable_area_compliance.filtered *
-      human_filter_metrics.driving_direction_compliance.filtered *
-      human_filter_metrics.traffic_light_compliance.filtered;
-    const double filtered_ego_progress =
-      human_filter_metrics.ego_progress.filter_applied ? 1.0 : agent_metrics.ego_progress;
-    result.human_filtered.weighted_metrics =
-      (5.0 * filtered_ego_progress +
-       5.0 * human_filter_metrics.time_to_collision_within_bound.filtered +
-       2.0 * human_filter_metrics.lane_keeping.filtered +
-       2.0 * human_filter_metrics.history_comfort.filtered +
-       2.0 * human_filter_metrics.extended_comfort.filtered) /
-      kSyntheticWeightedDenominator;
+    result.human_filtered.multiplicative_metrics_prod = calculate_multiplicative_metrics_prod(
+      human_filter_metrics.no_at_fault_collision.filtered,
+      human_filter_metrics.drivable_area_compliance.filtered,
+      human_filter_metrics.driving_direction_compliance.filtered,
+      human_filter_metrics.traffic_light_compliance.filtered);
+    result.human_filtered.weighted_metrics = calculate_weighted_metrics(
+      human_filter_metrics.ego_progress.filtered,
+      human_filter_metrics.time_to_collision_within_bound.filtered,
+      human_filter_metrics.lane_keeping.filtered, human_filter_metrics.history_comfort.filtered,
+      agent_metrics.extended_comfort);
     result.human_filtered.epdms =
       result.human_filtered.multiplicative_metrics_prod * result.human_filtered.weighted_metrics;
   }

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.cpp
@@ -152,6 +152,7 @@ SyntheticEpdmsMetrics calculate_synthetic_epdms(
       human_filter_metrics.drivable_area_compliance.filtered,
       human_filter_metrics.driving_direction_compliance.filtered,
       human_filter_metrics.traffic_light_compliance.filtered);
+    // EC bypasses the human filter by design in the NAVSIM-faithful synthetic score.
     result.human_filtered.weighted_metrics = calculate_weighted_metrics(
       human_filter_metrics.ego_progress.filtered,
       human_filter_metrics.time_to_collision_within_bound.filtered,

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.cpp
@@ -72,11 +72,6 @@ HumanFilterMetrics calculate_human_filter_metrics(
     human_metrics.history_comfort, human_metrics.history_comfort_available);
 
   populate_human_filter_metric(
-    result.extended_comfort, agent_metrics.extended_comfort,
-    agent_metrics.extended_comfort_available, human_metrics.extended_comfort,
-    human_metrics.extended_comfort_available);
-
-  populate_human_filter_metric(
     result.ego_progress, agent_metrics.ego_progress, agent_metrics.ego_progress_available,
     human_metrics.ego_progress, human_metrics.ego_progress_available);
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/epdms/aggregation/epdms_aggregation.hpp
@@ -61,7 +61,6 @@ struct HumanFilterMetrics
   };
 
   Metric history_comfort;
-  Metric extended_comfort;
   Metric ego_progress;
   Metric time_to_collision_within_bound;
   Metric lane_keeping;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -1897,9 +1897,6 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
   std::vector<double> human_history_comfort_values;
   std::vector<double> filtered_history_comfort_values;
   std::size_t history_comfort_filter_applied_count = 0;
-  std::vector<double> human_extended_comfort_values;
-  std::vector<double> filtered_extended_comfort_values;
-  std::size_t extended_comfort_filter_applied_count = 0;
   std::vector<double> human_ego_progress_values;
   std::vector<double> filtered_ego_progress_values;
   std::size_t ego_progress_filter_applied_count = 0;
@@ -1928,12 +1925,6 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
     }
     history_comfort_filter_applied_count +=
       static_cast<std::size_t>(m.history_comfort.filter_applied);
-    if (m.extended_comfort.human_reference_available) {
-      human_extended_comfort_values.push_back(m.extended_comfort.human_reference);
-      filtered_extended_comfort_values.push_back(m.extended_comfort.filtered);
-    }
-    extended_comfort_filter_applied_count +=
-      static_cast<std::size_t>(m.extended_comfort.filter_applied);
     if (m.ego_progress.human_reference_available) {
       human_ego_progress_values.push_back(m.ego_progress.human_reference);
       filtered_ego_progress_values.push_back(m.ego_progress.filtered);
@@ -1975,9 +1966,6 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
   emit_human_filter_metric(
     "history_comfort", "history comfort subscore", human_history_comfort_values,
     filtered_history_comfort_values, history_comfort_filter_applied_count);
-  emit_human_filter_metric(
-    "extended_comfort", "extended comfort subscore", human_extended_comfort_values,
-    filtered_extended_comfort_values, extended_comfort_filter_applied_count);
   emit_human_filter_metric(
     "ego_progress", "ego progress subscore", human_ego_progress_values,
     filtered_ego_progress_values, ego_progress_filter_applied_count);
@@ -2186,9 +2174,6 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
       traj["human_reference"]["history_comfort"] = hf.history_comfort.human_reference;
       traj["human_reference"]["history_comfort_available"] =
         hf.history_comfort.human_reference_available;
-      traj["human_reference"]["extended_comfort"] = hf.extended_comfort.human_reference;
-      traj["human_reference"]["extended_comfort_available"] =
-        hf.extended_comfort.human_reference_available;
       traj["human_reference"]["ego_progress"] = hf.ego_progress.human_reference;
       traj["human_reference"]["ego_progress_available"] = hf.ego_progress.human_reference_available;
       traj["human_reference"]["time_to_collision_within_bound"] =
@@ -2215,9 +2200,6 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
 
       traj["human_filtered"]["history_comfort"] = hf.history_comfort.filtered;
       traj["human_filtered"]["history_comfort_filter_applied"] = hf.history_comfort.filter_applied;
-      traj["human_filtered"]["extended_comfort"] = hf.extended_comfort.filtered;
-      traj["human_filtered"]["extended_comfort_filter_applied"] =
-        hf.extended_comfort.filter_applied;
       traj["human_filtered"]["ego_progress"] = hf.ego_progress.filtered;
       traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress.filter_applied;
       traj["human_filtered"]["time_to_collision_within_bound"] =

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
@@ -34,23 +34,6 @@ TEST(EpdmsAggregationTest, HumanFilterPromotesAgentMetricToOneWhenHumanIsZero)
   EXPECT_DOUBLE_EQ(result.history_comfort.filtered, 1.0);
 }
 
-TEST(EpdmsAggregationTest, HumanFilterDoesNotPopulateExtendedComfort)
-{
-  EpdmsMetricSnapshot agent;
-  agent.extended_comfort = 0.25;
-  agent.extended_comfort_available = true;
-
-  EpdmsMetricSnapshot human;
-  human.extended_comfort = 0.0;
-  human.extended_comfort_available = true;
-
-  const auto result = calculate_human_filter_metrics(agent, human);
-  EXPECT_DOUBLE_EQ(result.extended_comfort.human_reference, 0.0);
-  EXPECT_FALSE(result.extended_comfort.human_reference_available);
-  EXPECT_DOUBLE_EQ(result.extended_comfort.filtered, 0.0);
-  EXPECT_FALSE(result.extended_comfort.filter_applied);
-}
-
 TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
 {
   EpdmsMetricSnapshot agent;
@@ -94,7 +77,7 @@ TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
   EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 0.90625);
 }
 
-TEST(EpdmsAggregationTest, HumanFilteredAggregationFiltersProgressButNotExtendedComfort)
+TEST(EpdmsAggregationTest, HumanFilteredAggregationUsesRawExtendedComfort)
 {
   EpdmsMetricSnapshot agent;
   agent.history_comfort = 0.5;
@@ -105,7 +88,7 @@ TEST(EpdmsAggregationTest, HumanFilteredAggregationFiltersProgressButNotExtended
   agent.time_to_collision_within_bound_available = true;
   agent.lane_keeping = 1.0;
   agent.lane_keeping_available = true;
-  agent.extended_comfort = 0.0;
+  agent.extended_comfort = 0.5;
   agent.extended_comfort_available = true;
   agent.no_at_fault_collision = 1.0;
   agent.no_at_fault_collision_available = true;
@@ -130,8 +113,8 @@ TEST(EpdmsAggregationTest, HumanFilteredAggregationFiltersProgressButNotExtended
   const auto result = calculate_synthetic_epdms(agent, filter);
   EXPECT_TRUE(result.human_filtered.available);
   EXPECT_DOUBLE_EQ(result.human_filtered.multiplicative_metrics_prod, 1.0);
-  EXPECT_DOUBLE_EQ(result.human_filtered.weighted_metrics, 0.8125);
-  EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 0.8125);
+  EXPECT_DOUBLE_EQ(result.human_filtered.weighted_metrics, 0.875);
+  EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 0.875);
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
@@ -34,6 +34,23 @@ TEST(EpdmsAggregationTest, HumanFilterPromotesAgentMetricToOneWhenHumanIsZero)
   EXPECT_DOUBLE_EQ(result.history_comfort.filtered, 1.0);
 }
 
+TEST(EpdmsAggregationTest, HumanFilterDoesNotPopulateExtendedComfort)
+{
+  EpdmsMetricSnapshot agent;
+  agent.extended_comfort = 0.25;
+  agent.extended_comfort_available = true;
+
+  EpdmsMetricSnapshot human;
+  human.extended_comfort = 0.0;
+  human.extended_comfort_available = true;
+
+  const auto result = calculate_human_filter_metrics(agent, human);
+  EXPECT_DOUBLE_EQ(result.extended_comfort.human_reference, 0.0);
+  EXPECT_FALSE(result.extended_comfort.human_reference_available);
+  EXPECT_DOUBLE_EQ(result.extended_comfort.filtered, 0.0);
+  EXPECT_FALSE(result.extended_comfort.filter_applied);
+}
+
 TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
 {
   EpdmsMetricSnapshot agent;
@@ -57,7 +74,6 @@ TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
   agent.traffic_light_compliance_available = true;
 
   HumanFilterMetrics filter;
-  filter.extended_comfort.filtered = 1.0;
   filter.ego_progress.filtered = 1.0;
   filter.history_comfort.filtered = 1.0;
   filter.time_to_collision_within_bound.filtered = 1.0;
@@ -106,8 +122,6 @@ TEST(EpdmsAggregationTest, HumanFilteredAggregationFiltersProgressButNotExtended
   filter.ego_progress.filter_applied = true;
   filter.time_to_collision_within_bound.filtered = 1.0;
   filter.lane_keeping.filtered = 1.0;
-  filter.extended_comfort.filtered = 1.0;
-  filter.extended_comfort.filter_applied = true;
   filter.no_at_fault_collision.filtered = 1.0;
   filter.drivable_area_compliance.filtered = 1.0;
   filter.driving_direction_compliance.filtered = 1.0;

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_epdms_aggregation.cpp
@@ -58,6 +58,7 @@ TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
 
   HumanFilterMetrics filter;
   filter.extended_comfort.filtered = 1.0;
+  filter.ego_progress.filtered = 1.0;
   filter.history_comfort.filtered = 1.0;
   filter.time_to_collision_within_bound.filtered = 1.0;
   filter.lane_keeping.filtered = 1.0;
@@ -73,8 +74,50 @@ TEST(EpdmsAggregationTest, SyntheticEpdmsUsesFirstStageMetricGroups)
   EXPECT_DOUBLE_EQ(result.raw.epdms, 0.3515625);
   EXPECT_TRUE(result.human_filtered.available);
   EXPECT_DOUBLE_EQ(result.human_filtered.multiplicative_metrics_prod, 1.0);
-  EXPECT_DOUBLE_EQ(result.human_filtered.weighted_metrics, 1.0);
-  EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 1.0);
+  EXPECT_DOUBLE_EQ(result.human_filtered.weighted_metrics, 0.90625);
+  EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 0.90625);
+}
+
+TEST(EpdmsAggregationTest, HumanFilteredAggregationFiltersProgressButNotExtendedComfort)
+{
+  EpdmsMetricSnapshot agent;
+  agent.history_comfort = 0.5;
+  agent.history_comfort_available = true;
+  agent.ego_progress = 0.0;
+  agent.ego_progress_available = true;
+  agent.time_to_collision_within_bound = 1.0;
+  agent.time_to_collision_within_bound_available = true;
+  agent.lane_keeping = 1.0;
+  agent.lane_keeping_available = true;
+  agent.extended_comfort = 0.0;
+  agent.extended_comfort_available = true;
+  agent.no_at_fault_collision = 1.0;
+  agent.no_at_fault_collision_available = true;
+  agent.drivable_area_compliance = 1.0;
+  agent.drivable_area_compliance_available = true;
+  agent.driving_direction_compliance = 1.0;
+  agent.driving_direction_compliance_available = true;
+  agent.traffic_light_compliance = 1.0;
+  agent.traffic_light_compliance_available = true;
+
+  HumanFilterMetrics filter;
+  filter.history_comfort.filtered = 0.5;
+  filter.ego_progress.filtered = 1.0;
+  filter.ego_progress.filter_applied = true;
+  filter.time_to_collision_within_bound.filtered = 1.0;
+  filter.lane_keeping.filtered = 1.0;
+  filter.extended_comfort.filtered = 1.0;
+  filter.extended_comfort.filter_applied = true;
+  filter.no_at_fault_collision.filtered = 1.0;
+  filter.drivable_area_compliance.filtered = 1.0;
+  filter.driving_direction_compliance.filtered = 1.0;
+  filter.traffic_light_compliance.filtered = 1.0;
+
+  const auto result = calculate_synthetic_epdms(agent, filter);
+  EXPECT_TRUE(result.human_filtered.available);
+  EXPECT_DOUBLE_EQ(result.human_filtered.multiplicative_metrics_prod, 1.0);
+  EXPECT_DOUBLE_EQ(result.human_filtered.weighted_metrics, 0.8125);
+  EXPECT_DOUBLE_EQ(result.human_filtered.epdms, 0.8125);
 }
 
 }  // namespace autoware::planning_data_analyzer::metrics


### PR DESCRIPTION
## Description
This PR updates the EPDMS aggregation path to match the NAVSIM-faithful human-filter behavior for the migrated scores.

### Changes:
- Keep EP in the human-filtered synthetic score.
- Do not human-filter EC.
- Factor the shared synthetic aggregation formulas to reduce duplication.

## Validation
- Full Takanawa run:
  - Inference time: elapsed_sec=192.75
  - Analyzer time: elapsed_sec=197.93
