### PR TITLE
feat(planning_data_analyzer): expose EPDMS debug launch gate

### DIFF
--- a/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
+++ b/planning/autoware_planning_data_analyzer/launch/planning_data_analyzer.launch.xml
@@ -10,6 +10,7 @@
   <arg name="gt_trajectory_topic" default="/planning/ground_truth_trajectory" description="GT trajectory topic for gt_trajectory mode"/>
   <arg name="gt_sync_tolerance_ms" default="200.0" description="Sync tolerance (ms) for GT trajectory alignment"/>
   <arg name="enable_epdms_calculation" default="true" description="Enable EPDMS calculation and EPDMS debug outputs"/>
+  <arg name="debug_topics_enabled" default="false" description="Enable EPDMS debug topic outputs"/>
 
   <group if="$(eval '&quot;$(var vehicle_model)&quot; != &quot;&quot;')">
     <node pkg="autoware_planning_data_analyzer" exec="autoware_planning_data_analyzer_node" name="autoware_planning_data_analyzer" output="screen">
@@ -23,6 +24,7 @@
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
       <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
+      <param name="open_loop.debug_topics_enabled" value="$(var debug_topics_enabled)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>
@@ -38,6 +40,7 @@
       <param name="open_loop.gt_trajectory_topic" value="$(var gt_trajectory_topic)"/>
       <param name="open_loop.gt_sync_tolerance_ms" value="$(var gt_sync_tolerance_ms)"/>
       <param name="open_loop.enable_epdms_calculation" value="$(var enable_epdms_calculation)"/>
+      <param name="open_loop.debug_topics_enabled" value="$(var debug_topics_enabled)"/>
       <param name="open_loop.evaluator_config_path" value="$(var evaluator_config_file)"/>
     </node>
   </group>


### PR DESCRIPTION
## Summary
- Add a `debug_topics_enabled` launch argument for `planning_data_analyzer.launch.xml`.
- Wire it to the existing `open_loop.debug_topics_enabled` node parameter.
- Keep the default as `false`, so EPDMS debug topics remain opt-in.

## Behavior
- `enable_epdms_calculation:=false` still suppresses EPDMS and debug outputs.
- `debug_topics_enabled:=true` enables EPDMS debug topics only when EPDMS calculation is enabled.

## Validation
- `git diff --check`