### PR TITLE
ci: use underlay workspace

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -55,6 +55,21 @@ jobs:
         id: get-modified-packages
         uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
 
+      - name: Remove autoware_core packages from underlay
+        run: |
+          tmp_dir=$(mktemp -d)
+          git clone --depth 1 --branch main \
+            https://github.com/autowarefoundation/autoware_core.git "$tmp_dir"
+          for pkg_xml in $(find "$tmp_dir" -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            if [ -d "/opt/autoware/$pkg_name" ]; then
+              echo "Removing /opt/autoware/$pkg_name"
+              sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+          done
+          rm -rf "$tmp_dir"
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -62,6 +62,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
+          underlay-workspace: /opt/autoware
 
       - name: Test
         id: test
@@ -71,7 +72,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
-
+          underlay-workspace: /opt/autoware
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -47,7 +47,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
-
+          underlay-workspace: /opt/autoware
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         id: test
@@ -56,7 +56,7 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
-
+          underlay-workspace: /opt/autoware
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
         uses: codecov/codecov-action@v3

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -40,6 +40,21 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Remove autoware_core packages from underlay
+        run: |
+          tmp_dir=$(mktemp -d)
+          git clone --depth 1 --branch main \
+            https://github.com/autowarefoundation/autoware_core.git "$tmp_dir"
+          for pkg_xml in $(find "$tmp_dir" -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            if [ -d "/opt/autoware/$pkg_name" ]; then
+              echo "Removing /opt/autoware/$pkg_name"
+              sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+          done
+          rm -rf "$tmp_dir"
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -7,17 +7,16 @@ on:
 
 jobs:
   check-build-depends:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         rosdistro:
-          - humble
+          - jazzy
         include:
-          - rosdistro: humble
-            container: ros:humble
-            build-depends-repos: build_depends.repos
+          - rosdistro: jazzy
+            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -34,6 +33,5 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
-          underlay-workspace: /opt/autoware
-          
+          build-depends-repos: build_depends.repos
+          underlay-workspace: /opt/autoware          

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -34,4 +34,4 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: build_depends.repos
-          underlay-workspace: /opt/autoware          
+          underlay-workspace: /opt/autoware

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -35,3 +35,5 @@ jobs:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
+          underlay-workspace: /opt/autoware
+          

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -28,6 +28,21 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Remove autoware_core packages from underlay
+        run: |
+          tmp_dir=$(mktemp -d)
+          git clone --depth 1 --branch main \
+            https://github.com/autowarefoundation/autoware_core.git "$tmp_dir"
+          for pkg_xml in $(find "$tmp_dir" -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            if [ -d "/opt/autoware/$pkg_name" ]; then
+              echo "Removing /opt/autoware/$pkg_name"
+              sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+          done
+          rm -rf "$tmp_dir"
+        shell: bash
+
       - name: Build
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,29 +1,7 @@
+# Do not add core (core/*) dependency repositories here.
+# Core packages are provided pre-built by the CI Docker image, and their versions
+# are defined by the image tag. Adding them here would cause redundant rebuilds.
 repositories:
-  # core
-  core/autoware_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.13.0
-  core/autoware_adapi_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: 1.9.1
-  core/autoware_internal_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.12.1
-  autoware/autoware_cmake:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_cmake.git
-    version: 1.2.0
-  core/autoware_utils:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_utils.git
-    version: 1.7.2
-  core/autoware_lanelet2_extension:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 1.1.0
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git


### PR DESCRIPTION
## Description
This is part of https://github.com/orgs/autowarefoundation/discussions/7096

Switches CI to build/test on top of the pre-built `universe-dependencies` Docker image and its `/opt/autoware` underlay workspace, instead of rebuilding core packages from source.

- Pass `underlay-workspace: /opt/autoware` to the build/test actions in `build-and-test.yaml`, `build-and-test-differential.yaml`, and `check-build-depends.yaml` so colcon builds against the pre-built core packages in the image.
- Migrate `check-build-depends` from Humble to Jazzy: `ubuntu-24.04` runner and the `ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy` container, dropping the per-matrix `build-depends-repos` in favor of a fixed `build_depends.repos`.
- Remove all `core/*` (and `autoware_cmake`) entries from `build_depends.repos`, since the core packages are now provided pre-built by the CI image and pinned by the image tag. Added a comment documenting that core repos must not be re-added here to avoid redundant rebuilds.

## How was this PR tested?

- [x] `build-and-test` workflows pass with the Jazzy `universe-dependencies` image and `/opt/autoware` underlay. https://github.com/mitsudome-r/autoware_tools/actions/runs/28241030822
- [x] `check-build-depends` workflow passes on `ubuntu-24.04` / `jazzy` against `build_depends.repos`. https://github.com/autowarefoundation/autoware_tools/actions/runs/28240888552/job/83667191031?pr=456

## Notes for reviewers

None.

## Effects on system behavior

None.
