### PR TITLE
feat(planning_data_analyzer): add EPDMS calculation gate

### DIFF
--- a/planning/autoware_planning_data_analyzer/README.md
+++ b/planning/autoware_planning_data_analyzer/README.md
@@ -82,6 +82,7 @@ Key parameters in `config/planning_data_analyzer.param.yaml`:
 - `evaluation_interval_ms`: Sampling interval (default: 100ms)
 - `sync_tolerance_ms`: Time synchronization tolerance (default: 100ms)
 - `trajectory_topic`: Trajectory topic to evaluate
+- `open_loop.enable_epdms_calculation`: Enables EPDMS subscore, synthetic EPDMS, and EPDMS debug calculation
 - `open_loop.*`: Open-loop specific settings
 
 ---

--- a/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
+++ b/planning/autoware_planning_data_analyzer/config/planning_data_analyzer.param.yaml
@@ -47,6 +47,8 @@
       # Debug visualization topics are expensive and disabled by default.
       # This switch is reserved for the follow-up debug-topic PR.
       debug_topics_enabled: false
+      # Disable to skip EPDMS subscore, synthetic EPDMS, and EPDMS debug calculations.
+      enable_epdms_calculation: true
       # Maximum planned trajectory duration to evaluate [s].
       # 0.0 means use the full trajectory from the bag.
       trajectory_evaluation_horizon: 4.0

--- a/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
+++ b/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
@@ -9,6 +9,7 @@
   <arg name="gt_source_mode" default="kinematic_state" description="GT source mode: kinematic_state or gt_trajectory"/>
   <arg name="gt_trajectory_topic" default="/planning/ground_truth_trajectory" description="GT trajectory topic for gt_trajectory mode"/>
   <arg name="gt_sync_tolerance_ms" default="200.0" description="Sync tolerance (ms) for GT trajectory alignment"/>
+  <arg name="enable_epdms_calculation" default="true" description="Enable EPDMS calculation and EPDMS debug outputs"/>
 
   <group if="$(eval '&quot;$(var vehicle_model)&quot; != &quot;&quot;')">
     <node pkg="autoware_planning_data_analyzer" exec="autoware_planning_data_analyzer_node" name="autoware_planning_data_analyzer" output="screen">
@@ -21,6 +22,7 @@
       <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
+      <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>
@@ -35,6 +37,7 @@
       <param name="open_loop.gt_source_mode" value="$(var gt_source_mode)"/>
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
+      <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.cpp
@@ -124,6 +124,8 @@ AutowarePlanningDataAnalyzerNode::AutowarePlanningDataAnalyzerNode(
   enabled_metric_names_ =
     get_or_declare_parameter<std::vector<std::string>>(*this, "open_loop.enabled_metrics");
   debug_topics_enabled_ = get_or_declare_parameter<bool>(*this, "open_loop.debug_topics_enabled");
+  enable_epdms_calculation_ =
+    get_or_declare_parameter<bool>(*this, "open_loop.enable_epdms_calculation");
   trajectory_evaluation_horizon_s_ =
     get_or_declare_parameter<double>(*this, "open_loop.trajectory_evaluation_horizon");
   history_comfort_params_.past_horizon_s =
@@ -526,6 +528,7 @@ void AutowarePlanningDataAnalyzerNode::run_evaluation()
       evaluator.set_json_output_dir(output_dir_path.string());
       evaluator.set_metric_variant(open_loop_metric_variant);
       evaluator.set_enabled_metrics(enabled_metric_names_);
+      evaluator.set_epdms_calculation_enabled(enable_epdms_calculation_);
       evaluator.set_debug_topics_enabled(debug_topics_enabled_);
       evaluator.set_trajectory_evaluation_horizon(trajectory_evaluation_horizon_s_);
       evaluator.set_evaluation_horizons(evaluation_horizons);

--- a/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
+++ b/planning/autoware_planning_data_analyzer/src/autoware_planning_data_analyzer_node.hpp
@@ -90,6 +90,7 @@ private:
   double gt_sync_tolerance_ms_ = 200.0;
   std::vector<std::string> enabled_metric_names_;
   bool debug_topics_enabled_ = false;
+  bool enable_epdms_calculation_ = true;
   double trajectory_evaluation_horizon_s_ = 4.0;
   metrics::HistoryComfortParameters history_comfort_params_;
   metrics::ExtendedComfortParameters extended_comfort_parameters_;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -649,12 +649,8 @@ void OpenLoopEvaluator::evaluate(
         const auto agent_snapshot = build_epdms_snapshot(metrics);
         human_filter_metrics_list_[i] =
           metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
-        if (enabled_metrics_.enable_epdms_calculation) {
-          synthetic_epdms_metrics_list_[i] =
-            metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
-        } else {
-          synthetic_epdms_metrics_list_[i] = metrics::SyntheticEpdmsMetrics{};
-        }
+        synthetic_epdms_metrics_list_[i] =
+          metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
 
         const auto processed = phase2_processed.fetch_add(1U) + 1U;
         if (processed % kProgressLogInterval == 0U || processed == total_samples) {

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -1684,351 +1684,356 @@ nlohmann::json OpenLoopEvaluator::get_summary_as_json() const
       tag, "min_ttc", "Minimum Time To Collision within " + tag + " horizon [s]", min_ttc_vals);
   }
 
-  std::vector<double> history_comfort_values;
-  history_comfort_values.reserve(metrics_list_.size());
-  std::size_t history_comfort_available_count = 0;
-  std::map<std::string, std::size_t> history_comfort_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++history_comfort_reason_counts[m.history_comfort_reason];
-    if (m.history_comfort_available) {
-      history_comfort_values.push_back(m.history_comfort);
-      ++history_comfort_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "history_comfort", "Binary history comfort subscore across trajectories [-]",
-    history_comfort_values);
-  j["aggregate/history_comfort_available_count"] = history_comfort_available_count;
-  j["aggregate/history_comfort_unavailable_count"] =
-    metrics_list_.size() - history_comfort_available_count;
-  j["aggregate/history_comfort_reason_counts"] = history_comfort_reason_counts;
-  std::vector<double> extended_comfort_values;
-  extended_comfort_values.reserve(metrics_list_.size());
-  std::size_t extended_comfort_available_count = 0;
-  std::map<std::string, std::size_t> extended_comfort_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++extended_comfort_reason_counts[m.extended_comfort_reason];
-    if (m.extended_comfort_available) {
-      extended_comfort_values.push_back(m.extended_comfort);
-      ++extended_comfort_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "extended_comfort",
-    "Binary extended comfort subscore across consecutive trajectories [-]",
-    extended_comfort_values);
-  j["aggregate/extended_comfort_available_count"] = extended_comfort_available_count;
-  j["aggregate/extended_comfort_unavailable_count"] =
-    metrics_list_.size() - extended_comfort_available_count;
-  j["aggregate/extended_comfort_reason_counts"] = extended_comfort_reason_counts;
-  std::vector<double> time_to_collision_within_bound_values;
-  time_to_collision_within_bound_values.reserve(metrics_list_.size());
-  std::size_t time_to_collision_within_bound_available_count = 0;
-  std::map<std::string, std::size_t> time_to_collision_within_bound_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++time_to_collision_within_bound_reason_counts[m.time_to_collision_within_bound_reason];
-    if (m.time_to_collision_within_bound_available) {
-      time_to_collision_within_bound_values.push_back(m.time_to_collision_within_bound);
-      ++time_to_collision_within_bound_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "time_to_collision_within_bound",
-    "Binary TTC-within-bound subscore across trajectories [-]",
-    time_to_collision_within_bound_values);
-  j["aggregate/time_to_collision_within_bound_available_count"] =
-    time_to_collision_within_bound_available_count;
-  j["aggregate/time_to_collision_within_bound_unavailable_count"] =
-    metrics_list_.size() - time_to_collision_within_bound_available_count;
-  j["aggregate/time_to_collision_within_bound_reason_counts"] =
-    time_to_collision_within_bound_reason_counts;
-  std::vector<double> lane_keeping_values;
-  lane_keeping_values.reserve(metrics_list_.size());
-  std::size_t lane_keeping_available_count = 0;
-  std::map<std::string, std::size_t> lane_keeping_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++lane_keeping_reason_counts[m.lane_keeping_reason];
-    if (m.lane_keeping_available) {
-      lane_keeping_values.push_back(m.lane_keeping);
-      ++lane_keeping_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "lane_keeping", "Binary lane keeping subscore across trajectories [-]",
-    lane_keeping_values);
-  j["aggregate/lane_keeping_available_count"] = lane_keeping_available_count;
-  j["aggregate/lane_keeping_unavailable_count"] =
-    metrics_list_.size() - lane_keeping_available_count;
-  j["aggregate/lane_keeping_reason_counts"] = lane_keeping_reason_counts;
-  std::vector<double> ego_progress_values;
-  ego_progress_values.reserve(metrics_list_.size());
-  std::size_t ego_progress_available_count = 0;
-  std::map<std::string, std::size_t> ego_progress_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++ego_progress_reason_counts[m.ego_progress_reason];
-    if (m.ego_progress_available) {
-      ego_progress_values.push_back(m.ego_progress);
-      ++ego_progress_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "ego_progress", "Proposal-relative ego progress subscore across trajectories [-]",
-    ego_progress_values);
-  j["aggregate/ego_progress_available_count"] = ego_progress_available_count;
-  j["aggregate/ego_progress_unavailable_count"] =
-    metrics_list_.size() - ego_progress_available_count;
-  j["aggregate/ego_progress_reason_counts"] = ego_progress_reason_counts;
-  std::vector<double> drivable_area_compliance_values;
-  drivable_area_compliance_values.reserve(metrics_list_.size());
-  std::size_t drivable_area_compliance_available_count = 0;
-  std::map<std::string, std::size_t> drivable_area_compliance_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++drivable_area_compliance_reason_counts[m.drivable_area_compliance_reason];
-    if (m.drivable_area_compliance_available) {
-      drivable_area_compliance_values.push_back(m.drivable_area_compliance);
-      ++drivable_area_compliance_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "drivable_area_compliance",
-    "Binary drivable area compliance subscore across trajectories [-]",
-    drivable_area_compliance_values);
-  j["aggregate/drivable_area_compliance_available_count"] =
-    drivable_area_compliance_available_count;
-  j["aggregate/drivable_area_compliance_unavailable_count"] =
-    metrics_list_.size() - drivable_area_compliance_available_count;
-  j["aggregate/drivable_area_compliance_reason_counts"] = drivable_area_compliance_reason_counts;
-  std::vector<double> no_at_fault_collision_values;
-  std::vector<double> time_to_at_fault_collision_values;
-  no_at_fault_collision_values.reserve(metrics_list_.size());
-  time_to_at_fault_collision_values.reserve(metrics_list_.size());
-  std::size_t no_at_fault_collision_available_count = 0;
-  std::map<std::string, std::size_t> no_at_fault_collision_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++no_at_fault_collision_reason_counts[m.no_at_fault_collision_reason];
-    if (m.no_at_fault_collision_available) {
-      no_at_fault_collision_values.push_back(m.no_at_fault_collision);
-      ++no_at_fault_collision_available_count;
-      if (std::isfinite(m.time_to_at_fault_collision_s)) {
-        time_to_at_fault_collision_values.push_back(m.time_to_at_fault_collision_s);
+  if (enabled_metrics_.enable_epdms_calculation) {
+    std::vector<double> history_comfort_values;
+    history_comfort_values.reserve(metrics_list_.size());
+    std::size_t history_comfort_available_count = 0;
+    std::map<std::string, std::size_t> history_comfort_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++history_comfort_reason_counts[m.history_comfort_reason];
+      if (m.history_comfort_available) {
+        history_comfort_values.push_back(m.history_comfort);
+        ++history_comfort_available_count;
       }
     }
-  }
-  emit_metric(
-    "aggregate", "no_at_fault_collision",
-    "NAVSIM-style no-at-fault-collision subscore across trajectories [-]",
-    no_at_fault_collision_values);
-  emit_metric(
-    "aggregate", "time_to_at_fault_collision_s",
-    "Time to first at-fault collision across trajectories [s]", time_to_at_fault_collision_values);
-  j["aggregate/no_at_fault_collision_available_count"] = no_at_fault_collision_available_count;
-  j["aggregate/no_at_fault_collision_unavailable_count"] =
-    metrics_list_.size() - no_at_fault_collision_available_count;
-  j["aggregate/no_at_fault_collision_reason_counts"] = no_at_fault_collision_reason_counts;
-  std::vector<double> driving_direction_compliance_values;
-  std::vector<double> max_oncoming_progress_values;
-  driving_direction_compliance_values.reserve(metrics_list_.size());
-  max_oncoming_progress_values.reserve(metrics_list_.size());
-  std::size_t driving_direction_compliance_available_count = 0;
-  std::map<std::string, std::size_t> driving_direction_compliance_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++driving_direction_compliance_reason_counts[m.driving_direction_compliance_reason];
-    if (m.driving_direction_compliance_available) {
-      driving_direction_compliance_values.push_back(m.driving_direction_compliance);
-      max_oncoming_progress_values.push_back(m.max_oncoming_progress_m);
-      ++driving_direction_compliance_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "driving_direction_compliance",
-    "NAVSIM-style driving direction compliance subscore across trajectories [-]",
-    driving_direction_compliance_values);
-  emit_metric(
-    "aggregate", "max_oncoming_progress_m",
-    "Maximum rolling 1s oncoming progress across trajectories [m]", max_oncoming_progress_values);
-  j["aggregate/driving_direction_compliance_available_count"] =
-    driving_direction_compliance_available_count;
-  j["aggregate/driving_direction_compliance_unavailable_count"] =
-    metrics_list_.size() - driving_direction_compliance_available_count;
-  j["aggregate/driving_direction_compliance_reason_counts"] =
-    driving_direction_compliance_reason_counts;
-  std::vector<double> traffic_light_compliance_values;
-  traffic_light_compliance_values.reserve(metrics_list_.size());
-  std::size_t traffic_light_compliance_available_count = 0;
-  std::map<std::string, std::size_t> traffic_light_compliance_reason_counts;
-  for (const auto & m : metrics_list_) {
-    ++traffic_light_compliance_reason_counts[m.traffic_light_compliance_reason];
-    if (m.traffic_light_compliance_available) {
-      traffic_light_compliance_values.push_back(m.traffic_light_compliance);
-      ++traffic_light_compliance_available_count;
-    }
-  }
-  emit_metric(
-    "aggregate", "traffic_light_compliance",
-    "Binary traffic light compliance subscore across trajectories [-]",
-    traffic_light_compliance_values);
-  j["aggregate/traffic_light_compliance_available_count"] =
-    traffic_light_compliance_available_count;
-  j["aggregate/traffic_light_compliance_unavailable_count"] =
-    metrics_list_.size() - traffic_light_compliance_available_count;
-  j["aggregate/traffic_light_compliance_reason_counts"] = traffic_light_compliance_reason_counts;
-
-  auto emit_human_filter_metric = [&](
-                                    const std::string & metric_name, const std::string & desc,
-                                    const std::vector<double> & human_vals,
-                                    const std::vector<double> & filtered_vals,
-                                    const std::size_t applied_count) {
     emit_metric(
-      "aggregate/human_reference", metric_name, "Human reference " + desc + " [-]", human_vals);
+      "aggregate", "history_comfort", "Binary history comfort subscore across trajectories [-]",
+      history_comfort_values);
+    j["aggregate/history_comfort_available_count"] = history_comfort_available_count;
+    j["aggregate/history_comfort_unavailable_count"] =
+      metrics_list_.size() - history_comfort_available_count;
+    j["aggregate/history_comfort_reason_counts"] = history_comfort_reason_counts;
+    std::vector<double> extended_comfort_values;
+    extended_comfort_values.reserve(metrics_list_.size());
+    std::size_t extended_comfort_available_count = 0;
+    std::map<std::string, std::size_t> extended_comfort_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++extended_comfort_reason_counts[m.extended_comfort_reason];
+      if (m.extended_comfort_available) {
+        extended_comfort_values.push_back(m.extended_comfort);
+        ++extended_comfort_available_count;
+      }
+    }
     emit_metric(
-      "aggregate/human_filtered", metric_name, "Human-filtered " + desc + " [-]", filtered_vals);
-    j["aggregate/human_filter_applied_counts/" + metric_name] = applied_count;
-  };
+      "aggregate", "extended_comfort",
+      "Binary extended comfort subscore across consecutive trajectories [-]",
+      extended_comfort_values);
+    j["aggregate/extended_comfort_available_count"] = extended_comfort_available_count;
+    j["aggregate/extended_comfort_unavailable_count"] =
+      metrics_list_.size() - extended_comfort_available_count;
+    j["aggregate/extended_comfort_reason_counts"] = extended_comfort_reason_counts;
+    std::vector<double> time_to_collision_within_bound_values;
+    time_to_collision_within_bound_values.reserve(metrics_list_.size());
+    std::size_t time_to_collision_within_bound_available_count = 0;
+    std::map<std::string, std::size_t> time_to_collision_within_bound_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++time_to_collision_within_bound_reason_counts[m.time_to_collision_within_bound_reason];
+      if (m.time_to_collision_within_bound_available) {
+        time_to_collision_within_bound_values.push_back(m.time_to_collision_within_bound);
+        ++time_to_collision_within_bound_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "time_to_collision_within_bound",
+      "Binary TTC-within-bound subscore across trajectories [-]",
+      time_to_collision_within_bound_values);
+    j["aggregate/time_to_collision_within_bound_available_count"] =
+      time_to_collision_within_bound_available_count;
+    j["aggregate/time_to_collision_within_bound_unavailable_count"] =
+      metrics_list_.size() - time_to_collision_within_bound_available_count;
+    j["aggregate/time_to_collision_within_bound_reason_counts"] =
+      time_to_collision_within_bound_reason_counts;
+    std::vector<double> lane_keeping_values;
+    lane_keeping_values.reserve(metrics_list_.size());
+    std::size_t lane_keeping_available_count = 0;
+    std::map<std::string, std::size_t> lane_keeping_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++lane_keeping_reason_counts[m.lane_keeping_reason];
+      if (m.lane_keeping_available) {
+        lane_keeping_values.push_back(m.lane_keeping);
+        ++lane_keeping_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "lane_keeping", "Binary lane keeping subscore across trajectories [-]",
+      lane_keeping_values);
+    j["aggregate/lane_keeping_available_count"] = lane_keeping_available_count;
+    j["aggregate/lane_keeping_unavailable_count"] =
+      metrics_list_.size() - lane_keeping_available_count;
+    j["aggregate/lane_keeping_reason_counts"] = lane_keeping_reason_counts;
+    std::vector<double> ego_progress_values;
+    ego_progress_values.reserve(metrics_list_.size());
+    std::size_t ego_progress_available_count = 0;
+    std::map<std::string, std::size_t> ego_progress_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++ego_progress_reason_counts[m.ego_progress_reason];
+      if (m.ego_progress_available) {
+        ego_progress_values.push_back(m.ego_progress);
+        ++ego_progress_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "ego_progress",
+      "Proposal-relative ego progress subscore across trajectories [-]", ego_progress_values);
+    j["aggregate/ego_progress_available_count"] = ego_progress_available_count;
+    j["aggregate/ego_progress_unavailable_count"] =
+      metrics_list_.size() - ego_progress_available_count;
+    j["aggregate/ego_progress_reason_counts"] = ego_progress_reason_counts;
+    std::vector<double> drivable_area_compliance_values;
+    drivable_area_compliance_values.reserve(metrics_list_.size());
+    std::size_t drivable_area_compliance_available_count = 0;
+    std::map<std::string, std::size_t> drivable_area_compliance_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++drivable_area_compliance_reason_counts[m.drivable_area_compliance_reason];
+      if (m.drivable_area_compliance_available) {
+        drivable_area_compliance_values.push_back(m.drivable_area_compliance);
+        ++drivable_area_compliance_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "drivable_area_compliance",
+      "Binary drivable area compliance subscore across trajectories [-]",
+      drivable_area_compliance_values);
+    j["aggregate/drivable_area_compliance_available_count"] =
+      drivable_area_compliance_available_count;
+    j["aggregate/drivable_area_compliance_unavailable_count"] =
+      metrics_list_.size() - drivable_area_compliance_available_count;
+    j["aggregate/drivable_area_compliance_reason_counts"] = drivable_area_compliance_reason_counts;
+    std::vector<double> no_at_fault_collision_values;
+    std::vector<double> time_to_at_fault_collision_values;
+    no_at_fault_collision_values.reserve(metrics_list_.size());
+    time_to_at_fault_collision_values.reserve(metrics_list_.size());
+    std::size_t no_at_fault_collision_available_count = 0;
+    std::map<std::string, std::size_t> no_at_fault_collision_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++no_at_fault_collision_reason_counts[m.no_at_fault_collision_reason];
+      if (m.no_at_fault_collision_available) {
+        no_at_fault_collision_values.push_back(m.no_at_fault_collision);
+        ++no_at_fault_collision_available_count;
+        if (std::isfinite(m.time_to_at_fault_collision_s)) {
+          time_to_at_fault_collision_values.push_back(m.time_to_at_fault_collision_s);
+        }
+      }
+    }
+    emit_metric(
+      "aggregate", "no_at_fault_collision",
+      "NAVSIM-style no-at-fault-collision subscore across trajectories [-]",
+      no_at_fault_collision_values);
+    emit_metric(
+      "aggregate", "time_to_at_fault_collision_s",
+      "Time to first at-fault collision across trajectories [s]",
+      time_to_at_fault_collision_values);
+    j["aggregate/no_at_fault_collision_available_count"] = no_at_fault_collision_available_count;
+    j["aggregate/no_at_fault_collision_unavailable_count"] =
+      metrics_list_.size() - no_at_fault_collision_available_count;
+    j["aggregate/no_at_fault_collision_reason_counts"] = no_at_fault_collision_reason_counts;
+    std::vector<double> driving_direction_compliance_values;
+    std::vector<double> max_oncoming_progress_values;
+    driving_direction_compliance_values.reserve(metrics_list_.size());
+    max_oncoming_progress_values.reserve(metrics_list_.size());
+    std::size_t driving_direction_compliance_available_count = 0;
+    std::map<std::string, std::size_t> driving_direction_compliance_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++driving_direction_compliance_reason_counts[m.driving_direction_compliance_reason];
+      if (m.driving_direction_compliance_available) {
+        driving_direction_compliance_values.push_back(m.driving_direction_compliance);
+        max_oncoming_progress_values.push_back(m.max_oncoming_progress_m);
+        ++driving_direction_compliance_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "driving_direction_compliance",
+      "NAVSIM-style driving direction compliance subscore across trajectories [-]",
+      driving_direction_compliance_values);
+    emit_metric(
+      "aggregate", "max_oncoming_progress_m",
+      "Maximum rolling 1s oncoming progress across trajectories [m]", max_oncoming_progress_values);
+    j["aggregate/driving_direction_compliance_available_count"] =
+      driving_direction_compliance_available_count;
+    j["aggregate/driving_direction_compliance_unavailable_count"] =
+      metrics_list_.size() - driving_direction_compliance_available_count;
+    j["aggregate/driving_direction_compliance_reason_counts"] =
+      driving_direction_compliance_reason_counts;
+    std::vector<double> traffic_light_compliance_values;
+    traffic_light_compliance_values.reserve(metrics_list_.size());
+    std::size_t traffic_light_compliance_available_count = 0;
+    std::map<std::string, std::size_t> traffic_light_compliance_reason_counts;
+    for (const auto & m : metrics_list_) {
+      ++traffic_light_compliance_reason_counts[m.traffic_light_compliance_reason];
+      if (m.traffic_light_compliance_available) {
+        traffic_light_compliance_values.push_back(m.traffic_light_compliance);
+        ++traffic_light_compliance_available_count;
+      }
+    }
+    emit_metric(
+      "aggregate", "traffic_light_compliance",
+      "Binary traffic light compliance subscore across trajectories [-]",
+      traffic_light_compliance_values);
+    j["aggregate/traffic_light_compliance_available_count"] =
+      traffic_light_compliance_available_count;
+    j["aggregate/traffic_light_compliance_unavailable_count"] =
+      metrics_list_.size() - traffic_light_compliance_available_count;
+    j["aggregate/traffic_light_compliance_reason_counts"] = traffic_light_compliance_reason_counts;
 
-  std::vector<double> human_history_comfort_values;
-  std::vector<double> filtered_history_comfort_values;
-  std::size_t history_comfort_filter_applied_count = 0;
-  std::vector<double> human_ego_progress_values;
-  std::vector<double> filtered_ego_progress_values;
-  std::size_t ego_progress_filter_applied_count = 0;
-  std::vector<double> human_ttc_within_bound_values;
-  std::vector<double> filtered_ttc_within_bound_values;
-  std::size_t ttc_within_bound_filter_applied_count = 0;
-  std::vector<double> human_lane_keeping_values;
-  std::vector<double> filtered_lane_keeping_values;
-  std::size_t lane_keeping_filter_applied_count = 0;
-  std::vector<double> human_dac_values;
-  std::vector<double> filtered_dac_values;
-  std::size_t dac_filter_applied_count = 0;
-  std::vector<double> human_nc_values;
-  std::vector<double> filtered_nc_values;
-  std::size_t nc_filter_applied_count = 0;
-  std::vector<double> human_ddc_values;
-  std::vector<double> filtered_ddc_values;
-  std::size_t ddc_filter_applied_count = 0;
-  std::vector<double> human_tlc_values;
-  std::vector<double> filtered_tlc_values;
-  std::size_t tlc_filter_applied_count = 0;
-  for (const auto & m : human_filter_metrics_list_) {
-    if (m.history_comfort.human_reference_available) {
-      human_history_comfort_values.push_back(m.history_comfort.human_reference);
-      filtered_history_comfort_values.push_back(m.history_comfort.filtered);
-    }
-    history_comfort_filter_applied_count +=
-      static_cast<std::size_t>(m.history_comfort.filter_applied);
-    if (m.ego_progress.human_reference_available) {
-      human_ego_progress_values.push_back(m.ego_progress.human_reference);
-      filtered_ego_progress_values.push_back(m.ego_progress.filtered);
-    }
-    ego_progress_filter_applied_count += static_cast<std::size_t>(m.ego_progress.filter_applied);
-    if (m.time_to_collision_within_bound.human_reference_available) {
-      human_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.human_reference);
-      filtered_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.filtered);
-    }
-    ttc_within_bound_filter_applied_count +=
-      static_cast<std::size_t>(m.time_to_collision_within_bound.filter_applied);
-    if (m.lane_keeping.human_reference_available) {
-      human_lane_keeping_values.push_back(m.lane_keeping.human_reference);
-      filtered_lane_keeping_values.push_back(m.lane_keeping.filtered);
-    }
-    lane_keeping_filter_applied_count += static_cast<std::size_t>(m.lane_keeping.filter_applied);
-    if (m.drivable_area_compliance.human_reference_available) {
-      human_dac_values.push_back(m.drivable_area_compliance.human_reference);
-      filtered_dac_values.push_back(m.drivable_area_compliance.filtered);
-    }
-    dac_filter_applied_count += static_cast<std::size_t>(m.drivable_area_compliance.filter_applied);
-    if (m.no_at_fault_collision.human_reference_available) {
-      human_nc_values.push_back(m.no_at_fault_collision.human_reference);
-      filtered_nc_values.push_back(m.no_at_fault_collision.filtered);
-    }
-    nc_filter_applied_count += static_cast<std::size_t>(m.no_at_fault_collision.filter_applied);
-    if (m.driving_direction_compliance.human_reference_available) {
-      human_ddc_values.push_back(m.driving_direction_compliance.human_reference);
-      filtered_ddc_values.push_back(m.driving_direction_compliance.filtered);
-    }
-    ddc_filter_applied_count +=
-      static_cast<std::size_t>(m.driving_direction_compliance.filter_applied);
-    if (m.traffic_light_compliance.human_reference_available) {
-      human_tlc_values.push_back(m.traffic_light_compliance.human_reference);
-      filtered_tlc_values.push_back(m.traffic_light_compliance.filtered);
-    }
-    tlc_filter_applied_count += static_cast<std::size_t>(m.traffic_light_compliance.filter_applied);
-  }
-  emit_human_filter_metric(
-    "history_comfort", "history comfort subscore", human_history_comfort_values,
-    filtered_history_comfort_values, history_comfort_filter_applied_count);
-  emit_human_filter_metric(
-    "ego_progress", "ego progress subscore", human_ego_progress_values,
-    filtered_ego_progress_values, ego_progress_filter_applied_count);
-  emit_human_filter_metric(
-    "time_to_collision_within_bound", "TTC-within-bound subscore", human_ttc_within_bound_values,
-    filtered_ttc_within_bound_values, ttc_within_bound_filter_applied_count);
-  emit_human_filter_metric(
-    "lane_keeping", "lane keeping subscore", human_lane_keeping_values,
-    filtered_lane_keeping_values, lane_keeping_filter_applied_count);
-  emit_human_filter_metric(
-    "drivable_area_compliance", "drivable area compliance subscore", human_dac_values,
-    filtered_dac_values, dac_filter_applied_count);
-  emit_human_filter_metric(
-    "no_at_fault_collision", "no-at-fault collision subscore", human_nc_values, filtered_nc_values,
-    nc_filter_applied_count);
-  emit_human_filter_metric(
-    "driving_direction_compliance", "driving direction compliance subscore", human_ddc_values,
-    filtered_ddc_values, ddc_filter_applied_count);
-  emit_human_filter_metric(
-    "traffic_light_compliance", "traffic light compliance subscore", human_tlc_values,
-    filtered_tlc_values, tlc_filter_applied_count);
+    auto emit_human_filter_metric = [&](
+                                      const std::string & metric_name, const std::string & desc,
+                                      const std::vector<double> & human_vals,
+                                      const std::vector<double> & filtered_vals,
+                                      const std::size_t applied_count) {
+      emit_metric(
+        "aggregate/human_reference", metric_name, "Human reference " + desc + " [-]", human_vals);
+      emit_metric(
+        "aggregate/human_filtered", metric_name, "Human-filtered " + desc + " [-]", filtered_vals);
+      j["aggregate/human_filter_applied_counts/" + metric_name] = applied_count;
+    };
 
-  std::vector<double> synthetic_raw_prod_values;
-  std::vector<double> synthetic_raw_weighted_values;
-  std::vector<double> synthetic_raw_epdms_values;
-  std::size_t synthetic_raw_available_count = 0;
-  std::vector<double> synthetic_filtered_prod_values;
-  std::vector<double> synthetic_filtered_weighted_values;
-  std::vector<double> synthetic_filtered_epdms_values;
-  std::size_t synthetic_filtered_available_count = 0;
-  for (const auto & m : synthetic_epdms_metrics_list_) {
-    if (m.raw.available) {
-      synthetic_raw_prod_values.push_back(m.raw.multiplicative_metrics_prod);
-      synthetic_raw_weighted_values.push_back(m.raw.weighted_metrics);
-      synthetic_raw_epdms_values.push_back(m.raw.epdms);
-      ++synthetic_raw_available_count;
+    std::vector<double> human_history_comfort_values;
+    std::vector<double> filtered_history_comfort_values;
+    std::size_t history_comfort_filter_applied_count = 0;
+    std::vector<double> human_ego_progress_values;
+    std::vector<double> filtered_ego_progress_values;
+    std::size_t ego_progress_filter_applied_count = 0;
+    std::vector<double> human_ttc_within_bound_values;
+    std::vector<double> filtered_ttc_within_bound_values;
+    std::size_t ttc_within_bound_filter_applied_count = 0;
+    std::vector<double> human_lane_keeping_values;
+    std::vector<double> filtered_lane_keeping_values;
+    std::size_t lane_keeping_filter_applied_count = 0;
+    std::vector<double> human_dac_values;
+    std::vector<double> filtered_dac_values;
+    std::size_t dac_filter_applied_count = 0;
+    std::vector<double> human_nc_values;
+    std::vector<double> filtered_nc_values;
+    std::size_t nc_filter_applied_count = 0;
+    std::vector<double> human_ddc_values;
+    std::vector<double> filtered_ddc_values;
+    std::size_t ddc_filter_applied_count = 0;
+    std::vector<double> human_tlc_values;
+    std::vector<double> filtered_tlc_values;
+    std::size_t tlc_filter_applied_count = 0;
+    for (const auto & m : human_filter_metrics_list_) {
+      if (m.history_comfort.human_reference_available) {
+        human_history_comfort_values.push_back(m.history_comfort.human_reference);
+        filtered_history_comfort_values.push_back(m.history_comfort.filtered);
+      }
+      history_comfort_filter_applied_count +=
+        static_cast<std::size_t>(m.history_comfort.filter_applied);
+      if (m.ego_progress.human_reference_available) {
+        human_ego_progress_values.push_back(m.ego_progress.human_reference);
+        filtered_ego_progress_values.push_back(m.ego_progress.filtered);
+      }
+      ego_progress_filter_applied_count += static_cast<std::size_t>(m.ego_progress.filter_applied);
+      if (m.time_to_collision_within_bound.human_reference_available) {
+        human_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.human_reference);
+        filtered_ttc_within_bound_values.push_back(m.time_to_collision_within_bound.filtered);
+      }
+      ttc_within_bound_filter_applied_count +=
+        static_cast<std::size_t>(m.time_to_collision_within_bound.filter_applied);
+      if (m.lane_keeping.human_reference_available) {
+        human_lane_keeping_values.push_back(m.lane_keeping.human_reference);
+        filtered_lane_keeping_values.push_back(m.lane_keeping.filtered);
+      }
+      lane_keeping_filter_applied_count += static_cast<std::size_t>(m.lane_keeping.filter_applied);
+      if (m.drivable_area_compliance.human_reference_available) {
+        human_dac_values.push_back(m.drivable_area_compliance.human_reference);
+        filtered_dac_values.push_back(m.drivable_area_compliance.filtered);
+      }
+      dac_filter_applied_count +=
+        static_cast<std::size_t>(m.drivable_area_compliance.filter_applied);
+      if (m.no_at_fault_collision.human_reference_available) {
+        human_nc_values.push_back(m.no_at_fault_collision.human_reference);
+        filtered_nc_values.push_back(m.no_at_fault_collision.filtered);
+      }
+      nc_filter_applied_count += static_cast<std::size_t>(m.no_at_fault_collision.filter_applied);
+      if (m.driving_direction_compliance.human_reference_available) {
+        human_ddc_values.push_back(m.driving_direction_compliance.human_reference);
+        filtered_ddc_values.push_back(m.driving_direction_compliance.filtered);
+      }
+      ddc_filter_applied_count +=
+        static_cast<std::size_t>(m.driving_direction_compliance.filter_applied);
+      if (m.traffic_light_compliance.human_reference_available) {
+        human_tlc_values.push_back(m.traffic_light_compliance.human_reference);
+        filtered_tlc_values.push_back(m.traffic_light_compliance.filtered);
+      }
+      tlc_filter_applied_count +=
+        static_cast<std::size_t>(m.traffic_light_compliance.filter_applied);
     }
-    if (m.human_filtered.available) {
-      synthetic_filtered_prod_values.push_back(m.human_filtered.multiplicative_metrics_prod);
-      synthetic_filtered_weighted_values.push_back(m.human_filtered.weighted_metrics);
-      synthetic_filtered_epdms_values.push_back(m.human_filtered.epdms);
-      ++synthetic_filtered_available_count;
+    emit_human_filter_metric(
+      "history_comfort", "history comfort subscore", human_history_comfort_values,
+      filtered_history_comfort_values, history_comfort_filter_applied_count);
+    emit_human_filter_metric(
+      "ego_progress", "ego progress subscore", human_ego_progress_values,
+      filtered_ego_progress_values, ego_progress_filter_applied_count);
+    emit_human_filter_metric(
+      "time_to_collision_within_bound", "TTC-within-bound subscore", human_ttc_within_bound_values,
+      filtered_ttc_within_bound_values, ttc_within_bound_filter_applied_count);
+    emit_human_filter_metric(
+      "lane_keeping", "lane keeping subscore", human_lane_keeping_values,
+      filtered_lane_keeping_values, lane_keeping_filter_applied_count);
+    emit_human_filter_metric(
+      "drivable_area_compliance", "drivable area compliance subscore", human_dac_values,
+      filtered_dac_values, dac_filter_applied_count);
+    emit_human_filter_metric(
+      "no_at_fault_collision", "no-at-fault collision subscore", human_nc_values,
+      filtered_nc_values, nc_filter_applied_count);
+    emit_human_filter_metric(
+      "driving_direction_compliance", "driving direction compliance subscore", human_ddc_values,
+      filtered_ddc_values, ddc_filter_applied_count);
+    emit_human_filter_metric(
+      "traffic_light_compliance", "traffic light compliance subscore", human_tlc_values,
+      filtered_tlc_values, tlc_filter_applied_count);
+
+    std::vector<double> synthetic_raw_prod_values;
+    std::vector<double> synthetic_raw_weighted_values;
+    std::vector<double> synthetic_raw_epdms_values;
+    std::size_t synthetic_raw_available_count = 0;
+    std::vector<double> synthetic_filtered_prod_values;
+    std::vector<double> synthetic_filtered_weighted_values;
+    std::vector<double> synthetic_filtered_epdms_values;
+    std::size_t synthetic_filtered_available_count = 0;
+    for (const auto & m : synthetic_epdms_metrics_list_) {
+      if (m.raw.available) {
+        synthetic_raw_prod_values.push_back(m.raw.multiplicative_metrics_prod);
+        synthetic_raw_weighted_values.push_back(m.raw.weighted_metrics);
+        synthetic_raw_epdms_values.push_back(m.raw.epdms);
+        ++synthetic_raw_available_count;
+      }
+      if (m.human_filtered.available) {
+        synthetic_filtered_prod_values.push_back(m.human_filtered.multiplicative_metrics_prod);
+        synthetic_filtered_weighted_values.push_back(m.human_filtered.weighted_metrics);
+        synthetic_filtered_epdms_values.push_back(m.human_filtered.epdms);
+        ++synthetic_filtered_available_count;
+      }
     }
+    emit_metric(
+      "aggregate/synthetic_epdms", "raw_multiplicative_metrics_prod",
+      "Synthetic EPDMS multiplicative product across trajectories [-]", synthetic_raw_prod_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "raw_weighted_metrics",
+      "Synthetic EPDMS weighted score across trajectories [-]", synthetic_raw_weighted_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "raw", "Synthetic EPDMS score across trajectories [-]",
+      synthetic_raw_epdms_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "human_filtered_multiplicative_metrics_prod",
+      "Human-filtered synthetic EPDMS multiplicative product across trajectories [-]",
+      synthetic_filtered_prod_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "human_filtered_weighted_metrics",
+      "Human-filtered synthetic EPDMS weighted score across trajectories [-]",
+      synthetic_filtered_weighted_values);
+    emit_metric(
+      "aggregate/synthetic_epdms", "human_filtered",
+      "Human-filtered synthetic EPDMS score across trajectories [-]",
+      synthetic_filtered_epdms_values);
+    j["aggregate/synthetic_epdms/raw_available_count"] = synthetic_raw_available_count;
+    j["aggregate/synthetic_epdms/raw_unavailable_count"] =
+      synthetic_epdms_metrics_list_.size() - synthetic_raw_available_count;
+    j["aggregate/synthetic_epdms/human_filtered_available_count"] =
+      synthetic_filtered_available_count;
+    j["aggregate/synthetic_epdms/human_filtered_unavailable_count"] =
+      synthetic_epdms_metrics_list_.size() - synthetic_filtered_available_count;
   }
-  emit_metric(
-    "aggregate/synthetic_epdms", "raw_multiplicative_metrics_prod",
-    "Synthetic EPDMS multiplicative product across trajectories [-]", synthetic_raw_prod_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "raw_weighted_metrics",
-    "Synthetic EPDMS weighted score across trajectories [-]", synthetic_raw_weighted_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "raw", "Synthetic EPDMS score across trajectories [-]",
-    synthetic_raw_epdms_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "human_filtered_multiplicative_metrics_prod",
-    "Human-filtered synthetic EPDMS multiplicative product across trajectories [-]",
-    synthetic_filtered_prod_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "human_filtered_weighted_metrics",
-    "Human-filtered synthetic EPDMS weighted score across trajectories [-]",
-    synthetic_filtered_weighted_values);
-  emit_metric(
-    "aggregate/synthetic_epdms", "human_filtered",
-    "Human-filtered synthetic EPDMS score across trajectories [-]",
-    synthetic_filtered_epdms_values);
-  j["aggregate/synthetic_epdms/raw_available_count"] = synthetic_raw_available_count;
-  j["aggregate/synthetic_epdms/raw_unavailable_count"] =
-    synthetic_epdms_metrics_list_.size() - synthetic_raw_available_count;
-  j["aggregate/synthetic_epdms/human_filtered_available_count"] =
-    synthetic_filtered_available_count;
-  j["aggregate/synthetic_epdms/human_filtered_unavailable_count"] =
-    synthetic_epdms_metrics_list_.size() - synthetic_filtered_available_count;
 
   // ----- override_only aggregation -----
   // Re-aggregate per-horizon ADE/FDE (plus the rest of the horizon metrics for symmetry)
@@ -2128,112 +2133,117 @@ nlohmann::json OpenLoopEvaluator::get_full_results_as_json() const
     traj["lateral_deviations"] = m.lateral_deviations;
     traj["longitudinal_deviations"] = m.longitudinal_deviations;
     traj["ttc"] = m.ttc;
-    traj["history_comfort"] = m.history_comfort;
-    traj["history_comfort_available"] = m.history_comfort_available;
-    traj["history_comfort_reason"] = m.history_comfort_reason;
-    traj["extended_comfort"] = m.extended_comfort;
-    traj["extended_comfort_available"] = m.extended_comfort_available;
-    traj["extended_comfort_reason"] = m.extended_comfort_reason;
-    traj["time_to_collision_within_bound"] = m.time_to_collision_within_bound;
-    traj["time_to_collision_within_bound_available"] = m.time_to_collision_within_bound_available;
-    traj["time_to_collision_within_bound_reason"] = m.time_to_collision_within_bound_reason;
-    traj["time_to_collision_infraction_time_s"] = m.time_to_collision_infraction_time_s;
-    traj["lane_keeping"] = m.lane_keeping;
-    traj["lane_keeping_available"] = m.lane_keeping_available;
-    traj["lane_keeping_reason"] = m.lane_keeping_reason;
-    traj["ego_progress"] = m.ego_progress;
-    traj["ego_progress_available"] = m.ego_progress_available;
-    traj["ego_progress_reason"] = m.ego_progress_reason;
-    traj["ego_progress_raw_m"] = m.ego_progress_raw_m;
-    traj["ego_progress_best_raw_m"] = m.ego_progress_best_raw_m;
-    traj["ego_progress_multiplicative_mask"] = m.ego_progress_mask;
-    traj["ego_progress_denominator_m"] = m.ego_progress_denominator_m;
-    traj["drivable_area_compliance"] = m.drivable_area_compliance;
-    traj["drivable_area_compliance_available"] = m.drivable_area_compliance_available;
-    traj["drivable_area_compliance_reason"] = m.drivable_area_compliance_reason;
-    traj["no_at_fault_collision"] = m.no_at_fault_collision;
-    traj["no_at_fault_collision_available"] = m.no_at_fault_collision_available;
-    traj["no_at_fault_collision_reason"] = m.no_at_fault_collision_reason;
-    traj["time_to_at_fault_collision_s"] = m.time_to_at_fault_collision_s;
-    traj["driving_direction_compliance"] = m.driving_direction_compliance;
-    traj["driving_direction_compliance_available"] = m.driving_direction_compliance_available;
-    traj["driving_direction_compliance_reason"] = m.driving_direction_compliance_reason;
-    traj["max_oncoming_progress_m"] = m.max_oncoming_progress_m;
-    traj["traffic_light_compliance"] = m.traffic_light_compliance;
-    traj["traffic_light_compliance_available"] = m.traffic_light_compliance_available;
-    traj["traffic_light_compliance_reason"] = m.traffic_light_compliance_reason;
-    if (i < human_filter_metrics_list_.size()) {
-      const auto & hf = human_filter_metrics_list_[i];
-      traj["human_reference"]["history_comfort"] = hf.history_comfort.human_reference;
-      traj["human_reference"]["history_comfort_available"] =
-        hf.history_comfort.human_reference_available;
-      traj["human_reference"]["ego_progress"] = hf.ego_progress.human_reference;
-      traj["human_reference"]["ego_progress_available"] = hf.ego_progress.human_reference_available;
-      traj["human_reference"]["time_to_collision_within_bound"] =
-        hf.time_to_collision_within_bound.human_reference;
-      traj["human_reference"]["time_to_collision_within_bound_available"] =
-        hf.time_to_collision_within_bound.human_reference_available;
-      traj["human_reference"]["lane_keeping"] = hf.lane_keeping.human_reference;
-      traj["human_reference"]["lane_keeping_available"] = hf.lane_keeping.human_reference_available;
-      traj["human_reference"]["drivable_area_compliance"] =
-        hf.drivable_area_compliance.human_reference;
-      traj["human_reference"]["drivable_area_compliance_available"] =
-        hf.drivable_area_compliance.human_reference_available;
-      traj["human_reference"]["no_at_fault_collision"] = hf.no_at_fault_collision.human_reference;
-      traj["human_reference"]["no_at_fault_collision_available"] =
-        hf.no_at_fault_collision.human_reference_available;
-      traj["human_reference"]["driving_direction_compliance"] =
-        hf.driving_direction_compliance.human_reference;
-      traj["human_reference"]["driving_direction_compliance_available"] =
-        hf.driving_direction_compliance.human_reference_available;
-      traj["human_reference"]["traffic_light_compliance"] =
-        hf.traffic_light_compliance.human_reference;
-      traj["human_reference"]["traffic_light_compliance_available"] =
-        hf.traffic_light_compliance.human_reference_available;
+    if (enabled_metrics_.enable_epdms_calculation) {
+      traj["history_comfort"] = m.history_comfort;
+      traj["history_comfort_available"] = m.history_comfort_available;
+      traj["history_comfort_reason"] = m.history_comfort_reason;
+      traj["extended_comfort"] = m.extended_comfort;
+      traj["extended_comfort_available"] = m.extended_comfort_available;
+      traj["extended_comfort_reason"] = m.extended_comfort_reason;
+      traj["time_to_collision_within_bound"] = m.time_to_collision_within_bound;
+      traj["time_to_collision_within_bound_available"] = m.time_to_collision_within_bound_available;
+      traj["time_to_collision_within_bound_reason"] = m.time_to_collision_within_bound_reason;
+      traj["time_to_collision_infraction_time_s"] = m.time_to_collision_infraction_time_s;
+      traj["lane_keeping"] = m.lane_keeping;
+      traj["lane_keeping_available"] = m.lane_keeping_available;
+      traj["lane_keeping_reason"] = m.lane_keeping_reason;
+      traj["ego_progress"] = m.ego_progress;
+      traj["ego_progress_available"] = m.ego_progress_available;
+      traj["ego_progress_reason"] = m.ego_progress_reason;
+      traj["ego_progress_raw_m"] = m.ego_progress_raw_m;
+      traj["ego_progress_best_raw_m"] = m.ego_progress_best_raw_m;
+      traj["ego_progress_multiplicative_mask"] = m.ego_progress_mask;
+      traj["ego_progress_denominator_m"] = m.ego_progress_denominator_m;
+      traj["drivable_area_compliance"] = m.drivable_area_compliance;
+      traj["drivable_area_compliance_available"] = m.drivable_area_compliance_available;
+      traj["drivable_area_compliance_reason"] = m.drivable_area_compliance_reason;
+      traj["no_at_fault_collision"] = m.no_at_fault_collision;
+      traj["no_at_fault_collision_available"] = m.no_at_fault_collision_available;
+      traj["no_at_fault_collision_reason"] = m.no_at_fault_collision_reason;
+      traj["time_to_at_fault_collision_s"] = m.time_to_at_fault_collision_s;
+      traj["driving_direction_compliance"] = m.driving_direction_compliance;
+      traj["driving_direction_compliance_available"] = m.driving_direction_compliance_available;
+      traj["driving_direction_compliance_reason"] = m.driving_direction_compliance_reason;
+      traj["max_oncoming_progress_m"] = m.max_oncoming_progress_m;
+      traj["traffic_light_compliance"] = m.traffic_light_compliance;
+      traj["traffic_light_compliance_available"] = m.traffic_light_compliance_available;
+      traj["traffic_light_compliance_reason"] = m.traffic_light_compliance_reason;
+      if (i < human_filter_metrics_list_.size()) {
+        const auto & hf = human_filter_metrics_list_[i];
+        traj["human_reference"]["history_comfort"] = hf.history_comfort.human_reference;
+        traj["human_reference"]["history_comfort_available"] =
+          hf.history_comfort.human_reference_available;
+        traj["human_reference"]["ego_progress"] = hf.ego_progress.human_reference;
+        traj["human_reference"]["ego_progress_available"] =
+          hf.ego_progress.human_reference_available;
+        traj["human_reference"]["time_to_collision_within_bound"] =
+          hf.time_to_collision_within_bound.human_reference;
+        traj["human_reference"]["time_to_collision_within_bound_available"] =
+          hf.time_to_collision_within_bound.human_reference_available;
+        traj["human_reference"]["lane_keeping"] = hf.lane_keeping.human_reference;
+        traj["human_reference"]["lane_keeping_available"] =
+          hf.lane_keeping.human_reference_available;
+        traj["human_reference"]["drivable_area_compliance"] =
+          hf.drivable_area_compliance.human_reference;
+        traj["human_reference"]["drivable_area_compliance_available"] =
+          hf.drivable_area_compliance.human_reference_available;
+        traj["human_reference"]["no_at_fault_collision"] = hf.no_at_fault_collision.human_reference;
+        traj["human_reference"]["no_at_fault_collision_available"] =
+          hf.no_at_fault_collision.human_reference_available;
+        traj["human_reference"]["driving_direction_compliance"] =
+          hf.driving_direction_compliance.human_reference;
+        traj["human_reference"]["driving_direction_compliance_available"] =
+          hf.driving_direction_compliance.human_reference_available;
+        traj["human_reference"]["traffic_light_compliance"] =
+          hf.traffic_light_compliance.human_reference;
+        traj["human_reference"]["traffic_light_compliance_available"] =
+          hf.traffic_light_compliance.human_reference_available;
 
-      traj["human_filtered"]["history_comfort"] = hf.history_comfort.filtered;
-      traj["human_filtered"]["history_comfort_filter_applied"] = hf.history_comfort.filter_applied;
-      traj["human_filtered"]["ego_progress"] = hf.ego_progress.filtered;
-      traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress.filter_applied;
-      traj["human_filtered"]["time_to_collision_within_bound"] =
-        hf.time_to_collision_within_bound.filtered;
-      traj["human_filtered"]["time_to_collision_within_bound_filter_applied"] =
-        hf.time_to_collision_within_bound.filter_applied;
-      traj["human_filtered"]["lane_keeping"] = hf.lane_keeping.filtered;
-      traj["human_filtered"]["lane_keeping_filter_applied"] = hf.lane_keeping.filter_applied;
-      traj["human_filtered"]["drivable_area_compliance"] = hf.drivable_area_compliance.filtered;
-      traj["human_filtered"]["drivable_area_compliance_filter_applied"] =
-        hf.drivable_area_compliance.filter_applied;
-      traj["human_filtered"]["no_at_fault_collision"] = hf.no_at_fault_collision.filtered;
-      traj["human_filtered"]["no_at_fault_collision_filter_applied"] =
-        hf.no_at_fault_collision.filter_applied;
-      traj["human_filtered"]["driving_direction_compliance"] =
-        hf.driving_direction_compliance.filtered;
-      traj["human_filtered"]["driving_direction_compliance_filter_applied"] =
-        hf.driving_direction_compliance.filter_applied;
-      traj["human_filtered"]["traffic_light_compliance"] = hf.traffic_light_compliance.filtered;
-      traj["human_filtered"]["traffic_light_compliance_filter_applied"] =
-        hf.traffic_light_compliance.filter_applied;
-    }
-    if (i < synthetic_epdms_metrics_list_.size()) {
-      const auto & s = synthetic_epdms_metrics_list_[i];
-      traj["synthetic_epdms"]["raw_available"] = s.raw.available;
-      traj["synthetic_epdms"]["raw_multiplicative_metrics_prod"] =
-        s.raw.multiplicative_metrics_prod;
-      traj["synthetic_epdms"]["raw_weighted_metrics"] = s.raw.weighted_metrics;
-      traj["synthetic_epdms"]["raw"] = s.raw.epdms;
-      traj["synthetic_epdms"]["human_filtered_available"] = s.human_filtered.available;
-      traj["synthetic_epdms"]["human_filtered_multiplicative_metrics_prod"] =
-        s.human_filtered.multiplicative_metrics_prod;
-      traj["synthetic_epdms"]["human_filtered_weighted_metrics"] =
-        s.human_filtered.weighted_metrics;
-      traj["synthetic_epdms"]["human_filtered"] = s.human_filtered.epdms;
+        traj["human_filtered"]["history_comfort"] = hf.history_comfort.filtered;
+        traj["human_filtered"]["history_comfort_filter_applied"] =
+          hf.history_comfort.filter_applied;
+        traj["human_filtered"]["ego_progress"] = hf.ego_progress.filtered;
+        traj["human_filtered"]["ego_progress_filter_applied"] = hf.ego_progress.filter_applied;
+        traj["human_filtered"]["time_to_collision_within_bound"] =
+          hf.time_to_collision_within_bound.filtered;
+        traj["human_filtered"]["time_to_collision_within_bound_filter_applied"] =
+          hf.time_to_collision_within_bound.filter_applied;
+        traj["human_filtered"]["lane_keeping"] = hf.lane_keeping.filtered;
+        traj["human_filtered"]["lane_keeping_filter_applied"] = hf.lane_keeping.filter_applied;
+        traj["human_filtered"]["drivable_area_compliance"] = hf.drivable_area_compliance.filtered;
+        traj["human_filtered"]["drivable_area_compliance_filter_applied"] =
+          hf.drivable_area_compliance.filter_applied;
+        traj["human_filtered"]["no_at_fault_collision"] = hf.no_at_fault_collision.filtered;
+        traj["human_filtered"]["no_at_fault_collision_filter_applied"] =
+          hf.no_at_fault_collision.filter_applied;
+        traj["human_filtered"]["driving_direction_compliance"] =
+          hf.driving_direction_compliance.filtered;
+        traj["human_filtered"]["driving_direction_compliance_filter_applied"] =
+          hf.driving_direction_compliance.filter_applied;
+        traj["human_filtered"]["traffic_light_compliance"] = hf.traffic_light_compliance.filtered;
+        traj["human_filtered"]["traffic_light_compliance_filter_applied"] =
+          hf.traffic_light_compliance.filter_applied;
+      }
+      if (i < synthetic_epdms_metrics_list_.size()) {
+        const auto & s = synthetic_epdms_metrics_list_[i];
+        traj["synthetic_epdms"]["raw_available"] = s.raw.available;
+        traj["synthetic_epdms"]["raw_multiplicative_metrics_prod"] =
+          s.raw.multiplicative_metrics_prod;
+        traj["synthetic_epdms"]["raw_weighted_metrics"] = s.raw.weighted_metrics;
+        traj["synthetic_epdms"]["raw"] = s.raw.epdms;
+        traj["synthetic_epdms"]["human_filtered_available"] = s.human_filtered.available;
+        traj["synthetic_epdms"]["human_filtered_multiplicative_metrics_prod"] =
+          s.human_filtered.multiplicative_metrics_prod;
+        traj["synthetic_epdms"]["human_filtered_weighted_metrics"] =
+          s.human_filtered.weighted_metrics;
+        traj["synthetic_epdms"]["human_filtered"] = s.human_filtered.epdms;
+      }
     }
 
     traj["horizon_results"] = nlohmann::json::object();
     fill_horizon_json(traj["horizon_results"], m.horizon_results, m.num_points);
 
-    if (i < trajectory_point_metrics_list_.size()) {
+    if (enabled_metrics_.enable_epdms_calculation && i < trajectory_point_metrics_list_.size()) {
       const auto & pm = trajectory_point_metrics_list_[i];
       traj["trajectory_point_metrics"]["longitudinal_accelerations"] =
         pm.longitudinal_accelerations;

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.cpp
@@ -380,7 +380,8 @@ void OpenLoopEvaluator::set_enabled_metrics(const std::vector<std::string> & ena
 
 bool OpenLoopEvaluator::should_write_synthetic_epdms() const
 {
-  return enabled_metrics_.synthetic_epdms && all_epdms_inputs_enabled(enabled_metrics_);
+  return enabled_metrics_.synthetic_epdms && enabled_metrics_.enable_epdms_calculation &&
+         all_epdms_inputs_enabled(enabled_metrics_);
 }
 
 void OpenLoopEvaluator::evaluate(
@@ -468,69 +469,76 @@ void OpenLoopEvaluator::evaluate(
 
       try {
         const auto & eval_data = evaluation_data_list[i];
-        const auto future_objects =
-          eval_data.synchronized_data && eval_data.synchronized_data->trajectory
-            ? metrics::get_future_objects_for_trajectory(
-                *eval_data.synchronized_data->trajectory, object_timeline_,
-                trajectory_evaluation_horizon_s_)
-            : std::vector<TimedTrackedObjects>{};
-        const metrics::TrajectoryMetricDebugEnabledMetrics debug_enabled_metrics{
-          debug_topics_enabled_ && enabled_metrics_.time_to_collision_within_bound,
-          debug_topics_enabled_ && enabled_metrics_.no_at_fault_collision,
-          debug_topics_enabled_ && enabled_metrics_.drivable_area_compliance,
-          debug_topics_enabled_ && enabled_metrics_.lane_keeping,
-          debug_topics_enabled_ && enabled_metrics_.driving_direction_compliance,
-          debug_topics_enabled_ && enabled_metrics_.traffic_light_compliance};
-        auto trajectory_metrics = metrics::calculate_trajectory_point_metrics(
-          eval_data.synchronized_data, route_handler_, history_comfort_params_,
-          lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects,
-          debug_enabled_metrics);
-        auto metrics = evaluate_trajectory(eval_data);
-        metrics.history_comfort = trajectory_metrics.history_comfort;
-        metrics.history_comfort_available = trajectory_metrics.history_comfort_available;
-        metrics.history_comfort_reason = trajectory_metrics.history_comfort_reason;
-        metrics.time_to_collision_within_bound = trajectory_metrics.time_to_collision_within_bound;
-        metrics.time_to_collision_within_bound_available =
-          trajectory_metrics.time_to_collision_within_bound_available;
-        metrics.time_to_collision_within_bound_reason =
-          trajectory_metrics.time_to_collision_within_bound_reason;
-        metrics.time_to_collision_infraction_time_s =
-          trajectory_metrics.time_to_collision_infraction_time_s;
-        metrics.lane_keeping = trajectory_metrics.lane_keeping;
-        metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
-        metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
-        metrics.ego_progress = trajectory_metrics.ego_progress;
-        metrics.ego_progress_available = trajectory_metrics.ego_progress_available;
-        metrics.ego_progress_reason = trajectory_metrics.ego_progress_reason;
-        metrics.ego_progress_raw_m = trajectory_metrics.ego_progress_raw_m;
-        metrics.ego_progress_best_raw_m = trajectory_metrics.ego_progress_best_raw_m;
-        metrics.ego_progress_mask = trajectory_metrics.ego_progress_mask;
-        metrics.ego_progress_denominator_m = trajectory_metrics.ego_progress_denominator_m;
-        metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
-        metrics.drivable_area_compliance_available =
-          trajectory_metrics.drivable_area_compliance_available;
-        metrics.drivable_area_compliance_reason =
-          trajectory_metrics.drivable_area_compliance_reason;
-        metrics.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
-        metrics.no_at_fault_collision_available =
-          trajectory_metrics.no_at_fault_collision_available;
-        metrics.no_at_fault_collision_reason = trajectory_metrics.no_at_fault_collision_reason;
-        metrics.time_to_at_fault_collision_s = trajectory_metrics.time_to_at_fault_collision_s;
-        metrics.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
-        metrics.driving_direction_compliance_available =
-          trajectory_metrics.driving_direction_compliance_available;
-        metrics.driving_direction_compliance_reason =
-          trajectory_metrics.driving_direction_compliance_reason;
-        metrics.max_oncoming_progress_m = trajectory_metrics.max_oncoming_progress_m;
-        metrics.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
-        metrics.traffic_light_compliance_available =
-          trajectory_metrics.traffic_light_compliance_available;
-        metrics.traffic_light_compliance_reason =
-          trajectory_metrics.traffic_light_compliance_reason;
+        metrics::TrajectoryPointMetrics trajectory_metrics;
+        metrics::EpdmsMetricSnapshot human_snapshot;
+        if (enabled_metrics_.enable_epdms_calculation) {
+          const auto future_objects =
+            eval_data.synchronized_data && eval_data.synchronized_data->trajectory
+              ? metrics::get_future_objects_for_trajectory(
+                  *eval_data.synchronized_data->trajectory, object_timeline_,
+                  trajectory_evaluation_horizon_s_)
+              : std::vector<TimedTrackedObjects>{};
+          const metrics::TrajectoryMetricDebugEnabledMetrics debug_enabled_metrics{
+            debug_topics_enabled_ && enabled_metrics_.time_to_collision_within_bound,
+            debug_topics_enabled_ && enabled_metrics_.no_at_fault_collision,
+            debug_topics_enabled_ && enabled_metrics_.drivable_area_compliance,
+            debug_topics_enabled_ && enabled_metrics_.lane_keeping,
+            debug_topics_enabled_ && enabled_metrics_.driving_direction_compliance,
+            debug_topics_enabled_ && enabled_metrics_.traffic_light_compliance};
+          trajectory_metrics = metrics::calculate_trajectory_point_metrics(
+            eval_data.synchronized_data, route_handler_, history_comfort_params_,
+            lane_keeping_params_, driving_direction_params_, vehicle_info_, future_objects,
+            debug_enabled_metrics);
+          human_snapshot = calculate_human_reference_snapshot(
+            eval_data, route_handler_, history_comfort_params_, lane_keeping_params_,
+            driving_direction_params_, vehicle_info_);
+        }
 
-        auto human_snapshot = calculate_human_reference_snapshot(
-          eval_data, route_handler_, history_comfort_params_, lane_keeping_params_,
-          driving_direction_params_, vehicle_info_);
+        auto metrics = evaluate_trajectory(eval_data);
+        if (enabled_metrics_.enable_epdms_calculation) {
+          metrics.history_comfort = trajectory_metrics.history_comfort;
+          metrics.history_comfort_available = trajectory_metrics.history_comfort_available;
+          metrics.history_comfort_reason = trajectory_metrics.history_comfort_reason;
+          metrics.time_to_collision_within_bound =
+            trajectory_metrics.time_to_collision_within_bound;
+          metrics.time_to_collision_within_bound_available =
+            trajectory_metrics.time_to_collision_within_bound_available;
+          metrics.time_to_collision_within_bound_reason =
+            trajectory_metrics.time_to_collision_within_bound_reason;
+          metrics.time_to_collision_infraction_time_s =
+            trajectory_metrics.time_to_collision_infraction_time_s;
+          metrics.lane_keeping = trajectory_metrics.lane_keeping;
+          metrics.lane_keeping_available = trajectory_metrics.lane_keeping_available;
+          metrics.lane_keeping_reason = trajectory_metrics.lane_keeping_reason;
+          metrics.ego_progress = trajectory_metrics.ego_progress;
+          metrics.ego_progress_available = trajectory_metrics.ego_progress_available;
+          metrics.ego_progress_reason = trajectory_metrics.ego_progress_reason;
+          metrics.ego_progress_raw_m = trajectory_metrics.ego_progress_raw_m;
+          metrics.ego_progress_best_raw_m = trajectory_metrics.ego_progress_best_raw_m;
+          metrics.ego_progress_mask = trajectory_metrics.ego_progress_mask;
+          metrics.ego_progress_denominator_m = trajectory_metrics.ego_progress_denominator_m;
+          metrics.drivable_area_compliance = trajectory_metrics.drivable_area_compliance;
+          metrics.drivable_area_compliance_available =
+            trajectory_metrics.drivable_area_compliance_available;
+          metrics.drivable_area_compliance_reason =
+            trajectory_metrics.drivable_area_compliance_reason;
+          metrics.no_at_fault_collision = trajectory_metrics.no_at_fault_collision;
+          metrics.no_at_fault_collision_available =
+            trajectory_metrics.no_at_fault_collision_available;
+          metrics.no_at_fault_collision_reason = trajectory_metrics.no_at_fault_collision_reason;
+          metrics.time_to_at_fault_collision_s = trajectory_metrics.time_to_at_fault_collision_s;
+          metrics.driving_direction_compliance = trajectory_metrics.driving_direction_compliance;
+          metrics.driving_direction_compliance_available =
+            trajectory_metrics.driving_direction_compliance_available;
+          metrics.driving_direction_compliance_reason =
+            trajectory_metrics.driving_direction_compliance_reason;
+          metrics.max_oncoming_progress_m = trajectory_metrics.max_oncoming_progress_m;
+          metrics.traffic_light_compliance = trajectory_metrics.traffic_light_compliance;
+          metrics.traffic_light_compliance_available =
+            trajectory_metrics.traffic_light_compliance_available;
+          metrics.traffic_light_compliance_reason =
+            trajectory_metrics.traffic_light_compliance_reason;
+        }
 
         metrics_list_[i] = std::move(metrics);
         trajectory_point_metrics_list_[i] = std::move(trajectory_metrics);
@@ -591,6 +599,14 @@ void OpenLoopEvaluator::evaluate(
         auto & metrics = metrics_list_[i];
         auto & human_snapshot = human_snapshots[i];
 
+        if (!enabled_metrics_.enable_epdms_calculation) {
+          const auto processed = phase2_processed.fetch_add(1U) + 1U;
+          if (processed % kProgressLogInterval == 0U || processed == total_samples) {
+            log_parallel_progress("Parallel phase 2", processed, total_samples);
+          }
+          continue;
+        }
+
         if (i == 0U) {
           metrics.extended_comfort = 0.0;
           metrics.extended_comfort_available = false;
@@ -633,8 +649,12 @@ void OpenLoopEvaluator::evaluate(
         const auto agent_snapshot = build_epdms_snapshot(metrics);
         human_filter_metrics_list_[i] =
           metrics::calculate_human_filter_metrics(agent_snapshot, human_snapshot);
-        synthetic_epdms_metrics_list_[i] =
-          metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
+        if (enabled_metrics_.enable_epdms_calculation) {
+          synthetic_epdms_metrics_list_[i] =
+            metrics::calculate_synthetic_epdms(agent_snapshot, human_filter_metrics_list_[i]);
+        } else {
+          synthetic_epdms_metrics_list_[i] = metrics::SyntheticEpdmsMetrics{};
+        }
 
         const auto processed = phase2_processed.fetch_add(1U) + 1U;
         if (processed % kProgressLogInterval == 0U || processed == total_samples) {
@@ -1288,7 +1308,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   std_msgs::msg::Float64 scalar_msg;
   const auto write_scalar =
     [&](const bool enabled, const double value, const std::string & topic_name) {
-      if (!enabled) {
+      if (!enabled_metrics_.enable_epdms_calculation || !enabled) {
         return;
       }
       scalar_msg.data = value;
@@ -1336,7 +1356,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   std_msgs::msg::Bool availability_msg;
   const auto write_availability =
     [&](const bool enabled, const bool value, const std::string & topic_name) {
-      if (!enabled) {
+      if (!enabled_metrics_.enable_epdms_calculation || !enabled) {
         return;
       }
       availability_msg.data = value;
@@ -1381,7 +1401,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
   std_msgs::msg::String reason_msg;
   const auto write_reason =
     [&](const bool enabled, const std::string & value, const std::string & topic_name) {
-      if (!enabled) {
+      if (!enabled_metrics_.enable_epdms_calculation || !enabled) {
         return;
       }
       reason_msg.data = value;
@@ -1426,7 +1446,7 @@ void OpenLoopEvaluator::save_metrics_to_bag(
     bag_writer.write(gt_traj_msg, compared_trajectory_topic(), message_timestamp);
   }
 
-  if (debug_topics_enabled_) {
+  if (enabled_metrics_.enable_epdms_calculation && debug_topics_enabled_) {
     metrics::write_epdms_trajectory_horizon_debug_topics_to_bag(
       *trajectory_data->trajectory, ground_truth_trajectory, vehicle_info_, bag_writer,
       message_timestamp);
@@ -1444,6 +1464,10 @@ void OpenLoopEvaluator::save_trajectory_point_metrics_to_bag_with_variant(
   const metrics::TrajectoryPointMetrics & metrics, rosbag2_cpp::Writer & bag_writer,
   const rclcpp::Time & normalized_timestamp) const
 {
+  if (!enabled_metrics_.enable_epdms_calculation) {
+    return;
+  }
+
   const auto write_array =
     [&](const bool enabled, const std::vector<double> & data, const std::string & topic_name) {
       if (!enabled) {
@@ -2306,14 +2330,17 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     };
   const auto add_epdms_topic_if =
     [&](const bool enabled, const std::string & name, const std::string & type) {
-      add_topic_if(enabled, epdms_metric_topic(name), type);
+      add_topic_if(
+        enabled_metrics_.enable_epdms_calculation && enabled, epdms_metric_topic(name), type);
     };
   const auto add_epdms_availability_reason_if = [&](const bool enabled, const std::string & name) {
     add_epdms_topic_if(enabled, name + "_available", "std_msgs/msg/Bool");
     add_epdms_topic_if(enabled, name + "_reason", "std_msgs/msg/String");
   };
   const auto add_trajectory_array_if = [&](const bool enabled, const std::string & name) {
-    add_topic_if(enabled, trajectory_metric_topic(name), "std_msgs/msg/Float64MultiArray");
+    add_topic_if(
+      enabled_metrics_.enable_epdms_calculation && enabled, trajectory_metric_topic(name),
+      "std_msgs/msg/Float64MultiArray");
   };
 
   add_topic(dlr_result_topic(), "std_msgs/msg/String");
@@ -2329,9 +2356,7 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
   if (enabled_metrics_.time_to_collision_within_bound) {
     add_topic(metric_topic("ttc"), "std_msgs/msg/Float64MultiArray");
   }
-  if (enabled_metrics_.history_comfort) {
-    add_topic(epdms_metric_topic("history_comfort"), "std_msgs/msg/Float64");
-  }
+  add_epdms_topic_if(enabled_metrics_.history_comfort, "history_comfort", "std_msgs/msg/Float64");
   add_epdms_availability_reason_if(enabled_metrics_.history_comfort, "history_comfort");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "longitudinal_accelerations");
   add_trajectory_array_if(enabled_metrics_.history_comfort, "lateral_accelerations");
@@ -2390,7 +2415,7 @@ std::vector<std::pair<std::string, std::string>> OpenLoopEvaluator::get_result_t
     "/perception/object_recognition/objects", "autoware_perception_msgs/msg/PredictedObjects");
   add_topic("/tf", "tf2_msgs/msg/TFMessage");
   add_topic("/tf_static", "tf2_msgs/msg/TFMessage");
-  if (debug_topics_enabled_) {
+  if (enabled_metrics_.enable_epdms_calculation && debug_topics_enabled_) {
     metrics::add_epdms_debug_result_topics(
       topics, make_epdms_debug_enabled_metrics(enabled_metrics_));
   }

--- a/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
+++ b/planning/autoware_planning_data_analyzer/src/open_loop_evaluator.hpp
@@ -166,6 +166,7 @@ struct EnabledOpenLoopMetrics
   bool driving_direction_compliance{true};
   bool traffic_light_compliance{true};
   bool synthetic_epdms{true};
+  bool enable_epdms_calculation{true};
 };
 
 class OpenLoopEvaluator : public BaseEvaluator
@@ -210,6 +211,11 @@ public:
   void set_metric_variant(const std::string & metric_variant) { metric_variant_ = metric_variant; }
 
   void set_enabled_metrics(const std::vector<std::string> & enabled_metric_names);
+
+  void set_epdms_calculation_enabled(bool enabled)
+  {
+    enabled_metrics_.enable_epdms_calculation = enabled;
+  }
 
   void set_debug_topics_enabled(bool enabled) { debug_topics_enabled_ = enabled; }
 

--- a/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
+++ b/planning/autoware_planning_data_analyzer/test/test_open_loop_gt_source_mode.cpp
@@ -236,6 +236,35 @@ TEST_F(OpenLoopGTSourceModeTest, VariantsNamespaceOpenLoopResultTopics)
   EXPECT_TRUE(has_topic("/open_loop/metrics/epdms/synthetic_epdms_human_filtered_available"));
 }
 
+TEST_F(OpenLoopGTSourceModeTest, EpdmsGateDisablesEpdmsResultTopics)
+{
+  OpenLoopEvaluator evaluator(
+    rclcpp::get_logger("open_loop_gt_source_test"), nullptr,
+    OpenLoopEvaluator::GTSourceMode::GT_TRAJECTORY, 200.0);
+
+  evaluator.set_debug_topics_enabled(true);
+  evaluator.set_epdms_calculation_enabled(false);
+
+  const auto topics = evaluator.get_result_topics();
+  const auto has_topic = [&topics](const std::string & topic_name) {
+    return std::any_of(topics.begin(), topics.end(), [&topic_name](const auto & topic) {
+      return topic.first == topic_name;
+    });
+  };
+  const auto has_topic_prefix = [&topics](const std::string & prefix) {
+    return std::any_of(topics.begin(), topics.end(), [&prefix](const auto & topic) {
+      return topic.first.rfind(prefix, 0) == 0;
+    });
+  };
+
+  EXPECT_TRUE(has_topic("/open_loop/metrics/ade"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/fde"));
+  EXPECT_TRUE(has_topic("/open_loop/metrics/ttc"));
+  EXPECT_FALSE(has_topic_prefix("/open_loop/metrics/epdms/"));
+  EXPECT_FALSE(has_topic_prefix("/open_loop/metrics/trajectory/"));
+  EXPECT_FALSE(has_topic_prefix("/debug/epdms/"));
+}
+
 TEST_F(OpenLoopGTSourceModeTest, EnabledMetricsNarrowsOpenLoopResultTopics)
 {
   OpenLoopEvaluator evaluator(


### PR DESCRIPTION
## Description

Adds a DLR-controllable gate for EPDMS work in `autoware_planning_data_analyzer`.

The new `open_loop.enable_epdms_calculation` parameter and `enable_epdms_calculation` launch argument default to `true` to preserve existing behavior. When disabled, the open-loop evaluator skips:
- EPDMS subscore calculation
- human-reference/filter aggregation
- synthetic EPDMS aggregation
- EPDMS metric topics
- EPDMS trajectory metric topics
- `/debug/epdms/*` topic registration/output 

This is intended for DLR post-processing where optimized and raw trajectories are analyzed separately but EPDMS **should only be calculated once**.

## Changes

- Add `open_loop.enable_epdms_calculation` config parameter.
- Add `enable_epdms_calculation` launch argument.
- Wire the parameter through the analyzer node to `OpenLoopEvaluator`.
- Skip EPDMS calculation/output/debug paths when disabled.
- Add a unit test for result-topic gating.

## Testing

Verified with an actual run with rosbag

## For reviewers

This PR looks quite large **(+586 - 580)** at first glance but they are mostly indentation noise from wrapping an existing large json output block in :
```
if (enabled_metrics_.enable_epdms_calculation) {
  ...
}
```
