### PR TITLE
refactor(autoware_static_centerline_generator): construct DefaultPlanner directly instead of loading it through pluginlib

### DIFF
--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -32,10 +32,9 @@
 #include "utils.hpp"
 
 #include <autoware/geography_utils/lanelet2_projector.hpp>
-#include <autoware/mission_planner_universe/mission_planner_plugin.hpp>
+#include <autoware/mission_planner_universe/default_planner.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
-#include <pluginlib/class_loader.hpp>
 
 #include "std_msgs/msg/empty.hpp"
 #include "std_msgs/msg/float32.hpp"
@@ -364,6 +363,17 @@ StaticCenterlineGeneratorNode::StaticCenterlineGeneratorNode(
   // vehicle info
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
 
+  // parameters of the route planner
+  default_planner_param_.goal_angle_threshold_deg =
+    declare_parameter<double>("goal_angle_threshold_deg");
+  default_planner_param_.enable_correct_goal_pose =
+    declare_parameter<bool>("enable_correct_goal_pose");
+  default_planner_param_.consider_no_drivable_lanes =
+    declare_parameter<bool>("consider_no_drivable_lanes");
+  default_planner_param_.check_footprint_inside_lanes =
+    declare_parameter<bool>("check_footprint_inside_lanes");
+  default_planner_param_.allow_area = declare_parameter<bool>("allow_area", false);
+
   centerline_source_ = [&]() {
     const auto centerline_source_param = declare_parameter<std::string>("centerline_source");
     if (centerline_source_param == "optimization_trajectory_base") {
@@ -683,18 +693,11 @@ LaneletRoute StaticCenterlineGeneratorNode::plan_route(
   const auto check_points =
     std::vector<geometry_msgs::msg::Pose>{start_center_pose, end_center_pose};
 
-  // create mission_planner plugin
-  auto plugin_loader = pluginlib::ClassLoader<autoware::mission_planner_universe::PlannerPlugin>(
-    "autoware_mission_planner_universe", "autoware::mission_planner_universe::PlannerPlugin");
-  auto mission_planner = plugin_loader.createSharedInstance(
-    "autoware::mission_planner_universe::lanelet2::DefaultPlanner");
-
-  // initialize mission_planner
-  auto node = rclcpp::Node("mission_planner");
-  mission_planner->initialize(&node, map_bin_ptr_);
-
   // plan route
-  return mission_planner->plan(check_points);
+  autoware::mission_planner_universe::lanelet2::DefaultPlanner mission_planner(
+    default_planner_param_, vehicle_info_);
+  mission_planner.set_map(*map_bin_ptr_);
+  return mission_planner.plan(check_points).route;
 }
 
 void StaticCenterlineGeneratorNode::on_plan_route(

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.hpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.hpp
@@ -15,6 +15,7 @@
 #ifndef STATIC_CENTERLINE_GENERATOR_NODE_HPP_
 #define STATIC_CENTERLINE_GENERATOR_NODE_HPP_
 
+#include "autoware/mission_planner_universe/default_planner.hpp"
 #include "autoware/universe_utils/ros/parameter.hpp"
 #include "autoware_static_centerline_generator/srv/load_map.hpp"
 #include "autoware_static_centerline_generator/srv/plan_path.hpp"
@@ -209,6 +210,9 @@ private:
 
   // vehicle info
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+
+  // parameters of the route planner
+  autoware::mission_planner_universe::lanelet2::DefaultPlannerParameters default_planner_param_;
 };
 }  // namespace autoware::static_centerline_generator
 #endif  // STATIC_CENTERLINE_GENERATOR_NODE_HPP_


### PR DESCRIPTION
## Description

`autoware_mission_planner_universe` drops pluginlib in autowarefoundation/autoware_universe#13283, mirroring the same refactor already merged into `autoware_core` (autowarefoundation/autoware_core#1334). This package is the only user of that plugin interface outside the package itself, so it moves to constructing the planner directly.

```cpp
// before
auto plugin_loader = pluginlib::ClassLoader<PlannerPlugin>(...);
auto mission_planner = plugin_loader.createSharedInstance("...lanelet2::DefaultPlanner");
auto node = rclcpp::Node("mission_planner");
mission_planner->initialize(&node, map_bin_ptr_);
return mission_planner->plan(check_points);

// after
lanelet2::DefaultPlanner mission_planner(default_planner_param_, vehicle_info_);
mission_planner.set_map(*map_bin_ptr_);
return mission_planner.plan(check_points).route;
```

The throwaway rclcpp::Node("mission_planner") is gone. It only existed because the plugin interface required a node, which is exactly what the upstream refactor removes.

## Related links

- autowarefoundation/autoware_universe#13283 — removes pluginlib from autoware_mission_planner_universe and makes default_planner.hpp a public header
- autowarefoundation/autoware_core#1334 — the same refactor on the core side

## How was this PR tested?

colcon build against a workspace containing autoware_universe#13283. The package builds with no new warnings.

## Notes for reviewers

declare_parameter for the planner parameters moved into the constructor rather than staying in plan_route().

plan_route() is reachable from the /planning/static_centerline_generator/plan_route service, so it can run more than once, and declare_parameter throws ParameterAlreadyDeclaredException on the second call for the same name. The previous code happened to avoid this because it created a fresh rclcpp::Node on every call. With that node gone, the declaration has to happen once. vehicle_info_ is already built in the constructor and kept as a member, so the parameters are placed next to it.

launch/static_centerline_generator.launch.xml needs no change: it already passes mission_planner.param.yaml to this node, and overrides check_footprint_inside_lanes there. Both keep working through *this.

## Interface changes

None.

## Effects on system behavior

None. The planner produces the same route; only the way it is constructed changes.