### PR TITLE
fix(autoware_static_centerline_generator): suppress GUI window in launch tests

### DIFF
--- a/planning/autoware_static_centerline_generator/test/utils/test_static_centerline_generator_launch_base.py
+++ b/planning/autoware_static_centerline_generator/test/utils/test_static_centerline_generator_launch_base.py
@@ -20,6 +20,7 @@ from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.actions import SetEnvironmentVariable
 from launch.actions import TimerAction
 from launch.launch_description_sources import AnyLaunchDescriptionSource
 import launch_testing
@@ -75,7 +76,13 @@ def generate_test_description_impl(
         launch_description.append(DeclareLaunchArgument("goal_method", default_value=goal_method))
 
     return LaunchDescription(
-        launch_description
+        [
+            # Run the PyQt5 GUI helper (centerline_updater_helper.py) without a visible window so
+            # the launch tests pass on headless CI (no display / no Qt platform plugin) and do not
+            # pop up a window during local `colcon test`. Scoped to the test launch only.
+            SetEnvironmentVariable("QT_QPA_PLATFORM", "offscreen"),
+        ]
+        + launch_description
         + [
             DeclareLaunchArgument("rviz", default_value="false"),
             DeclareLaunchArgument(


### PR DESCRIPTION
## Description

The GUI launch test (`test_static_centerline_generator_gui_launch.test.py`) starts the PyQt5 helper `centerline_updater_helper.py`, which creates a `QApplication`/`QMainWindow`. On headless CI there is no display and no Qt platform plugin can be initialized, so the helper crashes (`qt.qpa.xcb: could not connect to display`). Locally it pops up a visible window during `colcon test`.

## Fix

Add `SetEnvironmentVariable("QT_QPA_PLATFORM", "offscreen")` at the front of the launch-test `LaunchDescription` in `test/utils/test_static_centerline_generator_launch_base.py` (shared by both launch tests). The Qt event loop then runs without a visible window: the test passes on headless CI and no window appears during local `colcon test`. Runtime usage of the tool is unaffected — the variable is set only in the test launch description.

Closes #391

## Tests performed

`build-and-test-differential` was run on a fork PR (https://github.com/youtalk/autoware_tools/pull/1), which builds and runs the `autoware_static_centerline_generator` launch tests headlessly. Both distros pass:

- `build-and-test-differential (humble)` — success: https://github.com/youtalk/autoware_tools/actions/runs/26768535659/job/78901453990
- `build-and-test-differential (jazzy)` — success: https://github.com/youtalk/autoware_tools/actions/runs/26768535659/job/78901453921
