### PR TITLE
fix(autoware_static_centerline_generator): refresh centerline lane ids before saving

### DIFF
--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -1208,6 +1208,14 @@ void StaticCenterlineGeneratorNode::save_map()
     return;
   }
 
+  // Recompute the centerline lane ids for the current selection. The cached lane ids are produced
+  // by connect_centerline_to_lanelet() against whatever selection existed when `validate` ran, but
+  // get_selected_centerline() is sliced dynamically by start/end index. If the selection changed
+  // after validate (e.g. the GUI index updates were applied after the validate request), the cache
+  // goes stale and the size check below aborts the save. Refreshing here keeps the centerline and
+  // its lane ids consistent for the selection actually being saved.
+  connect_centerline_to_lanelet();
+
   const auto centerline = centerline_handler_.get_selected_centerline();
   const auto centerline_lane_ids = centerline_handler_.get_centerline_lane_ids();
 


### PR DESCRIPTION
## Description

When saving the generated centerline via the GUI flow, `save_map()` aborts with
`Cannot save map: size mismatch. centerline: N, lane_ids: M` and the map is not written.

Root cause: `CenterlineHandler::get_selected_centerline()` is sliced dynamically by the current
`start_index`/`end_index`, but `get_centerline_lane_ids()` returns a **cached** vector computed by
`connect_centerline_to_lanelet()` for whatever selection existed when `validate` last ran. When the
start/end index changes after `validate` (e.g. the GUI `traj_start_index` / `traj_end_index` updates
are applied after the validate request), the cached lane ids go stale relative to the now-sliced
centerline, so the size check in `save_map()` fails and the save is skipped. The cached count is also
non-deterministic because the whole-centerline length from the optimizer varies.

## Fix

Recompute the lane ids for the current selection by calling `connect_centerline_to_lanelet()` at the
start of `save_map()`, so the selected centerline and its lane ids are always consistent for the
selection being saved.

## Tests performed

Reproduced and verified via the `autoware_static_centerline_generator` GUI launch test built against
the latest source of the whole planning stack (autoware_core `-above` differential, jazzy). Before this
fix the test failed on the `size mismatch` save abort; with it, both jazzy and humble `-above` pass.
(Companion to autowarefoundation/autoware_tools#443, which makes the same launch test run headlessly;
the two fixes are independent — different files — and this one does not depend on #443.)
