### PR TITLE
ci(check-build-depends): use universe-dependencies container

### DIFF
--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -7,17 +7,16 @@ on:
 
 jobs:
   check-build-depends:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         rosdistro:
-          - humble
+          - jazzy
         include:
-          - rosdistro: humble
-            container: ros:humble
-            build-depends-repos: build_depends.repos
+          - rosdistro: jazzy
+            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -34,4 +33,4 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -19,7 +19,7 @@ repositories:
   core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git
-    version: 1.7.2
+    version: 1.8.0
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git


### PR DESCRIPTION
## Description
- Update the `check-build-depends` CI workflow to build against ROS 2 Jazzy instead of Humble, matching the project's current target distribution.
- Replace the plain `ros:humble` container with the prebuilt `ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy` image, so Autoware's universe dependencies are already present during the build-depends check.
- Bump the runner to `ubuntu-24.04` and simplify the matrix by inlining `build-depends-repos: build_depends.repos` (the per-distro override is no longer needed with a single distro).

## How was this PR tested?
- [ ] Confirm the `check-build-depends` workflow runs on this PR and resolves the `universe-dependencies-jazzy` container.
- [ ] Verify the build-depends check passes against `build_depends.repos` under Jazzy.

## Notes for reviewers

None.

## Effects on system behavior

None.
