### PR TITLE
fix: replay-route does not work in DLR test

### DIFF
--- a/planning/planning_debug_tools/README.md
+++ b/planning/planning_debug_tools/README.md
@@ -222,6 +222,8 @@ The following topics are published during replay:
 
 ### How it works
 
+The node subscribes to `/localization/kinematic_state` for the simulator ego pose and `/initialpose3d` to align the rosbag replay timeline when localization is reset (e.g. DLR DirectInitialPose).
+
 Whenever the ego's position changes, a chronological `reproduce_sequence` queue is generated based on its position with a search radius (default to 2 m).
 If the queue is empty, the nearest odom message in the rosbag is added to the queue.
 When publishing perception messages, the first element in the `reproduce_sequence` is popped and published.

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.cpp
@@ -37,10 +37,10 @@ PerceptionReproducer::PerceptionReproducer(
 
   ego_odom_search_radius_ = param_.search_radius;
 
-  // subscription for /initialpose to refresh cool down
+  // subscription for /initialpose3d to refresh cool down and sync bag anchor
   sub_init_pos_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "/initialpose", 1,
-    std::bind(&PerceptionReproducer::on_initialpose, this, std::placeholders::_1));
+    "/initialpose3d", 1,
+    std::bind(&PerceptionReproducer::on_pose_reset, this, std::placeholders::_1));
 
   // calculate average ego odom interval
   RCLCPP_INFO(get_logger(), "Calculating average ego odom interval");
@@ -72,10 +72,9 @@ PerceptionReproducer::PerceptionReproducer(
   RCLCPP_INFO(get_logger(), "PerceptionReproducer initialization completed");
 }
 
-void PerceptionReproducer::on_initialpose(
+void PerceptionReproducer::on_pose_reset(
   const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg)
 {
-  (void)msg;
   cool_down_indices_.clear();
 
   last_sequenced_ego_pose_.reset();
@@ -85,7 +84,7 @@ void PerceptionReproducer::on_initialpose(
     last_published_timestamp_ = rosbag_ego_odom_data_[nearest_ego_odom_idx].first;
   }
 
-  RCLCPP_INFO(get_logger(), "Cool down indices and last sequenced pose cleared by /initialpose");
+  RCLCPP_INFO(get_logger(), "Cool down indices and last sequenced pose cleared by /initialpose3d");
 }
 
 void PerceptionReproducer::on_timer()
@@ -198,6 +197,14 @@ void PerceptionReproducer::on_timer()
       cool_down_indices_.push_back(ego_odom_idx);
 
       return pose_timestamp;
+    }
+
+    if (!last_published_timestamp_.has_value()) {
+      const auto idx = find_nearest_ego_odom_index(ego_pose);
+      last_published_timestamp_ = rosbag_ego_odom_data_[idx].first;
+      RCLCPP_INFO(
+        get_logger(), "Seeded bag timestamp from ego pose (idx=%zu, t=%.3f)", idx,
+        last_published_timestamp_->seconds());
     }
 
     return last_published_timestamp_;

--- a/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.hpp
+++ b/planning/planning_debug_tools/src/perception_replayer/perception_reproducer.hpp
@@ -47,7 +47,7 @@ public:
 
 private:
   void on_timer();
-  void on_initialpose(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
+  void on_pose_reset(const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg);
 
   // find nearest ego odom index by position
   size_t find_nearest_ego_odom_index(const geometry_msgs::msg::Pose & ego_pose) const;


### PR DESCRIPTION
## Description

1.`/initialpose` ONLY works in RViz; this PR changes to subscribe `/initialpose3d` so it can now receive pose initialization from both DLRv2 or RViz.
2. `last_published_timestamp` is empty when the first pose initialization contains no available frame; this PR fixes this problem.

## How was this PR tested?
[Evaluator](https://evaluation.tier4.jp/evaluation/reports/a2c8a9cb-4602-5937-ac20-7d708c252868/tests/1d3e5775-485a-5885-bdb0-12f73b019ff1?project_id=x2_dev)

## Notes for reviewers

None.

## Effects on system behavior

None.
