### PR TITLE
fix(reaction_analyzer): migrate tier4_perception_launch to autoware_perception_launch

### DIFF
--- a/system/reaction_analyzer/launch/reaction_analyzer.launch.xml
+++ b/system/reaction_analyzer/launch/reaction_analyzer.launch.xml
@@ -35,7 +35,7 @@
 
     <!-- Occupancy Grid -->
     <push-ros-namespace namespace="occupancy_grid_map"/>
-    <include file="$(find-pkg-share tier4_perception_launch)/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml">
+    <include file="$(find-pkg-share autoware_perception_launch)/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml">
       <arg name="input_obstacle_pointcloud" value="true"/>
       <arg name="input_obstacle_and_raw_pointcloud" value="false"/>
       <arg name="input/obstacle_pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>

--- a/system/reaction_analyzer/package.xml
+++ b/system/reaction_analyzer/package.xml
@@ -38,7 +38,7 @@
   <depend>tf2_ros</depend>
 
   <exec_depend>autoware_launch</exec_depend>
-  <exec_depend>tier4_perception_launch</exec_depend>
+  <exec_depend>autoware_perception_launch</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_python</test_depend>


### PR DESCRIPTION
## Description

`reaction_analyzer` still references `tier4_perception_launch`, which was removed from autoware_universe and migrated to `autoware_perception_launch` in autowarefoundation/autoware_universe#12001.

Because of this, `reaction_analyzer` carries a dangling `<exec_depend>tier4_perception_launch</exec_depend>`. `rosdep` cannot resolve the key, so `build-and-test-packages-above-differential` fails for **any** autoware_universe PR that pulls `reaction_analyzer` into the packages-above graph, with:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
reaction_analyzer: Cannot locate rosdep definition for [tier4_perception_launch]
```

### The package is still needed (this is a rename, not a removal)

`reaction_analyzer.launch.xml` includes `occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml` from the perception launch package at runtime. The migrated `autoware_perception_launch` ships the **same file at the same relative path** and accepts the **same arguments** the include passes (`input_obstacle_pointcloud`, `input/obstacle_pointcloud`, `output`, `occupancy_grid_map_method`, `occupancy_grid_map_param_path`, `occupancy_grid_map_updater`, `occupancy_grid_map_updater_param_path`). So the fix is to point at the new package, not to drop the dependency.

## Changes

- `system/reaction_analyzer/launch/reaction_analyzer.launch.xml`: update the `<include>` to `$(find-pkg-share autoware_perception_launch)/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml`
- `system/reaction_analyzer/package.xml`: `<exec_depend>tier4_perception_launch</exec_depend>` → `<exec_depend>autoware_perception_launch</exec_depend>`

## How was this PR tested?

- Verified `tier4_perception_launch` has no remaining references under `system/reaction_analyzer/`.
- Verified the launch/package.xml are well-formed XML.
- Verified `autoware_perception_launch` provides the same launch file and compatible arguments.

## Related

- autowarefoundation/autoware_universe#12001 (removed/migrated `tier4_perception_launch`)