### PR TITLE
feat(planning_data_analyzer): filtering the `lateral_deviation_centerline` by `intersection_area`

### DIFF
--- a/planning/autoware_planning_data_analyzer/CMakeLists.txt
+++ b/planning/autoware_planning_data_analyzer/CMakeLists.txt
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_planning_data_analyzer)
 
 find_package(autoware_cmake REQUIRED)
+find_package(yaml-cpp REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/buffer.cpp
   src/base_evaluator.cpp
   src/open_loop_evaluator.cpp
+  src/metrics/evaluator/evaluator.cpp
   src/metrics/deviation_metrics.cpp
   src/metrics/geometry/comfort_signal.cpp
   src/metrics/geometry/ego_footprint.cpp
@@ -38,6 +40,8 @@ target_include_directories(${PROJECT_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
+
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::planning_data_analyzer::AutowarePlanningDataAnalyzerNode"
   EXECUTABLE autoware_planning_data_analyzer_node
@@ -58,6 +62,7 @@ if(BUILD_TESTING)
     test/metrics/test_ttc_within_bound.cpp
     test/metrics/test_no_at_fault_collision.cpp
     test/metrics/test_traffic_light_compliance.cpp
+    test/metrics/test_evaluator_metrics.cpp
     test/utils/test_override_windows.cpp
   )
 

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -21,7 +21,7 @@ For each evaluated trajectory, the following are computed:
 - TTC trace
 - per-horizon metrics (full, and configured horizons such as 1.0s, 2.0s, 4.0s, 8.0s)
 
-### Plnnaing Quality Score (EPDMS)
+### Planning Quality Score (EPDMS)
 
 To show multi-facet (comfort, progress, safety) quality of generated trajectory, EPDMS (Extended Predictive Driver Model Score) is computed based on the multiple subscores.
 
@@ -46,39 +46,61 @@ EPDMS is obtained from combining the following subscores:
 - driving_direction_compliance
 - traffic_light_compliance
 
-These subscores are exported both as per-trajectory outputs and as aggregate statistics.
+### Evaluator Metrics (bag-recorded scalars)
+
+The analyzer reads scalar metric topics from the input rosbag according to **[config/evaluator_config.yaml](config/evaluator_config.yaml)** (e.g. `control_evaluator`, `planning_evaluator`).
+Output is written to **`evaluator_metric.json`** (separate from trajectory metrics).
+If no configured topic has valid measurements, the file is not written.
+
+The package default `config/evaluator_config.yaml` is used automatically.
+Override only when needed: launch arg `evaluator_config_file`, or `-p open_loop.evaluator_config_path:=/path/to.yaml`.
+
+When a single `evaluator_config` entry is configured, keys are flat at the top level (e.g. `all/<metric_key>/mean`).
+Multiple entries are nested under each YAML `name`.
+
+Aggregation views (per metric key):
+
+- `all/<metric_key>/` — all odometry-synced measurements from the rosbag
+- `included/<metric_key>/` — measurements not matching **any** exclusion rule
+- `excluded/<rule_name>/<metric_key>/` — measurements matching that rule
+
+Each view exports `count`, `mean`, `min`, `max`, `percentile_95`, `percentile_99`, and per-metric
+`description` (aggregates of evaluator values recorded in the evaluation rosbag).
+
+Supported exclusion rules: `intersection_area` (ego pose inside vector-map `intersection_area` polygon)
+
+Odometry samples within 2 m of the first pose (pre-departure waiting) are excluded from aggregation.
 
 ## Quick Start
 
 ### Open Loop Evaluation
 
 ```sh
-ros2 run autoware_planning_data_analyzer autoware_planning_data_analyzer_node --ros-args \
-  -p bag_path:=~/my_bag \
-  -p evaluation.mode:=open_loop \
-  -p trajectory_topic:=/planning/trajectory \
-  -p json_output_path:=~/results.json
+ros2 launch autoware_planning_data_analyzer planning_data_analyzer.launch.xml \
+  bag_path:=$HOME/test_bag.mcap \
+  output_dir:=$HOME/planning_analyzer_output
 ```
 
 ## Output Files
 
-- **`evaluation_result.json`** - Detailed metrics (ADE, FDE, TTC, etc.) and summary statistics
-- **`evaluation_output.bag/`** - Evaluation metrics as rosbag for visualization
-- **`debug_images/*.png`** - Trajectory visualization (with `--viz` flag)
+- `time_step_based_trajectory_metric.json` — open-loop trajectory aggregate metrics
+- `time_step_based_trajectory_result.jsonl` — per-trajectory DLR-style results
+- `time_step_based_trajectory_detailed_result.json` — full per-trajectory dump
+- `evaluator_metric.json` — evaluator metric aggregates per `evaluator_config` (if bag contains configured topics)
 
 ## Parameters
 
 Key parameters in `config/planning_data_analyzer.param.yaml`:
 
-- `evaluation.mode`: Evaluation mode (`open_loop`)
-- `evaluation_interval_ms`: Sampling interval (default: 100ms)
-- `sync_tolerance_ms`: Time synchronization tolerance (default: 100ms)
-- `trajectory_topic`: Trajectory topic to evaluate
-- `open_loop.*`: Open-loop specific settings
+- `evaluation.mode`: `open_loop`
+- `evaluation_interval_ms`: odometry sampling interval (default 100 ms)
+- `sync_tolerance_ms`: evaluator/trajectory topic sync tolerance (default 100 ms)
+- `open_loop.evaluator_config_path`: path to evaluator metric groups YAML (`name`, `topics`,
+  `exclusion.rules`); launch arg `evaluator_config_file` sets this (package default if omitted)
 
 ---
 
 ## For More Information
 
-- Configuration: [config/planning_data_analyzer.param.yaml](config/planning_data_analyzer.param.yaml)
+- Configuration: [config/planning_data_analyzer.param.yaml](config/planning_data_analyzer.param.yaml), [config/evaluator_config.yaml](config/evaluator_config.yaml)
 - Launch files: [launch/](launch/)

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -46,30 +46,14 @@ EPDMS is obtained from combining the following subscores:
 - driving_direction_compliance
 - traffic_light_compliance
 
+These subscores are exported both as per-trajectory outputs and as aggregate statistics.
+
 ### Evaluator Metrics (bag-recorded scalars)
 
-The analyzer reads scalar metric topics from the input rosbag according to **[config/evaluator_config.yaml](config/evaluator_config.yaml)** (e.g. `control_evaluator`, `planning_evaluator`).
-Output is written to **`evaluator_metric.json`** (separate from trajectory metrics).
-If no configured topic has valid measurements, the file is not written.
+`config/evaluator_config.yaml`で指定された topic を excepsion rule に従ってフィルターした結果を集計します。
 
-The package default `config/evaluator_config.yaml` is used automatically.
-Override only when needed: launch arg `evaluator_config_file`, or `-p open_loop.evaluator_config_path:=/path/to.yaml`.
-
-When a single `evaluator_config` entry is configured, keys are flat at the top level (e.g. `all/<metric_key>/mean`).
-Multiple entries are nested under each YAML `name`.
-
-Aggregation views (per metric key):
-
-- `all/<metric_key>/` — all odometry-synced measurements from the rosbag
-- `included/<metric_key>/` — measurements not matching **any** exclusion rule
-- `excluded/<rule_name>/<metric_key>/` — measurements matching that rule
-
-Each view exports `count`, `mean`, `min`, `max`, `percentile_95`, `percentile_99`, and per-metric
-`description` (aggregates of evaluator values recorded in the evaluation rosbag).
-
-Supported exclusion rules: `intersection_area` (ego pose inside vector-map `intersection_area` polygon)
-
-Odometry samples within 2 m of the first pose (pre-departure waiting) are excluded from aggregation.
+- lateral_deviation_centerline
+  - for excluded `intersection_area`
 
 ## Quick Start
 

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -50,7 +50,7 @@ These subscores are exported both as per-trajectory outputs and as aggregate sta
 
 ### Evaluator Metrics (bag-recorded scalars)
 
-`config/evaluator_config.yaml`で指定された topic を excepsion rule に従ってフィルターした結果を集計します。
+It aggregates the results of filtering the topics specified in `config/evaluator_config.yaml` according to the exception rules.
 
 - lateral_deviation_centerline
   - for excluded `intersection_area`

--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -60,27 +60,29 @@ These subscores are exported both as per-trajectory outputs and as aggregate sta
 ### Open Loop Evaluation
 
 ```sh
-ros2 launch autoware_planning_data_analyzer planning_data_analyzer.launch.xml \
-  bag_path:=$HOME/test_bag.mcap \
-  output_dir:=$HOME/planning_analyzer_output
+ros2 run autoware_planning_data_analyzer autoware_planning_data_analyzer_node --ros-args \
+  -p bag_path:=~/my_bag \
+  -p evaluation.mode:=open_loop \
+  -p trajectory_topic:=/planning/trajectory \
+  -p json_output_path:=~/results.json
 ```
 
 ## Output Files
 
-- `time_step_based_trajectory_metric.json` — open-loop trajectory aggregate metrics
-- `time_step_based_trajectory_result.jsonl` — per-trajectory DLR-style results
-- `time_step_based_trajectory_detailed_result.json` — full per-trajectory dump
-- `evaluator_metric.json` — evaluator metric aggregates per `evaluator_config` (if bag contains configured topics)
+- **`evaluation_result.json`** - Detailed metrics (ADE, FDE, TTC, etc.) and summary statistics
+- **`evaluation_output.bag/`** - Evaluation metrics as rosbag for visualization
+- **`debug_images/*.png`** - Trajectory visualization (with `--viz` flag)
+- **evaluator_metric.json** — evaluator metric aggregates per `evaluator_config` (if bag contains configured topics)
 
 ## Parameters
 
 Key parameters in `config/planning_data_analyzer.param.yaml`:
 
-- `evaluation.mode`: `open_loop`
-- `evaluation_interval_ms`: odometry sampling interval (default 100 ms)
-- `sync_tolerance_ms`: evaluator/trajectory topic sync tolerance (default 100 ms)
-- `open_loop.evaluator_config_path`: path to evaluator metric groups YAML (`name`, `topics`,
-  `exclusion.rules`); launch arg `evaluator_config_file` sets this (package default if omitted)
+- `evaluation.mode`: Evaluation mode (`open_loop`)
+- `evaluation_interval_ms`: Sampling interval (default: 100ms)
+- `sync_tolerance_ms`: Time synchronization tolerance (default: 100ms)
+- `trajectory_topic`: Trajectory topic to evaluate
+- `open_loop.*`: Open-loop specific settings
 
 ---
 

--- a/planning/autoware_planning_data_analyzer/config/evaluator_config.yaml
+++ b/planning/autoware_planning_data_analyzer/config/evaluator_config.yaml
@@ -1,0 +1,9 @@
+# Evaluator metric for open_loop analysis (control_evaluator, planning_evaluator, etc.).
+evaluator_config:
+  - name: lateral_deviation_centerline
+    topics:
+      - /control/control_evaluator/metrics/lateral_deviation_centerline
+      - /control/control_evaluator/metrics/lateral_deviation_centerline_abs
+    exclusion:
+      rules:
+        - intersection_area

--- a/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
+++ b/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="bag_path" description="Path to rosbag file or directory"/>
   <arg name="config_file" default="$(find-pkg-share autoware_planning_data_analyzer)/config/planning_data_analyzer.param.yaml" description="Path to parameter file"/>
+  <arg name="evaluator_config_file" default="$(find-pkg-share autoware_planning_data_analyzer)/config/evaluator_config.yaml" description="Path to control evaluator metric groups YAML"/>
   <arg name="vehicle_model" default="" description="Vehicle model name"/>
   <arg name="output_dir" description="Output directory for evaluation results (overrides config file if specified)"/>
   <arg name="trajectory_topic" default="/planning/trajectory" description="Trajectory topic to evaluate"/>
@@ -20,6 +21,7 @@
       <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
+      <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>
 
@@ -33,6 +35,7 @@
       <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
+      <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>
 </launch>

--- a/planning/autoware_planning_data_analyzer/package.xml
+++ b/planning/autoware_planning_data_analyzer/package.xml
@@ -40,7 +40,9 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>tier4_simulation_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>yaml-cpp</depend>
 
   <exec_depend>autoware_global_parameter_loader</exec_depend>
 

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -531,6 +531,10 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       evaluator.set_evaluation_horizons(evaluation_horizons);
       evaluator.set_extended_comfort_parameters(extended_comfort_parameters_);
       evaluator.set_override_window_sec(override_window_sec_);
+
+      const auto evaluator_configs = metrics::evaluator::load_evaluator_configs(*this);
+      evaluator.set_evaluator_configs(evaluator_configs);
+
       auto times =
         evaluator.run_evaluation_from_bag(bag_path_, evaluation_bag_writer_.get(), topic_names);
       start_time = times.first;

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.cpp
@@ -14,6 +14,7 @@
 
 #include "base_evaluator.hpp"
 
+#include "metrics/evaluator/evaluator.hpp"
 #include "metrics/trajectory_metrics.hpp"
 #include "serialized_bag_message.hpp"
 
@@ -27,13 +28,15 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::planning_data_analyzer
 {
 
 BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
   const std::string & bag_path, rosbag2_cpp::Writer * /*evaluation_bag_writer*/,
-  const TopicNames & topic_names)
+  const TopicNames & topic_names,
+  const std::vector<metrics::evaluator::EvaluatorConfig> & evaluator_configs)
 {
   // Open bag reader
   rosbag2_cpp::Reader bag_reader;
@@ -47,6 +50,7 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
 
   // Result to return
   BagProcessingResult result;
+  const auto evaluator_topics = metrics::evaluator::collect_evaluator_topics(evaluator_configs);
 
   // Find the time range of the bag
   rclcpp::Time bag_start_time = rclcpp::Time(std::numeric_limits<int64_t>::max());
@@ -132,6 +136,12 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
       } catch (const std::exception & e) {
         RCLCPP_WARN(logger_, "Failed to deserialize control_mode message: %s", e.what());
       }
+    } else if (
+      // evaluator metric topics
+      !evaluator_topics.empty() && metrics::evaluator::try_append_evaluator_metric_message(
+                                     topic_name, serialized_message, evaluator_topics,
+                                     result.evaluator_metric_values_by_topic, logger_)) {
+      continue;
     }
   }
 
@@ -187,6 +197,13 @@ BaseEvaluator::BagProcessingResult BaseEvaluator::process_bag_common(
   } else {
     result.evaluation_start_time = bag_start_time;
     result.evaluation_end_time = bag_end_time;
+  }
+
+  // Build evaluator metric groups
+  if (!evaluator_configs.empty()) {
+    result.evaluator_metric_groups = metrics::evaluator::build_evaluator_metric_groups(
+      evaluator_configs, result.evaluator_metric_values_by_topic, kinematic_states, route_handler_,
+      topic_names.sync_tolerance_ms, logger_);
   }
 
   return result;

--- a/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/base_evaluator.hpp
@@ -16,6 +16,7 @@
 #define BASE_EVALUATOR_HPP_
 
 #include "bag_handler.hpp"
+#include "metrics/evaluator/evaluator.hpp"
 #include "metrics/trajectory_metrics.hpp"
 #include "utils/override_windows.hpp"
 
@@ -24,6 +25,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rosbag2_cpp/reader.hpp>
 #include <rosbag2_cpp/writer.hpp>
+#include <rosbag2_storage/serialized_bag_message.hpp>
 #include <rosbag2_storage/topic_metadata.hpp>
 
 #include <tf2_msgs/msg/tf_message.hpp>
@@ -32,6 +34,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -156,11 +159,15 @@ protected:
     // captured as (timestamp_ns, mode) tuples. Used to detect override
     // windows (AUTONOMOUS -> MANUAL transitions).
     std::vector<utils::ControlModeEvent> control_mode_events;
+    std::map<std::string, std::vector<metrics::evaluator::TimestampedDouble>>
+      evaluator_metric_values_by_topic;
+    std::vector<metrics::evaluator::EvaluatorMetricGroup> evaluator_metric_groups;
   };
 
   BagProcessingResult process_bag_common(
     const std::string & bag_path, rosbag2_cpp::Writer * evaluation_bag_writer,
-    const TopicNames & topic_names);
+    const TopicNames & topic_names,
+    const std::vector<metrics::evaluator::EvaluatorConfig> & evaluator_configs = {});
 
   /**
    * @brief Save evaluation results to JSON file

--- a/planning/autoware_planning_data_analyzer/src/metrics/evaluator/evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/evaluator/evaluator.cpp
@@ -162,22 +162,26 @@ std::optional<double> find_closest_value(
   }
 
   const double tolerance_ns = tolerance_ms * 1e6;
-  auto closest = timestamped_values.begin();
-  double min_diff = std::abs(static_cast<double>(closest->timestamp_ns - target_time_ns));
+  const auto itr = std::lower_bound(
+    timestamped_values.begin(), timestamped_values.end(), target_time_ns,
+    [](const TimestampedDouble & value, int64_t target) { return value.timestamp_ns < target; });
 
-  for (auto itr = timestamped_values.begin(); itr != timestamped_values.end(); ++itr) {
-    const double diff = std::abs(static_cast<double>(itr->timestamp_ns - target_time_ns));
-    if (diff < min_diff) {
-      min_diff = diff;
-      closest = itr;
+  auto closest_itr = itr;
+  if (itr == timestamped_values.end()) {
+    closest_itr = std::prev(itr);
+  } else if (itr != timestamped_values.begin()) {
+    const auto prev_itr = std::prev(itr);
+    const double diff_prev = std::abs(static_cast<double>(prev_itr->timestamp_ns - target_time_ns));
+    const double diff_curr = std::abs(static_cast<double>(itr->timestamp_ns - target_time_ns));
+    if (diff_prev < diff_curr) {
+      closest_itr = prev_itr;
     }
   }
-
+  const double min_diff = std::abs(static_cast<double>(closest_itr->timestamp_ns - target_time_ns));
   if (min_diff > tolerance_ns) {
     return std::nullopt;
   }
-
-  return closest->value;
+  return closest_itr->value;
 }
 
 /** @brief Evaluate exclusion rules filtering. */

--- a/planning/autoware_planning_data_analyzer/src/metrics/evaluator/evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/evaluator/evaluator.cpp
@@ -1,0 +1,490 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "metrics/evaluator/evaluator.hpp"
+
+#include "metrics/geometry/lanelet_queries.hpp"
+#include "serialized_bag_message.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <rclcpp/serialization.hpp>
+
+#include <tier4_simulation_msgs/msg/user_defined_value.hpp>
+
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics::evaluator
+{
+
+namespace
+{
+
+EvaluatorMetricStats compute_stats(const std::vector<double> & values)
+{
+  EvaluatorMetricStats stats;
+  stats.count = values.size();
+  if (values.empty()) {
+    return stats;
+  }
+
+  stats.value = ::metrics::calculate_statistics(values);
+  std::vector<double> sorted = values;
+  std::sort(sorted.begin(), sorted.end());
+  stats.percentile_95 = ::metrics::compute_percentile(sorted, 0.95);
+  stats.percentile_99 = ::metrics::compute_percentile(sorted, 0.99);
+  return stats;
+}
+
+std::string make_description_format(const std::string & view_prefix)
+{
+  if (view_prefix == "all") {
+    return "Aggregate of all values in the recorded rosbag and synchronized to odometry.";
+  }
+  if (view_prefix == "included") {
+    return "Aggregate of odometry-synced values in the recorded rosbag outside excluded map "
+           "regions.";
+  }
+
+  const std::string excluded_prefix = "excluded/";
+  if (view_prefix.rfind(excluded_prefix, 0) == 0) {
+    const auto rule_name = view_prefix.substr(excluded_prefix.size());
+    return "Aggregate of odometry-synced values in the recorded rosbag where map exclusion rule '" +
+           rule_name + "' applies.";
+  }
+
+  return "";
+}
+
+std::string make_view_metric_description(
+  const std::string & view_prefix, const std::string & metric_key)
+{
+  const auto view_desc = make_description_format(view_prefix);
+  if (view_desc.empty()) {
+    return metric_key;
+  }
+  return metric_key + ": " + view_desc;
+}
+
+void emit_view_stats(
+  nlohmann::json & json_output, const std::string & view_prefix, const std::string & metric_key,
+  const EvaluatorMetricStats & stats)
+{
+  if (stats.count == 0) {
+    return;
+  }
+
+  // JSON output format per topic
+  const std::string base = view_prefix + "/" + metric_key;
+  json_output[base + "/description"] = make_view_metric_description(view_prefix, metric_key);
+  json_output[base + "/count"] = stats.count;
+  json_output[base + "/mean"] = stats.value.mean;
+  json_output[base + "/min"] = stats.value.min_val;
+  json_output[base + "/max"] = stats.value.max_val;
+  json_output[base + "/percentile_95"] = stats.percentile_95;
+  json_output[base + "/percentile_99"] = stats.percentile_99;
+}
+
+std::vector<std::string> read_string_sequence(const YAML::Node & node)
+{
+  if (!node || !node.IsSequence()) {
+    return {};
+  }
+
+  std::vector<std::string> values;
+  values.reserve(node.size());
+  for (const auto & item : node) {
+    values.push_back(item.as<std::string>());
+  }
+  return values;
+}
+
+EvaluatorConfig parse_evaluator_entry(const YAML::Node & entry)
+{
+  if (!entry.IsMap()) {
+    throw std::runtime_error("Each evaluator_config entry must be a map");
+  }
+
+  EvaluatorConfig config;
+  config.name = entry["name"] ? entry["name"].as<std::string>() : "";
+  config.topics = read_string_sequence(entry["topics"]);
+  if (entry["exclusion"] && entry["exclusion"]["rules"]) {
+    config.exclusion_rules = read_string_sequence(entry["exclusion"]["rules"]);
+  }
+
+  if (config.name.empty()) {
+    throw std::runtime_error("evaluator_config entry is missing 'name'");
+  }
+  if (config.topics.empty()) {
+    throw std::runtime_error(
+      "evaluator_config entry '" + config.name + "' is missing non-empty 'topics'");
+  }
+
+  return config;
+}
+
+std::optional<double> parse_user_defined_value_string(const std::string & value)
+{
+  try {
+    return std::stod(value);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+}
+
+std::optional<double> find_closest_value(
+  const std::vector<TimestampedDouble> & timestamped_values, const int64_t target_time_ns,
+  const double tolerance_ms)
+{
+  if (timestamped_values.empty()) {
+    return std::nullopt;
+  }
+
+  const double tolerance_ns = tolerance_ms * 1e6;
+  auto closest = timestamped_values.begin();
+  double min_diff = std::abs(static_cast<double>(closest->timestamp_ns - target_time_ns));
+
+  for (auto itr = timestamped_values.begin(); itr != timestamped_values.end(); ++itr) {
+    const double diff = std::abs(static_cast<double>(itr->timestamp_ns - target_time_ns));
+    if (diff < min_diff) {
+      min_diff = diff;
+      closest = itr;
+    }
+  }
+
+  if (min_diff > tolerance_ns) {
+    return std::nullopt;
+  }
+
+  return closest->value;
+}
+
+/** @brief Evaluate exclusion rules filtering. */
+std::vector<std::string> evaluate_exclusions(
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const std::vector<std::string> & exclusion_rule_names)
+{
+  std::vector<std::string> matched_rules;
+  for (const auto & rule_name : exclusion_rule_names) {
+    if (rule_name == "intersection_area") {
+      if (metrics::is_pose_in_intersection_area(pose, route_handler)) {
+        matched_rules.push_back(rule_name);
+      }
+    } else {
+      throw std::runtime_error(
+        "Unknown evaluator exclusion rule: " + rule_name + ". Supported rules: intersection_area.");
+    }
+  }
+  return matched_rules;
+}
+
+/** @brief Build evaluator metric measurements synced to odometry timestamps. */
+std::vector<EvaluatorMetricMeasurement> build_synced_metric_measurements(
+  const std::vector<std::shared_ptr<Odometry>> & kinematic_states,
+  const std::vector<TimestampedDouble> & metric_values,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const std::vector<std::string> & exclusion_rule_names, const double sync_tolerance_ms)
+{
+  std::vector<EvaluatorMetricMeasurement> measurements;
+  measurements.reserve(kinematic_states.size());
+
+  for (const auto & odometry : kinematic_states) {
+    if (!odometry) {
+      continue;
+    }
+
+    // Sync metric values to odometry timestamps
+    const int64_t timestamp_ns = rclcpp::Time(odometry->header.stamp).nanoseconds();
+    const auto metric_value = find_closest_value(metric_values, timestamp_ns, sync_tolerance_ms);
+    if (!metric_value.has_value()) {
+      continue;
+    }
+
+    // Build evaluator metric measurement
+    EvaluatorMetricMeasurement measurement;
+    measurement.value = *metric_value;
+    measurement.matched_exclusion_rules =
+      evaluate_exclusions(odometry->pose.pose, route_handler, exclusion_rule_names);
+    measurements.push_back(measurement);
+  }
+
+  return measurements;
+}
+
+}  // namespace
+
+/** @brief Drop odometry samples while ego remains near the first recorded pose (pre-departure). */
+std::vector<std::shared_ptr<Odometry>> filter_odometry_outside_initial_pose(
+  const std::vector<std::shared_ptr<Odometry>> & kinematic_states,
+  const double initial_pose_radius_m)
+{
+  std::vector<std::shared_ptr<Odometry>> filtered;
+  filtered.reserve(kinematic_states.size());
+
+  std::optional<std::pair<double, double>> initial_xy;
+  for (const auto & odometry : kinematic_states) {
+    if (!odometry) {
+      continue;
+    }
+
+    const double x = odometry->pose.pose.position.x;
+    const double y = odometry->pose.pose.position.y;
+    if (!initial_xy.has_value()) {
+      initial_xy = std::make_pair(x, y);
+      continue;
+    }
+
+    const double dx = x - initial_xy->first;
+    const double dy = y - initial_xy->second;
+    if (std::hypot(dx, dy) < initial_pose_radius_m) {
+      continue;
+    }
+
+    filtered.push_back(odometry);
+  }
+
+  return filtered;
+}
+
+std::vector<EvaluatorConfig> load_evaluator_configs_from_yaml_file(const std::string & path)
+{
+  if (!std::filesystem::exists(path)) {
+    throw std::runtime_error("evaluator_config file not found: " + path);
+  }
+
+  const YAML::Node root = YAML::LoadFile(path);
+  const YAML::Node evaluator_config_node =
+    root["evaluator_config"] ? root["evaluator_config"] : root;
+
+  if (!evaluator_config_node || !evaluator_config_node.IsSequence()) {
+    throw std::runtime_error(
+      "evaluator_config file must contain a sequence at key 'evaluator_config': " + path);
+  }
+
+  std::vector<EvaluatorConfig> configs;
+  configs.reserve(evaluator_config_node.size());
+  for (const auto & entry : evaluator_config_node) {
+    configs.push_back(parse_evaluator_entry(entry));
+  }
+
+  return configs;
+}
+
+std::vector<EvaluatorConfig> load_evaluator_configs(rclcpp::Node & node)
+{
+  constexpr const char * kEvaluatorConfigPathParam = "open_loop.evaluator_config_path";
+  if (!node.has_parameter(kEvaluatorConfigPathParam)) {
+    node.declare_parameter<std::string>(kEvaluatorConfigPathParam, "");
+  }
+
+  std::string config_path = node.get_parameter(kEvaluatorConfigPathParam).as_string();
+  if (config_path.empty()) {
+    const auto share_dir =
+      ament_index_cpp::get_package_share_directory("autoware_planning_data_analyzer");
+    config_path = (std::filesystem::path(share_dir) / "config" / "evaluator_config.yaml").string();
+  }
+
+  try {
+    auto configs = load_evaluator_configs_from_yaml_file(config_path);
+    RCLCPP_INFO(
+      node.get_logger(), "Loaded %zu evaluator config(s) from %s", configs.size(),
+      config_path.c_str());
+    return configs;
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      node.get_logger(), "Failed to load evaluator_config from '%s': %s", config_path.c_str(),
+      e.what());
+    return {};
+  }
+}
+
+std::unordered_set<std::string> collect_evaluator_topics(
+  const std::vector<EvaluatorConfig> & evaluator_configs)
+{
+  std::unordered_set<std::string> evaluator_topics;
+  for (const auto & evaluator_config : evaluator_configs) {
+    for (const auto & topic : evaluator_config.topics) {
+      if (!topic.empty()) {
+        evaluator_topics.insert(topic);
+      }
+    }
+  }
+  return evaluator_topics;
+}
+
+/** @brief Check if this topic is an evaluator aggregation target. */
+bool try_append_evaluator_metric_message(
+  const std::string & topic_name,
+  const std::shared_ptr<rosbag2_storage::SerializedBagMessage> & serialized_message,
+  const std::unordered_set<std::string> & evaluator_topics,
+  std::map<std::string, std::vector<TimestampedDouble>> & values_by_topic,
+  const rclcpp::Logger & logger)
+{
+  if (evaluator_topics.count(topic_name) == 0) {
+    return false;
+  }
+
+  using tier4_simulation_msgs::msg::UserDefinedValue;
+  const auto timestamp_ns = static_cast<int64_t>(get_timestamp_ns(*serialized_message));
+  try {
+    UserDefinedValue msg;
+    rclcpp::Serialization<UserDefinedValue> serializer;
+    rclcpp::SerializedMessage serialized_msg(*serialized_message->serialized_data);
+    serializer.deserialize_message(&serialized_msg, &msg);
+    if (const auto value = parse_user_defined_value_string(msg.value)) {
+      values_by_topic[topic_name].push_back({timestamp_ns, *value});
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(
+      logger, "Failed to deserialize evaluator metric on %s: %s", topic_name.c_str(), e.what());
+  }
+  return true;
+}
+
+std::vector<EvaluatorMetricGroup> build_evaluator_metric_groups(
+  const std::vector<EvaluatorConfig> & evaluator_configs,
+  std::map<std::string, std::vector<TimestampedDouble>> & values_by_topic,
+  const std::vector<std::shared_ptr<Odometry>> & kinematic_states,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const double sync_tolerance_ms, const rclcpp::Logger & logger)
+{
+  const auto evaluation_kinematic_states = filter_odometry_outside_initial_pose(kinematic_states);
+  if (evaluation_kinematic_states.empty()) {
+    RCLCPP_INFO(
+      logger, "Evaluator metrics skipped: no odometry samples outside the initial pose radius.");
+    return {};
+  }
+
+  for (auto & [topic, values] : values_by_topic) {
+    std::sort(values.begin(), values.end(), [](const auto & a, const auto & b) {
+      return a.timestamp_ns < b.timestamp_ns;
+    });
+  }
+
+  // Build evaluator metric groups
+  std::vector<EvaluatorMetricGroup> evaluator_metric_groups;
+  for (const auto & evaluator_config : evaluator_configs) {
+    EvaluatorMetricGroup group;
+    group.group_name = evaluator_config.name;
+    group.exclusion_rules = evaluator_config.exclusion_rules;
+
+    // Build evaluator metric measurements for each topic
+    for (const auto & topic : evaluator_config.topics) {
+      const auto slash = topic.rfind('/');
+      const std::string metric_key = slash == std::string::npos ? topic : topic.substr(slash + 1);
+      const auto values_itr = values_by_topic.find(topic);
+      if (values_itr == values_by_topic.end() || values_itr->second.empty()) {
+        RCLCPP_INFO(
+          logger, "Evaluator '%s': no messages on %s", evaluator_config.name.c_str(),
+          topic.c_str());
+        continue;
+      }
+
+      // Analyze values and sync them to odometry timestamps
+      auto measurements = build_synced_metric_measurements(
+        evaluation_kinematic_states, values_itr->second, route_handler,
+        evaluator_config.exclusion_rules, sync_tolerance_ms);
+      if (measurements.empty()) {
+        continue;
+      }
+
+      // Add measurements to the group
+      group.measurements_by_metric_key[metric_key] = std::move(measurements);
+      RCLCPP_INFO(
+        logger, "Evaluator '%s': collected %zu measurements for %s (%s)",
+        evaluator_config.name.c_str(), group.measurements_by_metric_key[metric_key].size(),
+        metric_key.c_str(), topic.c_str());
+    }
+
+    // Add group to the list if it has measurements
+    if (!group.measurements_by_metric_key.empty()) {
+      evaluator_metric_groups.push_back(std::move(group));
+    }
+  }
+
+  return evaluator_metric_groups;
+}
+
+EvaluatorMetricAggregationResult aggregate_metric_measurements(
+  const std::vector<EvaluatorMetricMeasurement> & measurements,
+  const std::vector<std::string> & exclusion_rule_names, const std::string & metric_key)
+{
+  EvaluatorMetricAggregationResult result;
+  result.metric_key = metric_key;
+  for (const auto & rule_name : exclusion_rule_names) {
+    result.excluded_stats_by_rule.emplace(rule_name, EvaluatorMetricStats{});
+  }
+
+  std::vector<double> all_values;
+  std::vector<double> included_values;
+  std::map<std::string, std::vector<double>> excluded_values_by_rule;
+
+  all_values.reserve(measurements.size());
+  included_values.reserve(measurements.size());
+
+  for (const auto & measurement : measurements) {
+    all_values.push_back(measurement.value);
+
+    if (measurement.matched_exclusion_rules.empty()) {
+      included_values.push_back(measurement.value);
+      continue;
+    }
+
+    for (const auto & rule_name : measurement.matched_exclusion_rules) {
+      excluded_values_by_rule[rule_name].push_back(measurement.value);
+    }
+  }
+
+  // Aggregate all values, included values, and excluded values per exclusion rule.
+  // Metrics count: all = each_excluded_topic + included_topic
+  // (There may be some discrepancies due to synchronization issues.)
+  result.all_stats = compute_stats(all_values);
+  result.included_stats = compute_stats(included_values);
+  for (const auto & rule_name : exclusion_rule_names) {
+    const auto itr = excluded_values_by_rule.find(rule_name);
+    if (itr == excluded_values_by_rule.end()) {
+      continue;
+    }
+    result.excluded_stats_by_rule[rule_name] = compute_stats(itr->second);
+  }
+
+  return result;
+}
+
+nlohmann::json evaluator_group_aggregations_to_json(
+  const std::vector<EvaluatorMetricAggregationResult> & metric_results)
+{
+  nlohmann::json json_output;
+  for (const auto & result : metric_results) {
+    emit_view_stats(json_output, "all", result.metric_key, result.all_stats);
+    emit_view_stats(json_output, "included", result.metric_key, result.included_stats);
+    for (const auto & [rule_name, stats] : result.excluded_stats_by_rule) {
+      emit_view_stats(json_output, "excluded/" + rule_name, result.metric_key, stats);
+    }
+  }
+  return json_output;
+}
+
+}  // namespace autoware::planning_data_analyzer::metrics::evaluator

--- a/planning/autoware_planning_data_analyzer/src/metrics/evaluator/evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/evaluator/evaluator.hpp
@@ -1,0 +1,116 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef METRICS__EVALUATOR__EVALUATOR_HPP_
+#define METRICS__EVALUATOR__EVALUATOR_HPP_
+
+#include "data_types.hpp"
+#include "metrics/metric_types.hpp"
+
+#include <autoware/route_handler/route_handler.hpp>
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rosbag2_storage/serialized_bag_message.hpp>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics::evaluator
+{
+
+struct EvaluatorConfig
+{
+  std::string name;
+  std::vector<std::string> topics;
+  std::vector<std::string> exclusion_rules;
+};
+
+struct TimestampedDouble
+{
+  int64_t timestamp_ns{0};
+  double value{0.0};
+};
+
+/** @brief One evaluator metric value synced to an odometry timestamp from the evaluation rosbag. */
+struct EvaluatorMetricMeasurement
+{
+  double value{0.0};
+  std::vector<std::string> matched_exclusion_rules;
+};
+
+struct EvaluatorMetricStats
+{
+  ::metrics::Statistics value;  // max, mean, min
+  std::size_t count{0};         // number of measurements
+  double percentile_95{0.0};
+  double percentile_99{0.0};
+};
+
+struct EvaluatorMetricAggregationResult
+{
+  std::string metric_key;
+  EvaluatorMetricStats all_stats;
+  EvaluatorMetricStats included_stats;
+  std::map<std::string, EvaluatorMetricStats> excluded_stats_by_rule;
+};
+
+/** @brief One evaluator_config.yaml entry: topics sharing the same exclusion rules. */
+struct EvaluatorMetricGroup
+{
+  std::string group_name;
+  std::vector<std::string> exclusion_rules;
+  std::map<std::string, std::vector<EvaluatorMetricMeasurement>> measurements_by_metric_key;
+};
+
+std::vector<EvaluatorConfig> load_evaluator_configs_from_yaml_file(const std::string & path);
+
+std::vector<EvaluatorConfig> load_evaluator_configs(rclcpp::Node & node);
+
+std::unordered_set<std::string> collect_evaluator_topics(
+  const std::vector<EvaluatorConfig> & evaluator_configs);
+
+bool try_append_evaluator_metric_message(
+  const std::string & topic_name,
+  const std::shared_ptr<rosbag2_storage::SerializedBagMessage> & serialized_message,
+  const std::unordered_set<std::string> & evaluator_topics,
+  std::map<std::string, std::vector<TimestampedDouble>> & values_by_topic,
+  const rclcpp::Logger & logger);
+
+/** @brief Drop odometry samples while ego remains near the first recorded pose (pre-departure). */
+std::vector<std::shared_ptr<Odometry>> filter_odometry_outside_initial_pose(
+  const std::vector<std::shared_ptr<Odometry>> & kinematic_states,
+  double initial_pose_radius_m = 2.0);
+
+std::vector<EvaluatorMetricGroup> build_evaluator_metric_groups(
+  const std::vector<EvaluatorConfig> & evaluator_configs,
+  std::map<std::string, std::vector<TimestampedDouble>> & values_by_topic,
+  const std::vector<std::shared_ptr<Odometry>> & kinematic_states,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  double sync_tolerance_ms, const rclcpp::Logger & logger);
+
+EvaluatorMetricAggregationResult aggregate_metric_measurements(
+  const std::vector<EvaluatorMetricMeasurement> & measurements,
+  const std::vector<std::string> & exclusion_rule_names, const std::string & metric_key);
+
+nlohmann::json evaluator_group_aggregations_to_json(
+  const std::vector<EvaluatorMetricAggregationResult> & metric_results);
+
+}  // namespace autoware::planning_data_analyzer::metrics::evaluator
+
+#endif  // METRICS__EVALUATOR__EVALUATOR_HPP_

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/lanelet_queries.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/lanelet_queries.cpp
@@ -18,6 +18,7 @@
 
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/intersection.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
 
 #include <boost/geometry.hpp>
@@ -26,6 +27,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -152,6 +154,30 @@ std::vector<lanelet::ConstPolygon3d> collect_local_intersection_areas(
   return intersection_areas;
 }
 
+std::optional<autoware_utils_geometry::Polygon2d> get_intersection_area_polygon(
+  const lanelet::ConstLanelet & lanelet, const lanelet::LaneletMapConstPtr & map)
+{
+  const std::string area_id_str = lanelet.attributeOr("intersection_area", "else");
+  if (area_id_str == "else") {
+    return std::nullopt;
+  }
+
+  const auto area_id = static_cast<lanelet::Id>(std::stoll(area_id_str));
+  if (!map->polygonLayer.exists(area_id)) {
+    return std::nullopt;
+  }
+
+  const auto poly_3d = map->polygonLayer.get(area_id);
+  autoware_utils_geometry::Polygon2d poly;
+  for (const auto & point : poly_3d) {
+    poly.outer().emplace_back(point.x(), point.y());
+  }
+  if (poly.outer().size() >= 3) {
+    poly.outer().push_back(poly.outer().front());
+  }
+  return poly;
+}
+
 }  // namespace
 
 std::optional<lanelet::ConstLanelet> find_reference_lanelet(
@@ -214,6 +240,28 @@ bool is_pose_in_intersection(
          autoware::experimental::lanelet2_utils::is_intersection_lanelet(*lanelet);
 }
 
+bool is_pose_in_intersection_area(
+  const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler)
+{
+  if (!route_handler || !route_handler->isMapMsgReady()) {
+    return false;
+  }
+
+  const auto lanelet = find_reference_lanelet(pose, route_handler);
+  if (!lanelet.has_value()) {
+    return false;
+  }
+
+  const auto intersection_area =
+    get_intersection_area_polygon(*lanelet, route_handler->getLaneletMapPtr());
+  if (!intersection_area.has_value()) {
+    return false;
+  }
+
+  const autoware_utils_geometry::Point2d ego_point{pose.position.x, pose.position.y};
+  return boost::geometry::within(ego_point, *intersection_area);
+}
+
 bool is_pose_in_route_lane_polygon(
   const geometry_msgs::msg::Pose & pose, const std::shared_ptr<RouteHandler> & route_handler)
 {
@@ -246,17 +294,6 @@ std::optional<DrivingDirectionLocalContext> compute_driving_direction_local_cont
   context.in_intersection = std::any_of(
     context.intersection_areas.begin(), context.intersection_areas.end(),
     [&search_point](const auto & polygon) { return point_in_polygon(search_point, polygon); });
-
-  if (!context.in_intersection) {
-    for (const auto & lanelet : context.route_lanelets) {
-      if (
-        autoware::experimental::lanelet2_utils::is_intersection_lanelet(lanelet) &&
-        point_in_lanelet(search_point, lanelet)) {
-        context.in_intersection = true;
-        break;
-      }
-    }
-  }
   return context;
 }
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/lanelet_queries.cpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/lanelet_queries.cpp
@@ -294,6 +294,17 @@ std::optional<DrivingDirectionLocalContext> compute_driving_direction_local_cont
   context.in_intersection = std::any_of(
     context.intersection_areas.begin(), context.intersection_areas.end(),
     [&search_point](const auto & polygon) { return point_in_polygon(search_point, polygon); });
+
+  if (!context.in_intersection) {
+    for (const auto & lanelet : context.route_lanelets) {
+      if (
+        autoware::experimental::lanelet2_utils::is_intersection_lanelet(lanelet) &&
+        point_in_lanelet(search_point, lanelet)) {
+        context.in_intersection = true;
+        break;
+      }
+    }
+  }
   return context;
 }
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/geometry/lanelet_queries.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/geometry/lanelet_queries.hpp
@@ -49,7 +49,13 @@ lanelet::ConstLanelets collect_route_relevant_lanelets(
 
 autoware_utils_geometry::LineString2d to_linestring2d(const lanelet::ConstLineString3d & line);
 
+// Check if the pose is on a lanelet whose `turn_direction` attribute is set.
 bool is_pose_in_intersection(
+  const geometry_msgs::msg::Pose & pose,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler);
+
+// Check if the pose is inside the `intersection_area` polygon attached to the reference lanelet.
+bool is_pose_in_intersection_area(
   const geometry_msgs::msg::Pose & pose,
   const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler);
 

--- a/planning/autoware_planning_data_analyzer/src/metrics/metric_types.hpp
+++ b/planning/autoware_planning_data_analyzer/src/metrics/metric_types.hpp
@@ -93,6 +93,17 @@ Statistics calculate_statistics(const Container & values)
   return stats;
 }
 
+inline double compute_percentile(const std::vector<double> & sorted, double p)
+{
+  if (sorted.empty()) return 0.0;
+  if (sorted.size() == 1) return sorted[0];
+  const double idx = p * static_cast<double>(sorted.size() - 1);
+  const size_t lo = static_cast<size_t>(std::floor(idx));
+  const size_t hi = std::min(lo + 1, sorted.size() - 1);
+  const double frac = idx - static_cast<double>(lo);
+  return sorted[lo] * (1.0 - frac) + sorted[hi] * frac;
+}
+
 }  // namespace metrics
 
 #endif  // METRICS__METRIC_TYPES_HPP_

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -17,6 +17,7 @@
 #include "metrics/epdms/aggregation/epdms_aggregation.hpp"
 #include "metrics/geometry/metric_utils.hpp"
 #include "metrics/geometry/object_tracks.hpp"
+#include "metrics/metric_types.hpp"
 #include "metrics/trajectory_metrics.hpp"
 
 #include <autoware/motion_utils/trajectory/conversion.hpp>
@@ -365,17 +366,6 @@ static double compute_std_dev(const std::vector<double> & v)
   double var = 0.0;
   for (const double x : v) var += (x - m) * (x - m);
   return std::sqrt(var / v.size());
-}
-
-static double compute_percentile(const std::vector<double> & sorted, double p)
-{
-  if (sorted.empty()) return 0.0;
-  if (sorted.size() == 1) return sorted[0];
-  const double idx = p * static_cast<double>(sorted.size() - 1);
-  const size_t lo = static_cast<size_t>(std::floor(idx));
-  const size_t hi = std::min(lo + 1, sorted.size() - 1);
-  const double frac = idx - static_cast<double>(lo);
-  return sorted[lo] * (1.0 - frac) + sorted[hi] * frac;
 }
 
 static void fill_horizon_json(
@@ -1639,8 +1629,8 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
     j[prefix + "/min"] = sorted.empty() ? 0.0 : sorted.front();
     j[prefix + "/max"] = sorted.empty() ? 0.0 : sorted.back();
     j[prefix + "/std"] = compute_std_dev(vals);
-    j[prefix + "/percentile_95"] = compute_percentile(sorted, 0.95);
-    j[prefix + "/percentile_99"] = compute_percentile(sorted, 0.99);
+    j[prefix + "/percentile_95"] = ::metrics::compute_percentile(sorted, 0.95);
+    j[prefix + "/percentile_99"] = ::metrics::compute_percentile(sorted, 0.99);
   };
 
   std::set<std::string> all_keys;
@@ -2430,7 +2420,8 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
   RCLCPP_INFO(logger_, "Running open-loop evaluation for trajectory analysis");
 
   // Use base class method to process bag and get synchronized data
-  auto bag_result = process_bag_common(bag_path, evaluation_bag_writer, topic_names);
+  auto bag_result =
+    process_bag_common(bag_path, evaluation_bag_writer, topic_names, evaluator_configs_);
   object_timeline_ = bag_result.tracked_object_timeline;
 
   // Pass the control_mode timeline to enable override-only aggregation in the summary.
@@ -2469,6 +2460,32 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
     save_json_results(
       full_json, bag_path, "open_loop", "time_step_based_trajectory_detailed_result.json", false,
       true);
+  }
+
+  // Save evaluator metric results
+  if (!bag_result.evaluator_metric_groups.empty()) {
+    const auto build_group_json =
+      [](const metrics::evaluator::EvaluatorMetricGroup & metric_group) {
+        std::vector<metrics::evaluator::EvaluatorMetricAggregationResult> metric_results;
+        metric_results.reserve(metric_group.measurements_by_metric_key.size());
+        for (const auto & [metric_key, measurements] : metric_group.measurements_by_metric_key) {
+          metric_results.push_back(
+            metrics::evaluator::aggregate_metric_measurements(
+              measurements, metric_group.exclusion_rules, metric_key));
+        }
+        return metrics::evaluator::evaluator_group_aggregations_to_json(metric_results);
+      };
+
+    nlohmann::json evaluator_json;
+    if (bag_result.evaluator_metric_groups.size() == 1) {
+      evaluator_json = build_group_json(bag_result.evaluator_metric_groups.front());
+    } else {
+      for (const auto & metric_group : bag_result.evaluator_metric_groups) {
+        evaluator_json[metric_group.group_name] = build_group_json(metric_group);
+      }
+    }
+
+    save_json_results(evaluator_json, bag_path, "open_loop", "evaluator_metric.json", false, false);
   }
 
   RCLCPP_INFO(logger_, "Open-loop evaluation complete");

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -2477,12 +2477,8 @@ std::pair<rclcpp::Time, rclcpp::Time> OpenLoopEvaluator::run_evaluation_from_bag
       };
 
     nlohmann::json evaluator_json;
-    if (bag_result.evaluator_metric_groups.size() == 1) {
-      evaluator_json = build_group_json(bag_result.evaluator_metric_groups.front());
-    } else {
-      for (const auto & metric_group : bag_result.evaluator_metric_groups) {
-        evaluator_json[metric_group.group_name] = build_group_json(metric_group);
-      }
+    for (const auto & metric_group : bag_result.evaluator_metric_groups) {
+      evaluator_json[metric_group.group_name] = build_group_json(metric_group);
     }
 
     save_json_results(evaluator_json, bag_path, "open_loop", "evaluator_metric.json", false, false);

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -22,6 +22,7 @@
 #include "metrics/epdms/subscores/ego_progress.hpp"
 #include "metrics/epdms/subscores/extended_comfort.hpp"
 #include "metrics/epdms/subscores/lane_keeping.hpp"
+#include "metrics/evaluator/evaluator.hpp"
 #include "metrics/trajectory_metrics.hpp"
 #include "utils/override_windows.hpp"
 
@@ -239,6 +240,11 @@ public:
     control_mode_events_ = std::move(events);
   }
 
+  void set_evaluator_configs(const std::vector<metrics::evaluator::EvaluatorConfig> & configs)
+  {
+    evaluator_configs_ = configs;
+  }
+
   nlohmann::json get_summary_as_json() const override;
 
   nlohmann::json get_detailed_results_as_json() const override;
@@ -418,6 +424,7 @@ private:
   // Reserved for the follow-up debug-topic PR. PR 425 only stores the runtime switch.
   std::vector<TimedTrackedObjects> object_timeline_;
   bool debug_topics_enabled_{false};
+  std::vector<metrics::evaluator::EvaluatorConfig> evaluator_configs_;
 };
 
 }  // namespace autoware::planning_data_analyzer

--- a/planning/autoware_planning_data_analyzer/test/metrics/fixtures/evaluator_config.fixture.yaml
+++ b/planning/autoware_planning_data_analyzer/test/metrics/fixtures/evaluator_config.fixture.yaml
@@ -1,0 +1,9 @@
+# Fixture for unit tests only — not used at runtime.
+evaluator_config:
+  - name: test_metric_group
+    topics:
+      - /control/control_evaluator/metrics/foo_metric
+      - /control/control_evaluator/metrics/bar_metric_abs
+    exclusion:
+      rules:
+        - intersection_area

--- a/planning/autoware_planning_data_analyzer/test/metrics/test_evaluator_metrics.cpp
+++ b/planning/autoware_planning_data_analyzer/test/metrics/test_evaluator_metrics.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "metrics/evaluator/evaluator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::planning_data_analyzer::metrics::evaluator
+{
+namespace
+{
+
+EvaluatorMetricMeasurement make_measurement(
+  const double value, const std::vector<std::string> & matched_rules = {})
+{
+  EvaluatorMetricMeasurement measurement;
+  measurement.value = value;
+  measurement.matched_exclusion_rules = matched_rules;
+  return measurement;
+}
+
+std::shared_ptr<Odometry> make_odometry(const double x, const double y)
+{
+  auto odometry = std::make_shared<Odometry>();
+  odometry->pose.pose.position.x = x;
+  odometry->pose.pose.position.y = y;
+  return odometry;
+}
+
+TEST(EvaluatorMetrics, FilterOdometryOutsideInitialPose)
+{
+  const std::vector<std::shared_ptr<Odometry>> kinematic_states = {
+    make_odometry(10.0, 20.0), make_odometry(10.1, 20.0), make_odometry(10.0, 21.5),
+    make_odometry(15.0, 20.0)};
+
+  const auto filtered = filter_odometry_outside_initial_pose(kinematic_states, 2.0);
+  ASSERT_EQ(filtered.size(), 1U);
+  EXPECT_DOUBLE_EQ(filtered.front()->pose.pose.position.x, 15.0);
+  EXPECT_DOUBLE_EQ(filtered.front()->pose.pose.position.y, 20.0);
+}
+
+TEST(EvaluatorMetrics, IncludedWhenIntersectionExcluded)
+{
+  const std::vector<EvaluatorMetricMeasurement> measurements = {
+    make_measurement(0.1, {}), make_measurement(2.0, {"intersection_area"}),
+    make_measurement(-0.2, {})};
+
+  const auto result = aggregate_metric_measurements(
+    measurements, {"intersection_area"}, "lateral_deviation_centerline");
+
+  EXPECT_EQ(result.all_stats.count, 3U);
+  EXPECT_EQ(result.included_stats.count, 2U);
+  EXPECT_EQ(result.excluded_stats_by_rule.at("intersection_area").count, 1U);
+}
+
+TEST(EvaluatorConfig, LoadFromYamlFixture)
+{
+  const auto path =
+    std::filesystem::path(__FILE__).parent_path() / "fixtures" / "evaluator_config.fixture.yaml";
+  ASSERT_TRUE(std::filesystem::exists(path)) << path;
+
+  const auto configs = load_evaluator_configs_from_yaml_file(path.string());
+  ASSERT_EQ(configs.size(), 1U);
+  EXPECT_EQ(configs.front().exclusion_rules.front(), "intersection_area");
+}
+
+TEST(EvaluatorMetrics, GroupJsonUsesExpectedPaths)
+{
+  const auto result = aggregate_metric_measurements(
+    {make_measurement(0.1, {}), make_measurement(1.0, {"intersection_area"})},
+    {"intersection_area"}, "lateral_deviation_centerline");
+  const auto json = evaluator_group_aggregations_to_json({result});
+
+  EXPECT_TRUE(json.contains("included/lateral_deviation_centerline/mean"));
+  EXPECT_TRUE(json.contains("included/lateral_deviation_centerline/percentile_95"));
+  EXPECT_TRUE(json.contains("excluded/intersection_area/lateral_deviation_centerline/count"));
+  EXPECT_FALSE(json.contains("all/description"));
+}
+
+}  // namespace
+}  // namespace autoware::planning_data_analyzer::metrics::evaluator


### PR DESCRIPTION
## Description

Add aggregation of bag-recorded evaluator scalar metric topics (`control_evaluator`, `planning_evaluator`, ...) into the open-loop pipeline, written to a new output file `evaluator_metric.json` alongside the existing trajectory metric outputs.

### Main Change

- New module `src/metrics/evaluator/evaluator.{cpp,hpp}`:
  - Loads `evaluator_config.yaml` (groups of topics sharing the same
    exclusion rules).
  - Collects target topic names, deserializes scalar values from the bag,
    syncs them to odometry (`sync_tolerance_ms`).
  - Applies exclusion rules (currently `intersection_area`, via
    vector-map `intersection_area` polygons).
  - Aggregates per metric key into `all` / `included` /
    `excluded/<rule_name>` views with `count`, `mean`, `min`, `max`,
    `percentile_95`, `percentile_99`.
- New default config `config/evaluator_config.yaml`
  (`control_evaluator/.../lateral_deviation_centerline[_abs]`,
  excluded inside intersections).
- Launch arg `evaluator_config_file` →
  param `open_loop.evaluator_config_path`.
- `OpenLoopEvaluator` writes `evaluator_metric.json`
  (only when the bag contains any configured topic).

### Main Usage

After running the Evaluator test, execute the `planning_data_analyzer` using the rosbag file as input.
Output the results to the Archive and analyze them using ART.
Make the results viewable from the dashboard (TODO).

## How was this PR tested?

- [Evaluator Test](https://evaluation.tier4.jp/evaluation/reports/e980c6cd-94fa-5038-bf47-6d863f54bee5/tests/406ad989-e975-5e81-8212-4bdc27cf6a7f/c08eb140-d164-5ae6-8e7e-0b6dfe3c2a7b/8050cd4c-6a56-526b-9d3e-c367f756d035?project_id=x2_dev) (E2E)

  - `post_process_command: '''cd "/home/autoware/autoware.proj/" &&  ros2 launch autoware_planning_data_analyzer planning_data_analyzer.launch.xml bag_path:="$SCENARIO_BAG_PATH"  output_dir:="/home/autoware/.ros/log/autoware_metrics/data_analyzer/"'''`
  -  By adding the above command to webauto-ci.yml, I confirmed that the output from `planning_data_analyzer` appears in the Evaluator Test results archive. (Only E2E)
  
- Local Test
  - [This rosbag](https://evaluation.tier4.jp/evaluation/reports/304dabb2-d31e-5454-a8b2-b9046cab9077/tests/011417ab-dc18-5e83-ad82-d02391e3802a/7f72fe0b-8a1e-50fa-9fff-49b652d0da06/c641bc66-a3f4-5b27-870c-1eb1bb160c8a?project_id=x2_dev) used
  - ```sh
    rm -rf install/autoware_planning_data_analyzer build/autoware_planning_data_analyzer 
    colcon build --packages-select autoware_planning_data_analyzer
    
    ros2 launch autoware_planning_data_analyzer planning_data_analyzer.launch.xml   bag_path:=$HOME//test_bag.mcap   output_dir:=$HOME/planning_analyzer_output
      ```
  - [evaluator_metric.json](https://github.com/user-attachments/files/28289602/evaluator_metric.json)
<img width="2490" height="1060" alt="image" src="https://github.com/user-attachments/assets/896c95d8-ebbd-40c6-892b-fe2763065967" />

## Notes for reviewers

None.

## Effects on system behavior

None.
